### PR TITLE
Fix D1 binding issue in email signup

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -55,5 +55,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy .svelte-kit/cloudflare --project-name=grove-landing
+          command: pages deploy .svelte-kit/cloudflare --project-name=grove-landing --d1 DB=a6394da2-b7a6-48ce-b7fe-b1eb3e730e68 --r2 CDN_BUCKET=grove-cdn --var CDN_URL:https://cdn.grove.place
           workingDirectory: landing

--- a/landing/wrangler.toml
+++ b/landing/wrangler.toml
@@ -7,9 +7,18 @@ pages_build_output_dir = ".svelte-kit/cloudflare"
 [vars]
 CDN_URL = "http://localhost:5173/cdn"
 
-# Production bindings are configured in Cloudflare Dashboard:
-# - D1 Database: DB -> grove-engine-db
-# - R2 Bucket: CDN_BUCKET -> grove-cdn
-# - Secret: RESEND_API_KEY
-# - Secret: ADMIN_EMAILS
-# - Variable: CDN_URL -> https://cdn.grove.place
+# D1 Database binding
+[[d1_databases]]
+binding = "DB"
+database_name = "grove-engine-db"
+database_id = "a6394da2-b7a6-48ce-b7fe-b1eb3e730e68"
+
+# R2 Storage binding
+[[r2_buckets]]
+binding = "CDN_BUCKET"
+bucket_name = "grove-cdn"
+
+# Secrets (configured in Cloudflare Dashboard or via wrangler secret):
+# - RESEND_API_KEY
+# - ADMIN_EMAILS
+# Production CDN_URL is set via --var flag in deployment


### PR DESCRIPTION
The D1 database binding wasn't reaching the Pages runtime because wrangler pages deploy doesn't read [[d1_databases]] from wrangler.toml. This passes the binding explicitly via --d1 flag along with R2 and CDN_URL.

Also restored proper wrangler.toml config for local dev consistency.

🤖 Generated with [Claude Code](https://claude.ai/code)