### PR TITLE
Fix example page deployment issue

### DIFF
--- a/.github/workflows/deploy-example-site.yml
+++ b/.github/workflows/deploy-example-site.yml
@@ -32,10 +32,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build UI package
-        working-directory: packages/ui
-        run: pnpm run package
-
       - name: Build engine package
         working-directory: packages/engine
         run: pnpm run package


### PR DESCRIPTION
The workflow was referencing packages/ui which doesn't exist in the repository. Only packages/engine and packages/example-site exist.