### PR TITLE
feat: Add grove.place landing page with email signup

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,0 +1,50 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'landing/**'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: landing
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: landing/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .svelte-kit/cloudflare --project-name=grove-landing
+          workingDirectory: landing

--- a/DEPLOY-GUIDE.md
+++ b/DEPLOY-GUIDE.md
@@ -1,0 +1,131 @@
+# Grove Landing Page - Deployment Guide
+
+Everything is built. Follow these steps to go live.
+
+---
+
+## Step 1: Set Up Resend (Email)
+
+1. Go to [resend.com](https://resend.com) and create account
+2. **Add Domain**: Settings → Domains → Add `grove.place`
+3. **Add DNS Records**: Resend will show you 3 DNS records to add in Cloudflare:
+   - Go to Cloudflare Dashboard → grove.place → DNS
+   - Add the MX, TXT (SPF), and CNAME (DKIM) records Resend provides
+4. Wait for verification (usually 5-15 min)
+5. **Create API Key**: Settings → API Keys → Create
+6. Save the key (starts with `re_`)
+
+---
+
+## Step 2: Create Database Table
+
+Run this command from the `landing/` directory:
+
+```bash
+cd landing
+wrangler d1 execute grove-engine-db --remote --file=src/lib/db/schema.sql
+```
+
+---
+
+## Step 3: Create Cloudflare Pages Project
+
+```bash
+cd landing
+pnpm install
+pnpm run build
+wrangler pages project create grove-landing
+```
+
+When prompted:
+- Production branch: `main`
+
+---
+
+## Step 4: Bind D1 Database to Pages
+
+In Cloudflare Dashboard:
+1. Go to **Workers & Pages** → **grove-landing**
+2. **Settings** → **Bindings** → **Add**
+3. Select **D1 Database**
+   - Variable name: `DB`
+   - Database: `grove-engine-db`
+4. Click **Save**
+
+---
+
+## Step 5: Add Resend API Key
+
+```bash
+cd landing
+wrangler pages secret put RESEND_API_KEY
+```
+
+Paste your Resend API key when prompted.
+
+---
+
+## Step 6: Add Custom Domain
+
+In Cloudflare Dashboard:
+1. Go to **Workers & Pages** → **grove-landing**
+2. **Custom domains** → **Set up a custom domain**
+3. Enter: `grove.place`
+4. Click **Activate domain**
+
+---
+
+## Step 7: Set Up GitHub Auto-Deploy
+
+### Add GitHub Secrets
+
+In your GitHub repo → Settings → Secrets → Actions:
+
+| Secret Name | Value |
+|------------|-------|
+| `CLOUDFLARE_API_TOKEN` | Create at: CF Dashboard → My Profile → API Tokens → Create Token → "Edit Cloudflare Workers" template |
+| `CLOUDFLARE_ACCOUNT_ID` | `04e847fa7655624e84414a8280b3a4d0` |
+
+### Deploy Workflow
+
+The workflow at `.github/workflows/deploy-landing.yml` will auto-deploy on push to `main` when files in `landing/` change.
+
+---
+
+## Step 8: First Deploy
+
+```bash
+cd landing
+pnpm run deploy
+```
+
+Or just push to `main` and GitHub Actions will deploy.
+
+---
+
+## Verify
+
+1. Visit [grove.place](https://grove.place)
+2. Enter an email and submit
+3. Check your inbox for the welcome email
+
+---
+
+## Quick Reference
+
+| Resource | Location |
+|----------|----------|
+| Landing code | `landing/` |
+| Database schema | `landing/src/lib/db/schema.sql` |
+| Email templates | `landing/src/lib/email/templates.ts` |
+| Deploy workflow | `.github/workflows/deploy-landing.yml` |
+
+---
+
+## Troubleshooting
+
+**"D1 database not available"**: D1 binding not configured. Check Step 4.
+
+**Emails not sending**: Check Resend dashboard for errors. Verify domain is verified.
+
+**404 on grove.place**: Custom domain not activated or DNS not propagated. Wait 5 min.

--- a/landing/.gitignore
+++ b/landing/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.svelte-kit
+.wrangler
+build
+.env
+.env.*
+!.env.example
+.DS_Store
+*.local

--- a/landing/README.md
+++ b/landing/README.md
@@ -1,0 +1,27 @@
+# Grove Landing Page
+
+Minimal landing page for [grove.place](https://grove.place) with email signup functionality.
+
+## Tech Stack
+
+- **Framework**: SvelteKit 2 + Svelte 5
+- **Styling**: Tailwind CSS
+- **Database**: Cloudflare D1
+- **Email**: Resend
+- **Hosting**: Cloudflare Pages
+
+## Local Development
+
+```bash
+cd landing
+pnpm install
+pnpm run dev
+```
+
+## Deployment
+
+Automatic deployment via GitHub Actions on push to `main`. See `../.github/workflows/deploy-landing.yml`.
+
+## Configuration
+
+See [`../DEPLOY-GUIDE.md`](../DEPLOY-GUIDE.md) for setup instructions.

--- a/landing/package.json
+++ b/landing/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "grove-landing",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "wrangler pages dev .svelte-kit/cloudflare",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "deploy": "pnpm run build && wrangler pages deploy .svelte-kit/cloudflare"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241112.0",
+    "@sveltejs/adapter-cloudflare": "^4.7.4",
+    "@sveltejs/kit": "^2.8.0",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "svelte": "^5.2.0",
+    "svelte-check": "^4.0.0",
+    "tailwindcss": "^3.4.15",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0",
+    "wrangler": "^3.91.0"
+  },
+  "dependencies": {
+    "resend": "^4.0.0"
+  }
+}

--- a/landing/postcss.config.js
+++ b/landing/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {}
+	}
+};

