### PR TITLE
Switch project from npm to pnpm

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -15,7 +15,7 @@ Multi-tenant blog platform where users get their own blogs on subdomains (userna
 - **Payments:** Stripe
 - **Email:** Resend
 - **Styling:** Tailwind CSS
-- **Package Manager:** npm/yarn (TBD)
+- **Package Manager:** pnpm
 
 ## Architecture Notes
 - Multi-tenant architecture with subdomain routing

--- a/AgentUsage/documentation_standards.md
+++ b/AgentUsage/documentation_standards.md
@@ -140,7 +140,7 @@ A paragraph explaining the purpose and context of this project.
 ```bash
 pip install -r requirements.txt
 # or
-npm install
+pnpm install
 ```
 
 ## Quick Start

--- a/AgentUsage/git_guide.md
+++ b/AgentUsage/git_guide.md
@@ -925,7 +925,7 @@ Enforce conventional commits:
 
 ```bash
 # Install
-npm install --save-dev @commitlint/cli @commitlint/config-conventional
+pnpm add -D @commitlint/cli @commitlint/config-conventional
 
 # Configure (.commitlintrc.json)
 {
@@ -948,10 +948,10 @@ Automated changelog and versioning:
 
 ```bash
 # Install
-npm install --save-dev standard-version
+pnpm add -D standard-version
 
 # Use
-npm run release
+pnpm run release
 
 # Generates:
 # - Updates version in package.json

--- a/AgentUsage/house_agents.md
+++ b/AgentUsage/house_agents.md
@@ -9,7 +9,7 @@
 | Agent | Use For | Auto-Invoke When | Model |
 |-------|---------|------------------|-------|
 | **house-research** | Codebase searches, pattern finding | Searching 20+ files, finding patterns | Haiku 4.5 |
-| **house-bash** | Command execution, verbose output | Running tests, builds, npm install, deployments | Haiku 4.5 |
+| **house-bash** | Command execution, verbose output | Running tests, builds, pnpm install, deployments | Haiku 4.5 |
 | **house-git** | Git diffs, commit analysis | Reviewing diffs >100 lines, before commits | Haiku 4.5 |
 | **house-coder** | Small code patches (0-250 lines) | Import fixes, TODO implementations, bugs <50 lines | Haiku 4.5 |
 | **house-planner** | Task orchestration & planning | Multi-file changes (3+), new features, ambiguous tasks | Sonnet 4.5 |
@@ -27,7 +27,7 @@
 
 ### house-bash
 - Running: tests, builds, linters, deployments
-- Installing: npm install, pip install, package updates
+- Installing: pnpm install, pip install, package updates
 - Executing: scripts with verbose output
 - Starting: dev servers, Docker containers
 - **Threshold**: Output >100 lines expected

--- a/AgentUsage/multi_language_guide.md
+++ b/AgentUsage/multi_language_guide.md
@@ -12,14 +12,14 @@ This guide covers the languages used in this workspace:
 
 | Operation | Python (UV) | Go | Node.js | Rust |
 |-----------|-------------|-----|---------|------|
-| **Init Project** | `uv init` | `go mod init` | `npm init` | `cargo new` |
-| **Add Dependency** | `uv add package` | `go get pkg` | `npm install pkg` | `cargo add crate` |
-| **Install Deps** | `uv sync` | `go mod download` | `npm install` | `cargo build` |
+| **Init Project** | `uv init` | `go mod init` | `pnpm init` | `cargo new` |
+| **Add Dependency** | `uv add package` | `go get pkg` | `pnpm add pkg` | `cargo add crate` |
+| **Install Deps** | `uv sync` | `go mod download` | `pnpm install` | `cargo build` |
 | **Run Code** | `uv run script.py` | `go run main.go` | `node script.js` | `cargo run` |
-| **Run Tests** | `uv run pytest` | `go test ./...` | `npm test` | `cargo test` |
+| **Run Tests** | `uv run pytest` | `go test ./...` | `pnpm test` | `cargo test` |
 | **Build Binary** | N/A | `go build` | N/A | `cargo build --release` |
-| **Format Code** | `uv run ruff format` | `go fmt ./...` | `npm run format` | `cargo fmt` |
-| **Lint Code** | `uv run ruff check` | `go vet ./...` | `npm run lint` | `cargo clippy` |
+| **Format Code** | `uv run ruff format` | `go fmt ./...` | `pnpm run format` | `cargo fmt` |
+| **Lint Code** | `uv run ruff check` | `go vet ./...` | `pnpm run lint` | `cargo clippy` |
 
 ## Python (Primary Language)
 
@@ -174,14 +174,11 @@ project/
 
 ```bash
 # Initialize project
-npm init -y
+pnpm init
 
 # Install dependencies
-npm install express
-npm install --save-dev typescript @types/node
-
-# Or use pnpm (faster, disk-efficient)
-pnpm install express
+pnpm add express
+pnpm add -D typescript @types/node
 ```
 
 ### package.json Example
@@ -211,11 +208,11 @@ pnpm install express
 ### Common Commands
 
 ```bash
-npm install                 # Install dependencies
-npm run dev                # Run dev server
-npm test                   # Run tests
-npm run build              # Build for production
-npx tsc --init             # Initialize TypeScript
+pnpm install               # Install dependencies
+pnpm run dev               # Run dev server
+pnpm test                  # Run tests
+pnpm run build             # Build for production
+pnpm exec tsc --init       # Initialize TypeScript
 ```
 
 ## Rust Basics
@@ -325,7 +322,7 @@ echo "Building Go binaries..."
 cd ../../go && go build -o ../bin/go-tool
 
 echo "Building Node.js app..."
-cd ../node && npm install && npm run build
+cd ../node && pnpm install && pnpm run build
 
 echo "Building Rust components..."
 cd ../rust && cargo build --release
@@ -402,9 +399,9 @@ console.log(output);
 
 | Feature | UV (Python) | Go Modules | npm/pnpm | Cargo (Rust) |
 |---------|-------------|------------|----------|--------------|
-| **Speed** | Very Fast | Fast | Medium/Fast | Fast |
-| **Lock File** | uv.lock | go.sum | package-lock.json | Cargo.lock |
-| **Global Cache** | Yes | Yes | Yes (pnpm) | Yes |
+| **Speed** | Very Fast | Fast | Fast | Fast |
+| **Lock File** | uv.lock | go.sum | pnpm-lock.yaml | Cargo.lock |
+| **Global Cache** | Yes | Yes | Yes | Yes |
 | **Virtual Env** | Automatic | N/A | N/A | N/A |
 | **Version Resolution** | Automatic | Minimal | npm/pnpm | Smart |
 | **Offline Mode** | Yes | Yes | Yes | Yes |
@@ -413,7 +410,7 @@ console.log(output);
 
 - **UV**: Replaces pip, poetry, pyenv - all-in-one Python tool
 - **Go Modules**: Minimal, built into Go toolchain
-- **npm/pnpm**: npm is default, pnpm saves disk space
+- **pnpm**: Fast, disk-efficient Node.js package manager
 - **Cargo**: Excellent dependency resolution, built-in docs
 
 ## Related Guides
@@ -432,7 +429,7 @@ uv init && uv add requests && uv run python main.py
 go mod init example.com/app && go run main.go
 
 # Node.js
-npm init -y && npm install express && node index.js
+pnpm init && pnpm add express && node index.js
 
 # Rust
 cargo new app && cd app && cargo run

--- a/AgentUsage/pre_commit_hooks/TROUBLESHOOTING.md
+++ b/AgentUsage/pre_commit_hooks/TROUBLESHOOTING.md
@@ -27,7 +27,7 @@ uv add --dev black ruff
 
 **Prettier/ESLint not found (JavaScript):**
 ```bash
-npm install -D prettier eslint
+pnpm add -D prettier eslint
 ```
 
 **gofmt not found (Go):**
@@ -53,8 +53,8 @@ git commit -m "your message"
 **JavaScript:**
 ```bash
 # Auto-fix formatting
-npx prettier --write .
-npx eslint --fix .
+pnpm exec prettier --write .
+pnpm exec eslint --fix .
 
 # Try commit again
 git commit -m "your message"
@@ -97,7 +97,7 @@ git commit -m "your message"
 ```bash
 # Run tests locally to see failures
 pytest tests/           # Python
-npm test                # JavaScript
+pnpm test               # JavaScript
 go test ./...           # Go
 
 # Fix failing tests
@@ -126,7 +126,7 @@ git push --no-verify
 # Run only fast tests
 # Edit .git/hooks/pre-push and add:
 pytest tests/ -m "not slow"  # Mark slow tests with @pytest.mark.slow
-npm test -- --testPathIgnorePatterns=e2e  # Skip E2E tests
+pnpm test -- --testPathIgnorePatterns=e2e  # Skip E2E tests
 ```
 
 ---
@@ -136,7 +136,7 @@ npm test -- --testPathIgnorePatterns=e2e  # Skip E2E tests
 ```bash
 # Manually update deps
 uv sync              # Python
-npm install          # JavaScript
+pnpm install         # JavaScript
 go mod download      # Go
 
 # Check if hook exists

--- a/AgentUsage/pre_commit_hooks/examples.md
+++ b/AgentUsage/pre_commit_hooks/examples.md
@@ -177,8 +177,8 @@ Automatically updates dependencies when switching branches.
   ✓ Python dependencies updated (uv)
 
 📦 Node dependencies changed
-  Running 'npm install'...
-  ✓ Node dependencies updated (npm)
+  Running 'pnpm install'...
+  ✓ Node dependencies updated (pnpm)
 
 ✅ Dependency updates complete
 ```

--- a/AgentUsage/pre_commit_hooks/post-checkout
+++ b/AgentUsage/pre_commit_hooks/post-checkout
@@ -107,18 +107,18 @@ if git diff --name-only $PREV_HEAD $NEW_HEAD | grep -q "package.json\|package-lo
             echo -e "  ${RED}✗ Failed to update Node dependencies${NC}"
         fi
 
-    # npm
-    elif [ -f "package.json" ] && command -v npm &> /dev/null; then
-        echo "  Running 'npm install'..."
-        if npm install; then
-            echo -e "  ${GREEN}✓ Node dependencies updated (npm)${NC}"
+    # pnpm fallback (if no lock file but pnpm available)
+    elif [ -f "package.json" ] && command -v pnpm &> /dev/null; then
+        echo "  Running 'pnpm install'..."
+        if pnpm install; then
+            echo -e "  ${GREEN}✓ Node dependencies updated (pnpm)${NC}"
             deps_updated=1
         else
             echo -e "  ${RED}✗ Failed to update Node dependencies${NC}"
         fi
 
     else
-        echo -e "  ${YELLOW}⚠ No Node package manager found${NC}"
+        echo -e "  ${YELLOW}⚠ No Node package manager found (install pnpm)${NC}"
     fi
     echo ""
 fi

--- a/AgentUsage/pre_commit_hooks/pre-commit-javascript
+++ b/AgentUsage/pre_commit_hooks/pre-commit-javascript
@@ -44,21 +44,21 @@ if command -v prettier &> /dev/null; then
         checks_failed=1
     fi
 elif [ -f "node_modules/.bin/prettier" ]; then
-    # Local Prettier via npm
-    if npx prettier --check $js_ts_files 2>&1; then
+    # Local Prettier via pnpm
+    if pnpm exec prettier --check $js_ts_files 2>&1; then
         echo -e "${GREEN}✓ Prettier formatting passed${NC}"
     else
         echo -e "${RED}✗ Prettier formatting failed${NC}"
         echo -e "${YELLOW}Files need formatting:${NC}"
-        npx prettier --list-different $js_ts_files 2>&1 || true
+        pnpm exec prettier --list-different $js_ts_files 2>&1 || true
         echo ""
-        echo -e "${YELLOW}To fix: run 'npx prettier --write .'${NC}"
+        echo -e "${YELLOW}To fix: run 'pnpm exec prettier --write .'${NC}"
         checks_failed=1
     fi
 else
     echo -e "${RED}✗ Prettier is not installed${NC}"
-    echo -e "${YELLOW}Install with: npm install -D prettier${NC}"
-    echo -e "${YELLOW}Or globally: npm install -g prettier${NC}"
+    echo -e "${YELLOW}Install with: pnpm add -D prettier${NC}"
+    echo -e "${YELLOW}Or globally: pnpm add -g prettier${NC}"
     exit 1
 fi
 
@@ -82,20 +82,20 @@ if command -v eslint &> /dev/null; then
         checks_failed=1
     fi
 elif [ -f "node_modules/.bin/eslint" ]; then
-    # Local ESLint via npm
-    if npx eslint $js_ts_files 2>&1; then
+    # Local ESLint via pnpm
+    if pnpm exec eslint $js_ts_files 2>&1; then
         echo -e "${GREEN}✓ ESLint passed${NC}"
     else
         echo -e "${RED}✗ ESLint failed${NC}"
         echo -e "${YELLOW}Linting violations found:${NC}"
-        npx eslint $js_ts_files
+        pnpm exec eslint $js_ts_files
         echo ""
-        echo -e "${YELLOW}To fix: run 'npx eslint --fix .'${NC}"
+        echo -e "${YELLOW}To fix: run 'pnpm exec eslint --fix .'${NC}"
         checks_failed=1
     fi
 else
     echo -e "${YELLOW}⚠ ESLint is not installed (optional but recommended)${NC}"
-    echo -e "${YELLOW}Install with: npm install -D eslint${NC}"
+    echo -e "${YELLOW}Install with: pnpm add -D eslint${NC}"
 fi
 
 echo ""
@@ -116,7 +116,7 @@ if [ -n "$ts_files" ]; then
                 checks_failed=1
             fi
         elif [ -f "node_modules/.bin/tsc" ]; then
-            if npx tsc --noEmit 2>&1; then
+            if pnpm exec tsc --noEmit 2>&1; then
                 echo -e "${GREEN}✓ TypeScript type check passed${NC}"
             else
                 echo -e "${RED}✗ TypeScript type check failed${NC}"

--- a/AgentUsage/pre_commit_hooks/pre-commit-multi-language
+++ b/AgentUsage/pre_commit_hooks/pre-commit-multi-language
@@ -89,15 +89,15 @@ if [ -n "$js_ts_files" ]; then
         fi
     elif [ -f "node_modules/.bin/prettier" ]; then
         echo "  Running Prettier formatter (local)..."
-        if npx prettier --check $js_ts_files 2>&1; then
+        if pnpm exec prettier --check $js_ts_files 2>&1; then
             echo -e "  ${GREEN}✓ Prettier formatting passed${NC}"
         else
             echo -e "  ${RED}✗ Prettier formatting failed${NC}"
-            echo -e "  ${YELLOW}Fix with: npx prettier --write ${js_ts_files}${NC}"
+            echo -e "  ${YELLOW}Fix with: pnpm exec prettier --write ${js_ts_files}${NC}"
             checks_failed=1
         fi
     else
-        echo -e "  ${YELLOW}⚠ Prettier not installed (npm install -D prettier)${NC}"
+        echo -e "  ${YELLOW}⚠ Prettier not installed (pnpm add -D prettier)${NC}"
     fi
 
     # ESLint check
@@ -112,15 +112,15 @@ if [ -n "$js_ts_files" ]; then
         fi
     elif [ -f "node_modules/.bin/eslint" ]; then
         echo "  Running ESLint (local)..."
-        if npx eslint $js_ts_files 2>&1; then
+        if pnpm exec eslint $js_ts_files 2>&1; then
             echo -e "  ${GREEN}✓ ESLint passed${NC}"
         else
             echo -e "  ${RED}✗ ESLint failed${NC}"
-            echo -e "  ${YELLOW}Fix with: npx eslint --fix ${js_ts_files}${NC}"
+            echo -e "  ${YELLOW}Fix with: pnpm exec eslint --fix ${js_ts_files}${NC}"
             checks_failed=1
         fi
     else
-        echo -e "  ${YELLOW}⚠ ESLint not installed (npm install -D eslint)${NC}"
+        echo -e "  ${YELLOW}⚠ ESLint not installed (pnpm add -D eslint)${NC}"
     fi
 
     echo ""

--- a/AgentUsage/pre_commit_hooks/pre-push
+++ b/AgentUsage/pre_commit_hooks/pre-push
@@ -80,10 +80,10 @@ if [ -f "package.json" ]; then
     # Check if test script exists in package.json
     if grep -q '"test"' package.json && ! grep -q '"test": "echo \\"Error: no test specified\\"' package.json; then
         tests_run=1
-        echo "Running npm test..."
+        echo "Running pnpm test..."
         echo ""
 
-        if npm test 2>&1; then
+        if pnpm test 2>&1; then
             echo ""
             echo -e "${GREEN}✓ JavaScript tests passed${NC}"
         else

--- a/AgentUsage/pre_commit_hooks/setup_guide.md
+++ b/AgentUsage/pre_commit_hooks/setup_guide.md
@@ -180,7 +180,7 @@ Comprehensive checks for mixed-language projects:
 
 #### pre-push
 Runs tests before pushing to remote:
-- Auto-detects test framework (pytest, npm test, go test, cargo test)
+- Auto-detects test framework (pytest, pnpm test, go test, cargo test)
 - Prevents broken code from reaching remote
 - Non-blocking if no tests configured
 - **Recommended for all projects with tests**
@@ -190,7 +190,7 @@ Runs tests before pushing to remote:
 #### post-checkout
 Auto-updates dependencies when switching branches:
 - Detects changes in `package.json`, `pyproject.toml`, `go.mod`, etc.
-- Runs appropriate package manager (npm, uv, go mod, cargo)
+- Runs appropriate package manager (pnpm, uv, go mod, cargo)
 - Saves time and prevents "works on my branch" issues
 - **Recommended for team projects**
 

--- a/AgentUsage/project_setup.md
+++ b/AgentUsage/project_setup.md
@@ -171,18 +171,18 @@ touch src/YourProject/config/__init__.py
 ### JavaScript/TypeScript Projects
 
 ```bash
-# 1. Initialize npm project
-npm init -y
+# 1. Initialize pnpm project
+pnpm init
 
 # 2. Install dependencies
-npm install express dotenv
+pnpm add express dotenv
 
 # 3. Install dev dependencies
-npm install --save-dev typescript @types/node @types/express
-npm install --save-dev jest eslint prettier
+pnpm add -D typescript @types/node @types/express
+pnpm add -D jest eslint prettier
 
 # 4. Initialize TypeScript (if using)
-npx tsc --init
+pnpm exec tsc --init
 
 # 5. Create project structure
 mkdir -p src/{routes,controllers,middleware,utils}
@@ -414,7 +414,7 @@ grep "secrets.json" .gitignore
 
 # ✅ Dependencies installed
 # Python: uv sync
-# JavaScript: npm install
+# JavaScript: pnpm install
 # Go: go mod download
 # Rust: cargo build
 
@@ -423,7 +423,7 @@ tree -L 2 src/  # or appropriate directory
 
 # ✅ Tests run successfully (if any exist)
 # Python: uv run pytest
-# JavaScript: npm test
+# JavaScript: pnpm test
 # Go: go test ./...
 # Rust: cargo test
 ```
@@ -496,8 +496,8 @@ git config user.email "your.email@example.com"
 uv cache clean
 
 # JavaScript: Clear cache
-rm -rf node_modules package-lock.json
-npm install
+rm -rf node_modules pnpm-lock.yaml
+pnpm install
 
 # Go: Clear module cache
 go clean -modcache

--- a/AgentUsage/svelte5_guide.md
+++ b/AgentUsage/svelte5_guide.md
@@ -19,11 +19,11 @@ Using Svelte 5 with SvelteKit provides:
 
 ```bash
 # Project Setup
-npx sv create my-app      # Create new SvelteKit project
-cd my-app && npm install  # Install dependencies
-npm run dev               # Start dev server (localhost:5173)
-npm run build             # Build for production
-npm run preview           # Preview production build
+pnpm dlx sv create my-app  # Create new SvelteKit project
+cd my-app && pnpm install  # Install dependencies
+pnpm run dev               # Start dev server (localhost:5173)
+pnpm run build             # Build for production
+pnpm run preview           # Preview production build
 ```
 
 ### Runes Cheatsheet

--- a/CLOUDFLARE-SETUP.md
+++ b/CLOUDFLARE-SETUP.md
@@ -106,7 +106,7 @@ wrangler pages project create grove-engine --production-branch=main
 - Connect to GitHub repository (grove-engine)
 - Configure build settings:
   - Framework preset: SvelteKit
-  - Build command: `npm run build`
+  - Build command: `pnpm run build`
   - Build output directory: `.svelte-kit/cloudflare`
   - Node version: 20
 - Add environment variables with resource IDs from above

--- a/docs/PHASE-0.1-LAUNCH-PLAN.md
+++ b/docs/PHASE-0.1-LAUNCH-PLAN.md
@@ -78,7 +78,7 @@ Create three separate repositories:
 
 ### Local Development Setup
 - [ ] Install Node.js 20+ (LTS version)
-- [ ] Install npm/yarn/pnpm (package manager)
+- [ ] Install pnpm (package manager)
 - [ ] Install wrangler CLI (Cloudflare tooling)
 - [ ] Install SvelteKit CLI tools
 - [ ] Configure VS Code extensions:

--- a/docs/prompts/web-engine-extraction-prompt.md
+++ b/docs/prompts/web-engine-extraction-prompt.md
@@ -493,8 +493,8 @@ ADMIN_GITHUB_USERNAMES=xxx
 
 ```bash
 cd /home/user/GroveEngine/package
-npm install
-npm run build  # If you add a build step
+pnpm install
+pnpm run build  # If you add a build step
 ```
 
 Verify:
@@ -506,8 +506,8 @@ Verify:
 
 ```bash
 cd /tmp/AutumnsGrove-source
-npm install
-npm run build
+pnpm install
+pnpm run build
 ```
 
 **If build fails, check:**
@@ -518,7 +518,7 @@ npm run build
 ### 5.3 Run Website Dev Server
 
 ```bash
-npm run dev
+pnpm run dev
 ```
 
 **Test every feature manually:**
@@ -566,7 +566,7 @@ npm run dev
 ### 5.4 Run Type Checking
 
 ```bash
-npm run check  # svelte-check
+pnpm run check  # svelte-check
 ```
 
 Ensure no type errors in either project.
@@ -621,7 +621,7 @@ A SvelteKit blog engine with a powerful gutter content system.
 ## Installation
 
 ```bash
-npm install grove-engine
+pnpm add grove-engine
 ```
 
 ## Usage

--- a/docs/specs/engine-spec.md
+++ b/docs/specs/engine-spec.md
@@ -693,10 +693,10 @@ bucket_name = "grove-media"
 ### Build Process
 ```bash
 # Install dependencies
-npm install
+pnpm install
 
 # Build for production
-npm run build
+pnpm run build
 
 # Deploy to Cloudflare
 wrangler pages deploy .svelte-kit/cloudflare


### PR DESCRIPTION
- Update AGENT.md to use pnpm as the official package manager
- Update all documentation files to use pnpm commands instead of npm
- Update pre-commit hooks to use pnpm exec instead of npx
- Update pre-push hook to use pnpm test
- Update post-checkout hook to prefer pnpm
- Update examples and troubleshooting docs with pnpm commands

Files updated:
- AGENT.md, CLOUDFLARE-SETUP.md
- docs/PHASE-0.1-LAUNCH-PLAN.md, docs/specs/engine-spec.md
- docs/prompts/web-engine-extraction-prompt.md
- AgentUsage/project_setup.md, multi_language_guide.md, svelte5_guide.md
- AgentUsage/documentation_standards.md, house_agents.md, git_guide.md
- AgentUsage/pre_commit_hooks/* (hooks and documentation)