### PR TITLE
feat: rebrand GroveEngine to Lattice public name

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4,6 +4,18 @@
 
 ---
 
+## Project Naming
+
+| | |
+|---|---|
+| **Public name** | Lattice |
+| **Internal codename** | GroveEngine |
+| **npm package** | @autumnsgrove/groveengine |
+
+Lattice is the core framework that powers the Grove ecosystem. The name evokes a framework that supports growth—vines climb it, gardens are built around it. Use "Lattice" in user-facing documentation and marketing; use "GroveEngine" for internal references, database names, and infrastructure.
+
+---
+
 ## Project Purpose
 Multi-tenant blog platform where users get their own blogs on subdomains (username.grove.place). Built on Cloudflare infrastructure with SvelteKit, featuring an optional community feed where blogs can share posts, vote, and react with emojis.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Grove Platform
+# Lattice
 
-A modern, multi-tenant blogging platform where users get their own blogs on subdomains (username.grove.place). Built entirely on Cloudflare infrastructure with SvelteKit, featuring unique gutter annotations, a powerful markdown editor, and an optional community feed.
+> **Internal codename:** GroveEngine
+
+A modern, multi-tenant blogging platform where users get their own blogs on subdomains (username.grove.place). Built entirely on Cloudflare infrastructure with SvelteKit, featuring unique gutter annotations, a powerful markdown editor, and an optional community feed. Lattice is the core framework that supports the entire Grove ecosystem—the thing that holds everything else up.
 
 ## 📦 Packages
 
