### PR TITLE
Update all fonts to Quicksand

### DIFF
--- a/domains/tailwind.config.js
+++ b/domains/tailwind.config.js
@@ -34,8 +34,8 @@ export default {
 				}
 			},
 			fontFamily: {
-				serif: ['Georgia', 'Cambria', 'Times New Roman', 'serif'],
-				sans: ['system-ui', '-apple-system', 'sans-serif'],
+				serif: ['Quicksand', 'Georgia', 'Cambria', 'Times New Roman', 'serif'],
+				sans: ['Quicksand', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
 				mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'monospace']
 			}
 		}


### PR DESCRIPTION
Update Tailwind fontFamily config to prioritize Quicksand for both serif and sans font classes, ensuring consistent typography across the domain searcher website.

🤖 Generated with [Claude Code](https://claude.ai/code)