### PR TITLE
Fix email submission on landing page

### DIFF
--- a/landing/migrations/0000_email_signups.sql
+++ b/landing/migrations/0000_email_signups.sql
@@ -1,0 +1,14 @@
+-- Email signups table for grove.place landing page
+
+CREATE TABLE IF NOT EXISTS email_signups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT UNIQUE NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    confirmed_at TEXT,
+    unsubscribed_at TEXT,
+    source TEXT DEFAULT 'landing'
+);
+
+-- Index for quick lookups
+CREATE INDEX IF NOT EXISTS idx_email_signups_email ON email_signups(email);
+CREATE INDEX IF NOT EXISTS idx_email_signups_created ON email_signups(created_at);


### PR DESCRIPTION
The email signup form returns "Service temporarily unavailable" because the email_signups table was defined in schema.sql but never added to the migrations that run during deployment. This adds the table creation as migration 0000 so it runs before other migrations.