### PR TITLE
fix: add cache-dependency-path to pnpm workflow caching

### DIFF
--- a/.github/workflows/deploy-example-site.yml
+++ b/.github/workflows/deploy-example-site.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish-engine.yml
+++ b/.github/workflows/publish-engine.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@autumnsgrove'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install


### PR DESCRIPTION
Resolves "packages field missing or empty" error in GitHub Actions
by explicitly specifying the pnpm lockfile path for the setup-node
action's caching mechanism.