### PR TITLE
Fix broken email signup on landing page

### DIFF
--- a/landing/src/lib/components/EmailSignup.svelte
+++ b/landing/src/lib/components/EmailSignup.svelte
@@ -21,7 +21,7 @@
 				body: JSON.stringify({ email })
 			});
 
-			const data = await response.json();
+			const data = (await response.json()) as { error?: string };
 
 			if (response.ok) {
 				status = 'success';

--- a/landing/src/routes/admin/cdn/+page.svelte
+++ b/landing/src/routes/admin/cdn/+page.svelte
@@ -114,11 +114,11 @@
 					body: formData
 				});
 
-				const result = await response.json();
+				const result = (await response.json()) as { success?: boolean; file?: CdnFile; error?: string };
 
 				if (response.ok && result.success) {
 					uploadProgress[i].progress = 100;
-					files = [result.file, ...files];
+					files = [result.file as CdnFile, ...files];
 					if (!folders.includes(folder)) {
 						folders = [...folders, folder].sort();
 					}
@@ -169,7 +169,7 @@
 					successMessage = '';
 				}, 3000);
 			} else {
-				const result = await response.json();
+				const result = (await response.json()) as { error?: string };
 				throw new Error(result.error || 'Delete failed');
 			}
 		} catch (err) {

--- a/landing/src/routes/admin/login/+page.svelte
+++ b/landing/src/routes/admin/login/+page.svelte
@@ -19,7 +19,7 @@
 				body: JSON.stringify({ email })
 			});
 
-			const result = await response.json();
+			const result = (await response.json()) as { success?: boolean; error?: string };
 
 			if (response.ok && result.success) {
 				step = 'code';
@@ -47,7 +47,7 @@
 				body: JSON.stringify({ email, code })
 			});
 
-			const result = await response.json();
+			const result = (await response.json()) as { success?: boolean; error?: string };
 
 			if (response.ok && result.success) {
 				window.location.href = '/admin/cdn';

--- a/landing/src/routes/api/admin/cdn/files/[id]/+server.ts
+++ b/landing/src/routes/api/admin/cdn/files/[id]/+server.ts
@@ -41,7 +41,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals, platform 
 	}
 
 	const { DB, CDN_URL } = platform.env;
-	const body = await request.json();
+	const body = (await request.json()) as { alt_text?: unknown };
 	const { alt_text } = body;
 
 	if (typeof alt_text !== 'string') {


### PR DESCRIPTION
The response.json() calls were returning unknown type, which caused TypeScript errors that could fail the build. Added proper type assertions to fix the email signup and admin pages.

Files fixed:
- EmailSignup.svelte - signup response typing
- admin/cdn/+page.svelte - upload and delete response typing
- admin/login/+page.svelte - auth response typing
- api/admin/cdn/files/[id]/+server.ts - request body typing