### PR TITLE
feat(landing): add email signup CTA to vision page

### DIFF
--- a/docs/grove-the-vision.md
+++ b/docs/grove-the-vision.md
@@ -59,3 +59,10 @@ It's optional. Your blog exists independently, complete on its own. But if you c
 ---
 
 *A forest of voices. A place to be.*
+
+---
+
+We're not open yet, but we're growing.
+Leave your email to join us when Grove blooms.
+
+**[Join the waitlist →](https://grove.place)**

--- a/landing/src/routes/vision/+page.svelte
+++ b/landing/src/routes/vision/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import EmailSignup from '$lib/components/EmailSignup.svelte';
 </script>
 
 <svelte:head>
@@ -152,6 +153,17 @@
 					<p class="text-grove-700 font-serif text-lg">
 						A forest of voices. A place to be.
 					</p>
+				</section>
+
+				<!-- Call to Action -->
+				<section class="text-center py-8">
+					<p class="text-bark/70 font-sans leading-relaxed mb-6">
+						We're not open yet, but we're growing.<br />
+						Leave your email to join us when Grove blooms.
+					</p>
+					<div class="flex justify-center">
+						<EmailSignup />
+					</div>
 				</section>
 			</div>
 		</div>


### PR DESCRIPTION
Add a warm call-to-action at the bottom of the vision page that
flows naturally from the closing section, inviting readers to
join the waitlist. Uses the existing EmailSignup component.