--- a/landing/src/app.css
+++ b/landing/src/app.css
@@ -1,0 +1,33 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+	html {
+		font-family: Georgia, Cambria, 'Times New Roman', serif;
+	}
+
+	body {
+		@apply bg-cream text-bark antialiased;
+	}
+}
+
+@layer components {
+	.btn-primary {
+		@apply bg-grove-600 hover:bg-grove-700 text-white font-sans font-medium
+			px-6 py-3 rounded-lg transition-colors duration-200
+			focus:outline-none focus:ring-2 focus:ring-grove-500 focus:ring-offset-2;
+	}
+
+	.input-field {
+		@apply w-full px-4 py-3 rounded-lg border border-grove-200
+			focus:border-grove-500 focus:ring-2 focus:ring-grove-500/20
+			focus:outline-none transition-all duration-200
+			bg-white text-bark placeholder:text-bark/40;
+	}
+}
+
+/* Subtle leaf pattern background */
+.leaf-pattern {
+	background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M30 5c-5 10-15 15-25 15 10 5 15 15 15 25 5-10 15-15 25-15-10-5-15-15-15-25z' fill='%2322c55e' fill-opacity='0.03'/%3E%3C/svg%3E");
+}

--- a/landing/src/app.d.ts
+++ b/landing/src/app.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="@cloudflare/workers-types" />
+
+declare global {
+	namespace App {
+		interface Platform {
+			env: {
+				DB: D1Database;
+				RESEND_API_KEY: string;
+			};
+			context: {
+				waitUntil(promise: Promise<unknown>): void;
+			};
+			caches: CacheStorage & { default: Cache };
+		}
+	}
+}
+
+export {};

