### PR TITLE
docs: update inference provider hierarchy and add Cerebras

### DIFF
--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -2,7 +2,7 @@
 
 **Grove Platform**
 **Effective Date:** December 10, 2025
-**Last Updated:** December 10, 2025
+**Last Updated:** December 11, 2025
 
 ---
 
@@ -101,7 +101,7 @@ We share limited data with trusted service providers who help us operate Grove:
 | **Stripe** | Payment processing | Billing information |
 | **Resend** | Email delivery | Email address, email content |
 | **Google** | Authentication (optional) | Email address (if you use Google Sign-In) |
-| **Fireworks AI / Groq** | Content moderation | Post content (zero data retention) |
+| **Fireworks AI / Cerebras / Groq** | Content moderation | Post content (zero data retention) |
 
 These providers are contractually bound to protect your data and use it only for the services they provide to us.
 


### PR DESCRIPTION
Restructure inference providers based on model availability:
- Fireworks AI as primary (only provider with DeepSeek V3.2, Kimi K2, AND Llama 3.1)
- Cerebras as backup (Llama 3.3 70B, GPT-OSS-120B with ultra-fast inference)
- Groq as tertiary (note: Llama 3.1 70B deprecated Jan 2025)

Updates include:
- New provider hierarchy in content moderation spec
- Updated pricing tables with all three providers
- Added HuggingFace model links
- New fallback model order with provider IDs
- Cerebras documentation links
- Privacy policy updated to list all providers

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <agent@localhost>