@@ -16,7 +18,7 @@ A modern, multi-tenant blogging platform where users get their own blogs on subd
 |------|-----|-------------|
 | Grove Landing | [grove.place](https://grove.place) | Landing page with email signup |
 | Example Blog | [example.grove.place](https://example.grove.place) | Demo site (The Midnight Bloom Tea Café) |
-| Domain Search | [domains.grove.place](https://domains.grove.place) | AI-powered domain search tool |
+| Acorn | [acorn.grove.place](https://acorn.grove.place) | AI-powered domain discovery |
 | CDN | [cdn.grove.place](https://cdn.grove.place) | Content delivery network |
 | Auth | [auth.grove.place](https://auth.grove.place) | Heartwood authentication service |
 | Admin | [admin.grove.place](https://admin.grove.place) | Heartwood admin dashboard |
@@ -33,7 +35,7 @@ A modern, multi-tenant blogging platform where users get their own blogs on subd
 | GroveScout | [AutumnsGrove/GroveScout](https://github.com/AutumnsGrove/GroveScout) | Scout tool |
 | Aria | [AutumnsGrove/GroveMusic](https://github.com/AutumnsGrove/GroveMusic) | Music curation platform |
 | GroveSearch | [AutumnsGrove/GroveSearch](https://github.com/AutumnsGrove/GroveSearch) | Search service |
-| Acorn | [AutumnsGrove/GroveDomainTool](https://github.com/AutumnsGrove/GroveDomainTool) | AI-powered domain discovery |
+| Acorn | [AutumnsGrove/GroveDomainTool](https://github.com/AutumnsGrove/GroveDomainTool) | AI-powered domain discovery tool |
 
 ## 📁 Project Structure
 
@@ -51,7 +53,7 @@ GroveEngine/
 │   │   │   └── routes/       # SvelteKit routes (blog, admin, API, auth)
 │   │   └── migrations/       # D1 database migrations (7 migrations)
 │   └── example-site/         # Demo site: The Midnight Bloom Tea Café
-├── domains/                  # AI-powered domain search tool (domains.grove.place)
+├── domains/                  # Acorn: AI-powered domain discovery (acorn.grove.place)
 ├── landing/                  # Marketing site for grove.place
 ├── docs/                     # Project documentation
 │   ├── README.md             # Master project summary
@@ -129,8 +131,8 @@ import { parseMarkdown } from '@autumnsgrove/groveengine/utils/markdown';
 
 ## 🔍 Internal Tools
 
-### Domain Search (domains.grove.place)
-An AI-powered domain discovery tool that speeds up client consultations from 2-3 weeks to 1-2 days.
+### Acorn (acorn.grove.place)
+An AI-powered domain discovery tool that speeds up client consultations from 2-3 weeks to 1-2 days. Every oak was once an acorn—and every online presence starts with a name.
 
 **Features:**
 - Multi-provider AI swarm (Claude, DeepSeek, Kimi, Llama 4)

--- a/docs/specs/engine-spec.md
+++ b/docs/specs/engine-spec.md
@@ -6,9 +6,11 @@ tags:
 type: tech-spec
 ---
 
-# GroveEngine - Technical Specification
+# Lattice - Technical Specification
 
-**Package:** `@groveengine/core`
+> **Internal codename:** GroveEngine
+
+**Package:** `@autumnsgrove/groveengine`
 **Repository:** `GroveEngine`
 **Type:** npm Package / SvelteKit Library
 **Purpose:** Powers all individual blog instances with reusable components

--- a/domains/src/app.html
+++ b/domains/src/app.html
@@ -4,12 +4,12 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="description" content="Grove Domain Finder - AI-powered domain search tool" />
+		<meta name="description" content="Acorn - AI-powered domain discovery. Every oak was once an acorn." />
 		<meta name="theme-color" content="#7c3aed" />
-		<meta property="og:title" content="Grove Domain Finder" />
-		<meta property="og:description" content="Find the perfect domain name with AI-powered search" />
+		<meta property="og:title" content="Acorn — Domain Discovery" />
+		<meta property="og:description" content="Find the perfect domain name with AI-powered search. Every oak was once an acorn." />
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://domains.grove.place" />
+		<meta property="og:url" content="https://acorn.grove.place" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/domains/src/routes/+page.svelte
+++ b/domains/src/routes/+page.svelte
@@ -5,8 +5,8 @@
 </script>
 
 <svelte:head>
-	<title>Grove Domain Finder — AI-Powered Domain Search</title>
-	<meta name="description" content="Find the perfect domain name with AI-powered search. Our swarm of intelligent agents scans thousands of possibilities to find available, memorable domains." />
+	<title>Acorn — AI-Powered Domain Discovery</title>
+	<meta name="description" content="Find the perfect domain name with AI-powered search. Every oak was once an acorn—and every online presence starts with a name." />
 </svelte:head>
 
 <main class="min-h-screen flex flex-col">
@@ -33,11 +33,11 @@
 		</div>
 
 		<!-- Title -->
-		<h1 class="text-4xl md:text-5xl font-serif text-bark mb-3 text-center">Domain Finder</h1>
+		<h1 class="text-4xl md:text-5xl font-serif text-bark mb-3 text-center">Acorn</h1>
 
 		<!-- Tagline -->
 		<p class="text-xl md:text-2xl text-bark/70 font-serif italic mb-8 text-center">
-			AI-powered domain discovery
+			every oak was once an acorn
 		</p>
 
 		<!-- Decorative divider -->
@@ -52,12 +52,12 @@
 		<!-- Description -->
 		<div class="max-w-xl text-center mb-12 space-y-4">
 			<p class="text-bark/70 font-sans leading-relaxed">
-				Finding the perfect domain doesn't have to take weeks. Our AI-powered swarm of agents
-				generates creative options, checks availability in real-time, and evaluates each domain
-				for memorability, brandability, and email-friendliness.
+				Finding the perfect domain doesn't have to take weeks. Tell Acorn about your project, your vibe,
+				your budget—and it returns a curated list of available domains that actually fit. The seed you
+				plant here becomes your entire digital presence.
 			</p>
 			<p class="text-bark/60 font-sans text-sm">
-				Powered by Claude Sonnet for creative generation and a fleet of Haiku agents for rapid evaluation.
+				AI-powered domain discovery with real-time availability checks and smart scoring.
 			</p>
 		</div>
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,6 +1,8 @@
-# Lattice (@grove/engine)
+# Lattice (@autumnsgrove/groveengine)
 
-Multi-tenant blog engine for the Grove Platform. Each Grove site runs as its own Cloudflare Worker, powered by Lattice.
+> **Internal codename:** GroveEngine
+
+Multi-tenant blog engine for the Grove Platform. Each Grove site runs as its own Cloudflare Worker, powered by Lattice. A lattice is the framework that supports growth—vines climb it, gardens are built around it.
 
 ## Features
 


### PR DESCRIPTION
Apply Grove naming conventions to this repository:
- Rename main title from "Grove Platform" to "Lattice"
- Add internal codename notes throughout documentation
- Update domains.grove.place references to acorn.grove.place
- Rebrand domain finder app to "Acorn"
- Add Project Naming section to AGENT.md

Public name: Lattice
Internal codename: GroveEngine