### PR TITLE
Debug Cloudflare deployment build failures

### DIFF
--- a/packages/engine/dist/components/custom/ContentWithGutter.svelte
+++ b/packages/engine/dist/components/custom/ContentWithGutter.svelte
@@ -76,13 +76,16 @@
 
 	/**
 	 * Calculate positions based on anchor locations, with collision detection
+	 * Uses getBoundingClientRect() for accurate positioning regardless of offset parent chains
 	 */
 	async function updatePositions() {
 		if (!gutterElement || !contentBodyElement) return;
 
 		await tick(); // Wait for DOM to update
 
-		const gutterTop = gutterElement.offsetTop;
+		// Use getBoundingClientRect for accurate relative positioning
+		// This works regardless of offset parent chains and CSS transforms
+		const gutterRect = gutterElement.getBoundingClientRect();
 
 		let lastBottom = 0; // Track the bottom edge of the last positioned item
 		const newOverflowingAnchors = [];
@@ -94,20 +97,24 @@
 			if (!el && import.meta.env.DEV) {
 				console.warn(`Anchor element not found for: ${anchor}`);
 			}
+			// Use getBoundingClientRect for consistent positioning
+			const elRect = el ? el.getBoundingClientRect() : null;
 			return {
 				anchor,
 				key: getKey(anchor),
 				element: el,
-				top: el ? el.offsetTop : Infinity
+				elementRect: elRect,
+				top: elRect ? elRect.top : Infinity
 			};
 		}).sort((a, b) => a.top - b.top);
 
-		anchorPositions.forEach(({ anchor, key, element }) => {
+		anchorPositions.forEach(({ anchor, key, element, elementRect }) => {
 			const groupEl = anchorGroupElements[key];
 
-			if (element && groupEl) {
-				// Desired position (aligned with anchor element)
-				let desiredTop = element.offsetTop - gutterTop;
+			if (element && elementRect && groupEl) {
+				// Calculate position relative to the gutter element's top
+				// This accounts for any content above the content-body (headers, etc.)
+				let desiredTop = elementRect.top - gutterRect.top;
 
 				// Get the height of this gutter group
 				const groupHeight = groupEl.offsetHeight;
@@ -397,7 +404,7 @@
 	// Load DOMPurify only in browser
 	onMount(async () => {
 		if (browser) {
-			const module = await import('isomorphic-dompurify');
+			const module = await import('dompurify');
 			DOMPurify = module.default;
 		}
 	});

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -180,7 +180,7 @@
     "@types/dompurify": "^3.0.5",
     "chart.js": "^4.5.1",
     "clsx": "^2.1.1",
-    "isomorphic-dompurify": "^2.33.0",
+    "dompurify": "^3.3.0",
     "gray-matter": "^4.0.3",
     "lucide-svelte": "^0.554.0",
     "marked": "^17.0.1",

--- a/packages/engine/src/lib/components/custom/ContentWithGutter.svelte
+++ b/packages/engine/src/lib/components/custom/ContentWithGutter.svelte
@@ -404,7 +404,7 @@
 	// Load DOMPurify only in browser
 	onMount(async () => {
 		if (browser) {
-			const module = await import('isomorphic-dompurify');
+			const module = await import('dompurify');
 			DOMPurify = module.default;
 		}
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,12 +65,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      dompurify:
+        specifier: ^3.3.0
+        version: 3.3.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
-      isomorphic-dompurify:
-        specifier: ^2.33.0
-        version: 2.33.0
       lucide-svelte:
         specifier: ^0.554.0
         version: 0.554.0(svelte@5.45.3)
@@ -1787,10 +1787,6 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
-
-  isomorphic-dompurify@2.33.0:
-    resolution: {integrity: sha512-pXGR3rAHAXb5Bvr56pc5aV0Lh8laubLo7/60F+soOzDFmwks6MtgDhL7p46VoxLnwgIsjgmVhQpUt4mUlL/XEw==}
-    engines: {node: '>=20.19.5'}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -3840,16 +3836,6 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
-
-  isomorphic-dompurify@2.33.0:
-    dependencies:
-      dompurify: 3.3.0
-      jsdom: 27.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
 
   jiti@1.21.7: {}
 


### PR DESCRIPTION
Fixes Cloudflare build failure caused by jsdom/cssstyle being bundled. isomorphic-dompurify imports jsdom for server-side DOM parsing, but Rollup can't parse jsdom's Node.js-specific syntax when building for Cloudflare Workers.

Changes:
- Replace isomorphic-dompurify with browser-only dompurify
- Update sanitize.js to dynamically load DOMPurify in browser only
- Add SSR fallback that passes content through (content should be sanitized before storing in database)
- Update ContentWithGutter.svelte dynamic import

🤖 Generated with [Claude Code](https://claude.ai/code)