--- a/landing/src/app.html
+++ b/landing/src/app.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="Grove: a place to Be. Coming soon." />
+		<meta name="theme-color" content="#16a34a" />
+		<meta property="og:title" content="Grove" />
+		<meta property="og:description" content="A place to Be. Coming soon." />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://grove.place" />
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/landing/src/lib/components/EmailSignup.svelte
+++ b/landing/src/lib/components/EmailSignup.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	let email = $state('');
+	let status = $state<'idle' | 'loading' | 'success' | 'error'>('idle');
+	let errorMessage = $state('');
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+
+		if (!email || !email.includes('@')) {
+			status = 'error';
+			errorMessage = 'Please enter a valid email address';
+			return;
+		}
+
+		status = 'loading';
+
+		try {
+			const response = await fetch('/api/signup', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ email })
+			});
+
+			const data = await response.json();
+
+			if (response.ok) {
+				status = 'success';
+				email = '';
+			} else {
+				status = 'error';
+				errorMessage = data.error || 'Something went wrong. Please try again.';
+			}
+		} catch {
+			status = 'error';
+			errorMessage = 'Unable to connect. Please try again.';
+		}
+	}
+</script>
+
+{#if status === 'success'}
+	<div
+		class="bg-grove-50 border border-grove-200 rounded-lg px-6 py-4 text-center max-w-md animate-in"
+	>
+		<svg class="w-8 h-8 text-grove-600 mx-auto mb-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+			<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" stroke-linecap="round" />
+			<polyline points="22 4 12 14.01 9 11.01" stroke-linecap="round" stroke-linejoin="round" />
+		</svg>
+		<p class="text-grove-800 font-sans font-medium">You're on the list!</p>
+		<p class="text-grove-600 text-sm font-sans mt-1">We'll be in touch when Grove blooms.</p>
+	</div>
+{:else}
+	<form onsubmit={handleSubmit} class="w-full max-w-md">
+		<div class="flex flex-col sm:flex-row gap-3">
+			<input
+				type="email"
+				bind:value={email}
+				placeholder="your@email.com"
+				class="input-field flex-1"
+				disabled={status === 'loading'}
+				required
+			/>
+			<button type="submit" class="btn-primary whitespace-nowrap" disabled={status === 'loading'}>
+				{#if status === 'loading'}
+					<span class="inline-flex items-center gap-2">
+						<svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+							<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-opacity="0.25" />
+							<path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+						</svg>
+						Joining...
+					</span>
+				{:else}
+					Notify me
+				{/if}
+			</button>
+		</div>
+
+		{#if status === 'error'}
+			<p class="text-red-600 text-sm mt-2 font-sans">{errorMessage}</p>
+		{/if}
+
+		<p class="text-bark/40 text-xs mt-3 text-center font-sans">
+			No spam, ever. Unsubscribe anytime.
+		</p>
+	</form>
+{/if}
+
+<style>
+	.animate-in {
+		animation: fadeIn 0.3s ease-out;
+	}
+
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+			transform: translateY(-4px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+</style>

--- a/landing/src/lib/db/schema.sql
+++ b/landing/src/lib/db/schema.sql
@@ -1,0 +1,15 @@
+-- Email signups table for grove.place landing page
+-- Run this with: wrangler d1 execute grove-engine-db --file=src/lib/db/schema.sql
+
+CREATE TABLE IF NOT EXISTS email_signups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT UNIQUE NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    confirmed_at TEXT,
+    unsubscribed_at TEXT,
+    source TEXT DEFAULT 'landing'
+);
+
+-- Index for quick lookups
+CREATE INDEX IF NOT EXISTS idx_email_signups_email ON email_signups(email);
+CREATE INDEX IF NOT EXISTS idx_email_signups_created ON email_signups(created_at);

--- a/landing/src/lib/email/send.ts
+++ b/landing/src/lib/email/send.ts
@@ -1,0 +1,29 @@
+import { Resend } from 'resend';
+import { getWelcomeEmailHtml, getWelcomeEmailText } from './templates';
+
+export async function sendWelcomeEmail(
+	toEmail: string,
+	apiKey: string
+): Promise<{ success: boolean; error?: string }> {
+	const resend = new Resend(apiKey);
+
+	try {
+		const { error } = await resend.emails.send({
+			from: 'Grove <hello@grove.place>',
+			to: toEmail,
+			subject: 'Welcome to Grove 🌿',
+			html: getWelcomeEmailHtml(),
+			text: getWelcomeEmailText()
+		});
+
+		if (error) {
+			console.error('Resend error:', error);
+			return { success: false, error: error.message };
+		}
+
+		return { success: true };
+	} catch (err) {
+		console.error('Email send error:', err);
+		return { success: false, error: 'Failed to send email' };
+	}
+}

--- a/landing/src/lib/email/templates.ts
+++ b/landing/src/lib/email/templates.ts
@@ -1,0 +1,96 @@
+export function getWelcomeEmailHtml(): string {
+	return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome to Grove</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #fefdfb; font-family: Georgia, Cambria, 'Times New Roman', serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
+    <tr>
+      <td align="center" style="padding-bottom: 30px;">
+        <!-- Logo -->
+        <svg width="60" height="60" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M50 10C35 25 20 35 20 55C20 75 33 90 50 90C67 90 80 75 80 55C80 35 65 25 50 10Z" fill="#16a34a" fill-opacity="0.15"/>
+          <path d="M50 20C40 32 30 40 30 55C30 70 38 80 50 80C62 80 70 70 70 55C70 40 60 32 50 20Z" fill="#16a34a" fill-opacity="0.3"/>
+          <path d="M50 32C44 40 38 46 38 55C38 64 43 70 50 70C57 70 62 64 62 55C62 46 56 40 50 32Z" fill="#16a34a"/>
+          <path d="M50 70V95" stroke="#16a34a" stroke-width="3" stroke-linecap="round"/>
+        </svg>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding-bottom: 20px;">
+        <h1 style="margin: 0; font-size: 28px; color: #3d2914; font-weight: normal;">
+          Welcome to Grove
+        </h1>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding-bottom: 30px;">
+        <p style="margin: 0; font-size: 18px; color: #3d2914; opacity: 0.7; font-style: italic;">
+          a place to Be
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 30px; background-color: #f0fdf4; border-radius: 12px;">
+        <p style="margin: 0 0 16px 0; font-size: 16px; line-height: 1.6; color: #3d2914;">
+          Thank you for joining us early.
+        </p>
+        <p style="margin: 0 0 16px 0; font-size: 16px; line-height: 1.6; color: #3d2914;">
+          We're building something special — a quiet corner of the internet where your words can grow and flourish.
+        </p>
+        <p style="margin: 0; font-size: 16px; line-height: 1.6; color: #3d2914;">
+          We'll reach out when Grove is ready to bloom. Until then, thank you for believing in what we're growing.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding-top: 40px;">
+        <p style="margin: 0; font-size: 14px; color: #3d2914; opacity: 0.5;">
+          — The Grove Team
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding-top: 30px;">
+        <div style="display: inline-block;">
+          <span style="display: inline-block; width: 6px; height: 6px; background-color: #bbf7d0; border-radius: 50%; margin: 0 4px;"></span>
+          <span style="display: inline-block; width: 6px; height: 6px; background-color: #86efac; border-radius: 50%; margin: 0 4px;"></span>
+          <span style="display: inline-block; width: 6px; height: 6px; background-color: #4ade80; border-radius: 50%; margin: 0 4px;"></span>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding-top: 30px;">
+        <p style="margin: 0; font-size: 12px; color: #3d2914; opacity: 0.4;">
+          grove.place
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+`.trim();
+}
+
+export function getWelcomeEmailText(): string {
+	return `
+Welcome to Grove
+================
+
+a place to Be
+
+Thank you for joining us early.
+
+We're building something special — a quiet corner of the internet where your words can grow and flourish.
+
+We'll reach out when Grove is ready to bloom. Until then, thank you for believing in what we're growing.
+
+— The Grove Team
+
+grove.place
+`.trim();
+}

--- a/landing/src/routes/+layout.svelte
+++ b/landing/src/routes/+layout.svelte
@@ -1,0 +1,9 @@
+<script>
+	import '../app.css';
+
+	let { children } = $props();
+</script>
+
+<div class="min-h-screen leaf-pattern">
+	{@render children()}
+</div>

--- a/landing/src/routes/+page.svelte
+++ b/landing/src/routes/+page.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import EmailSignup from '$lib/components/EmailSignup.svelte';
+</script>
+
+<svelte:head>
+	<title>Grove</title>
+</svelte:head>
+
+<main class="min-h-screen flex flex-col items-center justify-center px-6 py-12">
+	<!-- Logo/Brand -->
+	<div class="mb-8">
+		<svg
+			class="w-20 h-20 text-grove-600"
+			viewBox="0 0 100 100"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<!-- Stylized tree/leaf mark -->
+			<path
+				d="M50 10C35 25 20 35 20 55C20 75 33 90 50 90C67 90 80 75 80 55C80 35 65 25 50 10Z"
+				fill="currentColor"
+				fill-opacity="0.15"
+			/>
+			<path
+				d="M50 20C40 32 30 40 30 55C30 70 38 80 50 80C62 80 70 70 70 55C70 40 60 32 50 20Z"
+				fill="currentColor"
+				fill-opacity="0.3"
+			/>
+			<path
+				d="M50 32C44 40 38 46 38 55C38 64 43 70 50 70C57 70 62 64 62 55C62 46 56 40 50 32Z"
+				fill="currentColor"
+			/>
+			<!-- Stem -->
+			<path d="M50 70V95" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+		</svg>
+	</div>
+
+	<!-- Title -->
+	<h1 class="text-4xl md:text-5xl font-serif text-bark mb-3 text-center">Grove</h1>
+
+	<!-- Tagline -->
+	<p class="text-xl md:text-2xl text-bark/70 font-serif italic mb-12 text-center">
+		a place to Be
+	</p>
+
+	<!-- Decorative divider -->
+	<div class="flex items-center gap-4 mb-12">
+		<div class="w-12 h-px bg-grove-300"></div>
+		<svg class="w-5 h-5 text-grove-400" viewBox="0 0 20 20" fill="currentColor">
+			<path
+				d="M10 2C8 6 5 8 2 8c3 2 5 5 5 10 2-4 5-6 8-6-3-2-5-5-5-10z"
+				fill-opacity="0.6"
+			/>
+		</svg>
+		<div class="w-12 h-px bg-grove-300"></div>
+	</div>
+
+	<!-- Coming soon text -->
+	<p class="text-bark/60 text-center max-w-md mb-8 font-sans">
+		Something is growing here. Leave your email to be the first to know when we bloom.
+	</p>
+
+	<!-- Email signup -->
+	<EmailSignup />
+
+	<!-- Footer flourish -->
+	<div class="mt-16 flex gap-2">
+		{#each [1, 2, 3] as i}
+			<svg
+				class="w-3 h-3 text-grove-300"
+				viewBox="0 0 20 20"
+				fill="currentColor"
+				style="opacity: {0.3 + i * 0.2}"
+			>
+				<circle cx="10" cy="10" r="4" />
+			</svg>
+		{/each}
+	</div>
+</main>

--- a/landing/src/routes/api/signup/+server.ts
+++ b/landing/src/routes/api/signup/+server.ts
@@ -1,0 +1,78 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { sendWelcomeEmail } from '$lib/email/send';
+
+export const POST: RequestHandler = async ({ request, platform }) => {
+	if (!platform?.env?.DB) {
+		console.error('D1 database not available');
+		return json({ error: 'Service temporarily unavailable' }, { status: 503 });
+	}
+
+	let body: { email?: string };
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Invalid request body' }, { status: 400 });
+	}
+
+	const { email } = body;
+
+	if (!email || typeof email !== 'string') {
+		return json({ error: 'Email is required' }, { status: 400 });
+	}
+
+	// Basic email validation
+	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+	if (!emailRegex.test(email)) {
+		return json({ error: 'Please enter a valid email address' }, { status: 400 });
+	}
+
+	const normalizedEmail = email.toLowerCase().trim();
+
+	try {
+		// Check if already signed up
+		const existing = await platform.env.DB.prepare(
+			'SELECT id, unsubscribed_at FROM email_signups WHERE email = ?'
+		)
+			.bind(normalizedEmail)
+			.first<{ id: number; unsubscribed_at: string | null }>();
+
+		if (existing) {
+			if (existing.unsubscribed_at) {
+				// Re-subscribe
+				await platform.env.DB.prepare(
+					'UPDATE email_signups SET unsubscribed_at = NULL, created_at = datetime("now") WHERE id = ?'
+				)
+					.bind(existing.id)
+					.run();
+
+				// Send welcome email in background
+				if (platform.env.RESEND_API_KEY) {
+					platform.context.waitUntil(
+						sendWelcomeEmail(normalizedEmail, platform.env.RESEND_API_KEY)
+					);
+				}
+
+				return json({ success: true, message: 'Welcome back!' });
+			}
+			return json({ error: 'This email is already on our list!' }, { status: 409 });
+		}
+
+		// Insert new signup
+		await platform.env.DB.prepare('INSERT INTO email_signups (email) VALUES (?)')
+			.bind(normalizedEmail)
+			.run();
+
+		// Send welcome email in background
+		if (platform.env.RESEND_API_KEY) {
+			platform.context.waitUntil(
+				sendWelcomeEmail(normalizedEmail, platform.env.RESEND_API_KEY)
+			);
+		}
+
+		return json({ success: true, message: 'Thanks for signing up!' });
+	} catch (error) {
+		console.error('Signup error:', error);
+		return json({ error: 'Something went wrong. Please try again.' }, { status: 500 });
+	}
+};

--- a/landing/static/favicon.svg
+++ b/landing/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M50 10C35 25 20 35 20 55C20 75 33 90 50 90C67 90 80 75 80 55C80 35 65 25 50 10Z" fill="#16a34a" fill-opacity="0.15"/>
+  <path d="M50 20C40 32 30 40 30 55C30 70 38 80 50 80C62 80 70 70 70 55C70 40 60 32 50 20Z" fill="#16a34a" fill-opacity="0.3"/>
+  <path d="M50 32C44 40 38 46 38 55C38 64 43 70 50 70C57 70 62 64 62 55C62 46 56 40 50 32Z" fill="#16a34a"/>
+  <path d="M50 70V95" stroke="#16a34a" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/landing/svelte.config.js
+++ b/landing/svelte.config.js
@@ -1,0 +1,17 @@
+import adapter from '@sveltejs/adapter-cloudflare';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	preprocess: vitePreprocess(),
+	kit: {
+		adapter: adapter({
+			routes: {
+				include: ['/*'],
+				exclude: ['<all>']
+			}
+		})
+	}
+};
+
+export default config;

--- a/landing/tailwind.config.js
+++ b/landing/tailwind.config.js
@@ -1,0 +1,30 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+	content: ['./src/**/*.{html,js,svelte,ts}'],
+	theme: {
+		extend: {
+			colors: {
+				grove: {
+					50: '#f0fdf4',
+					100: '#dcfce7',
+					200: '#bbf7d0',
+					300: '#86efac',
+					400: '#4ade80',
+					500: '#22c55e',
+					600: '#16a34a',
+					700: '#15803d',
+					800: '#166534',
+					900: '#14532d',
+					950: '#052e16'
+				},
+				cream: '#fefdfb',
+				bark: '#3d2914'
+			},
+			fontFamily: {
+				serif: ['Georgia', 'Cambria', 'Times New Roman', 'serif'],
+				sans: ['system-ui', '-apple-system', 'sans-serif']
+			}
+		}
+	},
+	plugins: []
+};

--- a/landing/tsconfig.json
+++ b/landing/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler",
+		"types": ["@cloudflare/workers-types"]
+	}
+}

--- a/landing/vite.config.ts
+++ b/landing/vite.config.ts
@@ -1,0 +1,6 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [sveltekit()]
+});

--- a/landing/wrangler.toml
+++ b/landing/wrangler.toml
@@ -1,0 +1,12 @@
+name = "grove-landing"
+compatibility_date = "2024-11-24"
+pages_build_output_dir = ".svelte-kit/cloudflare"
+
+# D1 Database binding
+[[d1_databases]]
+binding = "DB"
+database_name = "grove-engine-db"
+database_id = "a6394da2-b7a6-48ce-b7fe-b1eb3e730e68"
+
+# Environment variables (secrets added via wrangler)
+# RESEND_API_KEY - add via: wrangler pages secret put RESEND_API_KEY


### PR DESCRIPTION
- SvelteKit 2 + Svelte 5 landing page with minimal, lush grove branding
- Email signup form storing to D1 database
- Resend integration for welcome confirmation emails
- Cloudflare Pages deployment configuration
- GitHub Actions workflow for auto-deploy on push to main
- Deployment guide with step-by-step setup instructions