### PR TITLE
feat(landing): add dark mode toggle with CSS variables

### DIFF
--- a/landing/src/app.css
+++ b/landing/src/app.css
@@ -2,6 +2,148 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ═══════════════════════════════════════════════════════════════
+   GROVE DESIGN SYSTEM - CSS Custom Properties
+   All colors use CSS variables for live theme switching
+   ═══════════════════════════════════════════════════════════════ */
+
+:root {
+	/* Primary: Grove Green */
+	--grove-50: #f0fdf4;
+	--grove-100: #dcfce7;
+	--grove-200: #bbf7d0;
+	--grove-300: #86efac;
+	--grove-400: #4ade80;
+	--grove-500: #22c55e;
+	--grove-600: #16a34a;
+	--grove-700: #15803d;
+	--grove-800: #166534;
+	--grove-900: #14532d;
+	--grove-950: #052e16;
+
+	/* Neutral: Cream (Light Mode) */
+	--cream: #fefdfb;
+	--cream-50: #fefdfb;
+	--cream-100: #fdfcf8;
+	--cream-200: #faf8f3;
+	--cream-300: #f5f2ea;
+	--cream-400: #ede9de;
+	--cream-500: #e2ddd0;
+
+	/* Neutral: Bark (Light Mode) */
+	--bark: #3d2914;
+	--bark-50: #f9f6f3;
+	--bark-100: #f0e9e1;
+	--bark-200: #e0d2c2;
+	--bark-300: #ccb59c;
+	--bark-400: #b69575;
+	--bark-500: #a57c5a;
+	--bark-600: #8a6347;
+	--bark-700: #6f4d39;
+	--bark-800: #5a3f30;
+	--bark-900: #3d2914;
+	--bark-950: #2a1b0d;
+
+	/* Semantic Colors */
+	--color-background: var(--cream);
+	--color-foreground: var(--bark);
+	--color-foreground-muted: rgba(61, 41, 20, 0.7);
+	--color-foreground-subtle: rgba(61, 41, 20, 0.5);
+	--color-foreground-faint: rgba(61, 41, 20, 0.4);
+
+	--color-primary: var(--grove-600);
+	--color-primary-hover: var(--grove-700);
+	--color-primary-foreground: #ffffff;
+
+	--color-border: var(--grove-200);
+	--color-border-subtle: var(--grove-100);
+	--color-divider: var(--grove-300);
+
+	--color-surface: rgba(255, 255, 255, 0.5);
+	--color-surface-elevated: #ffffff;
+
+	--color-accent-bg: var(--grove-50);
+	--color-accent-border: var(--grove-200);
+	--color-accent-text: var(--grove-800);
+	--color-accent-text-muted: var(--grove-600);
+	--color-accent-text-subtle: var(--grove-500);
+
+	/* Status Colors */
+	--color-error: #dc2626;
+	--color-error-bg: #fee2e2;
+	--color-error-border: #fecaca;
+	--color-error-text: #991b1b;
+
+	/* Shadows */
+	--shadow-sm: 0 1px 2px 0 rgb(61 41 20 / 0.05);
+	--shadow-md: 0 4px 6px -1px rgb(61 41 20 / 0.1);
+	--shadow-focus: 0 0 0 2px var(--cream), 0 0 0 4px var(--grove-500);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DARK MODE - Nature at Night
+   ═══════════════════════════════════════════════════════════════ */
+
+.dark {
+	/* Neutral: Cream inverted for dark mode */
+	--cream: #1a1915;
+	--cream-50: #1a1915;
+	--cream-100: #252320;
+	--cream-200: #32302b;
+	--cream-300: #43403a;
+	--cream-400: #5c584f;
+	--cream-500: #777267;
+
+	/* Neutral: Bark inverted for dark mode */
+	--bark: #f5f2ea;
+	--bark-50: #2a1b0d;
+	--bark-100: #3d2914;
+	--bark-200: #5a3f30;
+	--bark-300: #6f4d39;
+	--bark-400: #8a6347;
+	--bark-500: #a57c5a;
+	--bark-600: #b69575;
+	--bark-700: #ccb59c;
+	--bark-800: #e0d2c2;
+	--bark-900: #f0e9e1;
+	--bark-950: #f9f6f3;
+
+	/* Semantic Colors - Dark Mode */
+	--color-background: var(--cream);
+	--color-foreground: var(--bark);
+	--color-foreground-muted: rgba(245, 242, 234, 0.7);
+	--color-foreground-subtle: rgba(245, 242, 234, 0.5);
+	--color-foreground-faint: rgba(245, 242, 234, 0.4);
+
+	--color-border: var(--cream-300);
+	--color-border-subtle: var(--cream-200);
+	--color-divider: var(--cream-400);
+
+	--color-surface: rgba(37, 35, 32, 0.5);
+	--color-surface-elevated: var(--cream-100);
+
+	--color-accent-bg: var(--grove-950);
+	--color-accent-border: var(--grove-900);
+	--color-accent-text: var(--grove-200);
+	--color-accent-text-muted: var(--grove-400);
+	--color-accent-text-subtle: var(--grove-500);
+
+	/* Status Colors - Dark Mode */
+	--color-error: #f87171;
+	--color-error-bg: rgba(220, 38, 38, 0.15);
+	--color-error-border: rgba(220, 38, 38, 0.3);
+	--color-error-text: #fecaca;
+
+	/* Shadows - Dark Mode */
+	--shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.2);
+	--shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3);
+	--shadow-focus: 0 0 0 2px var(--cream), 0 0 0 4px var(--grove-500);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   FONTS
+   ═══════════════════════════════════════════════════════════════ */
+
 @font-face {
 	font-family: 'Lexend';
 	src: url('/fonts/Lexend-Regular.ttf') format('truetype');
@@ -10,32 +152,209 @@
 	font-display: swap;
 }
 
+/* ═══════════════════════════════════════════════════════════════
+   BASE STYLES
+   ═══════════════════════════════════════════════════════════════ */
+
 @layer base {
 	html {
 		font-family: 'Lexend', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+		transition: background-color 0.2s ease, color 0.2s ease;
 	}
 
 	body {
-		@apply bg-cream text-bark antialiased;
+		background-color: var(--color-background);
+		color: var(--color-foreground);
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
 	}
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   COMPONENT CLASSES
+   ═══════════════════════════════════════════════════════════════ */
 
 @layer components {
 	.btn-primary {
-		@apply bg-grove-600 hover:bg-grove-700 text-white font-sans font-medium
-			px-6 py-3 rounded-lg transition-colors duration-200
-			focus:outline-none focus:ring-2 focus:ring-grove-500 focus:ring-offset-2;
+		background-color: var(--color-primary);
+		color: var(--color-primary-foreground);
+		font-family: system-ui, -apple-system, sans-serif;
+		font-weight: 500;
+		padding: 0.75rem 1.5rem;
+		border-radius: 0.5rem;
+		transition: background-color 0.2s ease;
+	}
+
+	.btn-primary:hover {
+		background-color: var(--color-primary-hover);
+	}
+
+	.btn-primary:focus {
+		outline: none;
+		box-shadow: var(--shadow-focus);
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
 	}
 
 	.input-field {
-		@apply w-full px-4 py-3 rounded-lg border border-grove-200
-			focus:border-grove-500 focus:ring-2 focus:ring-grove-500/20
-			focus:outline-none transition-all duration-200
-			bg-white text-bark placeholder:text-bark/40;
+		width: 100%;
+		padding: 0.75rem 1rem;
+		border-radius: 0.5rem;
+		border: 1px solid var(--color-border);
+		background-color: var(--color-surface-elevated);
+		color: var(--color-foreground);
+		transition: border-color 0.2s ease, box-shadow 0.2s ease;
+	}
+
+	.input-field::placeholder {
+		color: var(--color-foreground-faint);
+	}
+
+	.input-field:focus {
+		outline: none;
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.15);
+	}
+
+	.card {
+		background-color: var(--color-surface-elevated);
+		border: 1px solid var(--color-border);
+		border-radius: 0.75rem;
 	}
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   UTILITIES
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Text color utilities using CSS variables */
+.text-foreground { color: var(--color-foreground); }
+.text-foreground-muted { color: var(--color-foreground-muted); }
+.text-foreground-subtle { color: var(--color-foreground-subtle); }
+.text-foreground-faint { color: var(--color-foreground-faint); }
+
+.text-primary { color: var(--color-primary); }
+.text-primary-hover { color: var(--color-primary-hover); }
+
+.text-accent { color: var(--color-accent-text); }
+.text-accent-muted { color: var(--color-accent-text-muted); }
+.text-accent-subtle { color: var(--color-accent-text-subtle); }
+
+.text-error { color: var(--color-error); }
+
+/* Background utilities */
+.bg-page { background-color: var(--color-background); }
+.bg-surface { background-color: var(--color-surface); }
+.bg-surface-elevated { background-color: var(--color-surface-elevated); }
+.bg-accent { background-color: var(--color-accent-bg); }
+.bg-error { background-color: var(--color-error-bg); }
+
+/* Border utilities */
+.border-default { border-color: var(--color-border); }
+.border-subtle { border-color: var(--color-border-subtle); }
+.border-divider { border-color: var(--color-divider); }
+.border-accent { border-color: var(--color-accent-border); }
+.border-error { border-color: var(--color-error-border); }
+
+/* Divider color for text elements like "·" separators */
+.text-divider { color: var(--color-divider); }
 
 /* Subtle leaf pattern background */
 .leaf-pattern {
 	background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M30 5c-5 10-15 15-25 15 10 5 15 15 15 25 5-10 15-15 25-15-10-5-15-15-15-25z' fill='%2322c55e' fill-opacity='0.03'/%3E%3C/svg%3E");
+}
+
+.dark .leaf-pattern {
+	background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M30 5c-5 10-15 15-25 15 10 5 15 15 15 25 5-10 15-15 25-15-10-5-15-15-15-25z' fill='%2322c55e' fill-opacity='0.06'/%3E%3C/svg%3E");
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PROSE STYLES - Legal Documents
+   ═══════════════════════════════════════════════════════════════ */
+
+.prose-legal {
+	font-family: system-ui, -apple-system, sans-serif;
+	color: var(--color-foreground-muted);
+	line-height: 1.75;
+}
+
+.prose-legal section {
+	margin-bottom: 2rem;
+}
+
+.prose-legal h2 {
+	font-family: 'Lexend', Georgia, serif;
+	font-size: 1.25rem;
+	color: var(--color-foreground);
+	margin-bottom: 1rem;
+}
+
+.prose-legal h3 {
+	font-family: 'Lexend', Georgia, serif;
+	font-size: 1.125rem;
+	color: var(--color-foreground-muted);
+	margin-bottom: 0.5rem;
+}
+
+.prose-legal p {
+	margin-bottom: 1rem;
+}
+
+.prose-legal ul {
+	list-style-type: disc;
+	list-style-position: inside;
+	margin-left: 1rem;
+	margin-bottom: 1rem;
+}
+
+.prose-legal ul li {
+	margin-bottom: 0.25rem;
+}
+
+.prose-legal a {
+	color: var(--color-accent-text-muted);
+	text-decoration: underline;
+	transition: color 0.2s ease;
+}
+
+.prose-legal a:hover {
+	color: var(--color-primary);
+}
+
+.prose-legal table {
+	width: 100%;
+	font-size: 0.875rem;
+	border-collapse: collapse;
+	margin: 1rem 0;
+}
+
+.prose-legal th,
+.prose-legal td {
+	padding: 0.5rem 0.75rem;
+	text-align: left;
+}
+
+.prose-legal thead tr {
+	border-bottom: 1px solid var(--color-border);
+}
+
+.prose-legal tbody tr {
+	border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.prose-legal .uppercase {
+	text-transform: uppercase;
+	font-size: 0.875rem;
+}
+
+.prose-legal section.pt-6 {
+	padding-top: 1.5rem;
+	border-top: 1px solid var(--color-border);
+}
+
+.prose-legal strong {
+	color: var(--color-foreground);
 }

--- a/landing/src/lib/components/EmailSignup.svelte
+++ b/landing/src/lib/components/EmailSignup.svelte
@@ -42,26 +42,26 @@
 
 {#if status === 'success'}
 	<div
-		class="bg-grove-50 border border-grove-200 rounded-lg px-6 py-4 text-center max-w-md animate-in"
+		class="bg-accent border border-accent rounded-lg px-6 py-4 text-center max-w-md animate-in"
 	>
-		<svg class="w-8 h-8 text-grove-600 mx-auto mb-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+		<svg class="w-8 h-8 text-accent-muted mx-auto mb-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 			<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" stroke-linecap="round" />
 			<polyline points="22 4 12 14.01 9 11.01" stroke-linecap="round" stroke-linejoin="round" />
 		</svg>
-		<p class="text-grove-800 font-sans font-medium">You're on the list!</p>
-		<p class="text-grove-600 text-sm font-sans mt-1">Check your inbox for a welcome note.</p>
-		<p class="text-grove-500 text-xs font-sans mt-2">We'll be in touch when Grove blooms.</p>
+		<p class="text-accent font-sans font-medium">You're on the list!</p>
+		<p class="text-accent-muted text-sm font-sans mt-1">Check your inbox for a welcome note.</p>
+		<p class="text-accent-subtle text-xs font-sans mt-2">We'll be in touch when Grove blooms.</p>
 	</div>
 {:else if status === 'already_signed_up'}
 	<div
-		class="bg-grove-50 border border-grove-200 rounded-lg px-6 py-4 text-center max-w-md animate-in"
+		class="bg-accent border border-accent rounded-lg px-6 py-4 text-center max-w-md animate-in"
 	>
-		<svg class="w-8 h-8 text-grove-600 mx-auto mb-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+		<svg class="w-8 h-8 text-accent-muted mx-auto mb-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 			<path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" stroke-linecap="round" stroke-linejoin="round" />
 		</svg>
-		<p class="text-grove-800 font-sans font-medium">You're already on the list!</p>
-		<p class="text-grove-600 text-sm font-sans mt-1">Thank you for being so excited.</p>
-		<p class="text-grove-500 text-xs font-sans mt-2">We'll be in touch when Grove blooms.</p>
+		<p class="text-accent font-sans font-medium">You're already on the list!</p>
+		<p class="text-accent-muted text-sm font-sans mt-1">Thank you for being so excited.</p>
+		<p class="text-accent-subtle text-xs font-sans mt-2">We'll be in touch when Grove blooms.</p>
 	</div>
 {:else}
 	<form onsubmit={handleSubmit} class="w-full max-w-md">
@@ -92,10 +92,10 @@
 		</div>
 
 		{#if status === 'error'}
-			<p class="text-red-600 text-sm mt-2 font-sans">{errorMessage}</p>
+			<p class="text-error text-sm mt-2 font-sans">{errorMessage}</p>
 		{/if}
 
-		<p class="text-bark/40 text-xs mt-3 text-center font-sans">
+		<p class="text-foreground-faint text-xs mt-3 text-center font-sans">
 			No spam, ever. Unsubscribe anytime.
 		</p>
 	</form>

--- a/landing/src/lib/components/Footer.svelte
+++ b/landing/src/lib/components/Footer.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import ThemeToggle from './ThemeToggle.svelte';
+
+	interface Props {
+		maxWidth?: 'narrow' | 'default' | 'wide';
+		showExternalLinks?: boolean;
+	}
+
+	let { maxWidth = 'default', showExternalLinks = false }: Props = $props();
+
+	const maxWidthClass = {
+		narrow: 'max-w-2xl',
+		default: 'max-w-3xl',
+		wide: 'max-w-4xl'
+	};
+</script>
+
+<footer class="py-8 border-t border-default">
+	<div class="{maxWidthClass[maxWidth]} mx-auto px-6">
+		<div class="flex flex-col items-center gap-4">
+			<!-- Navigation Links -->
+			<div class="flex items-center gap-4 text-sm font-sans text-foreground-subtle flex-wrap justify-center">
+				<a href="/" class="hover:text-accent-muted transition-colors">Home</a>
+				<span class="text-divider">·</span>
+				<a href="/vision" class="hover:text-accent-muted transition-colors">Vision</a>
+				<span class="text-divider">·</span>
+				<a href="/pricing" class="hover:text-accent-muted transition-colors">Pricing</a>
+				<span class="text-divider">·</span>
+				<a href="/legal" class="hover:text-accent-muted transition-colors">Legal</a>
+			</div>
+
+			{#if showExternalLinks}
+				<!-- External Links (for homepage) -->
+				<div class="flex items-center gap-4 text-sm font-sans text-foreground-subtle flex-wrap justify-center">
+					<a
+						href="https://example.grove.place"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="hover:text-accent-muted transition-colors"
+						title="See a live example site built with Grove"
+					>
+						Example Site
+					</a>
+					<span class="text-divider">·</span>
+					<a
+						href="https://autumnsgrove.com/blog"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="hover:text-accent-muted transition-colors"
+						title="Developer's blog and documentation"
+					>
+						Blog
+					</a>
+					<span class="text-divider">·</span>
+					<a
+						href="https://github.com/AutumnsGrove/GroveEngine"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="hover:text-accent-muted transition-colors flex items-center gap-1"
+						title="View the Grove Engine source code"
+					>
+						<svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+							<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+						</svg>
+						GitHub
+					</a>
+				</div>
+			{/if}
+
+			<!-- Theme Toggle -->
+			<div class="flex items-center gap-3">
+				<span class="text-xs text-foreground-faint font-sans">Theme</span>
+				<ThemeToggle />
+			</div>
+		</div>
+	</div>
+</footer>

--- a/landing/src/lib/components/Header.svelte
+++ b/landing/src/lib/components/Header.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+
+	// Determine current page for highlighting
+	let currentPath = $derived($page.url.pathname);
+
+	interface Props {
+		maxWidth?: 'narrow' | 'default' | 'wide';
+	}
+
+	let { maxWidth = 'default' }: Props = $props();
+
+	const maxWidthClass = {
+		narrow: 'max-w-2xl',
+		default: 'max-w-3xl',
+		wide: 'max-w-4xl'
+	};
+</script>
+
+<header class="py-6 px-6 border-b border-default">
+	<div class="{maxWidthClass[maxWidth]} mx-auto flex items-center justify-between">
+		<a href="/" class="text-xl font-serif text-foreground hover:text-accent-muted transition-colors">
+			Grove
+		</a>
+		<nav class="flex items-center gap-6 text-sm font-sans">
+			<a
+				href="/vision"
+				class="transition-colors {currentPath === '/vision' ? 'text-accent-muted' : 'text-foreground-subtle hover:text-accent-muted'}"
+			>
+				Vision
+			</a>
+			<a
+				href="/pricing"
+				class="transition-colors {currentPath === '/pricing' ? 'text-accent-muted' : 'text-foreground-subtle hover:text-accent-muted'}"
+			>
+				Pricing
+			</a>
+			<a
+				href="/legal"
+				class="transition-colors {currentPath.startsWith('/legal') ? 'text-accent-muted' : 'text-foreground-subtle hover:text-accent-muted'}"
+			>
+				Legal
+			</a>
+		</nav>
+	</div>
+</header>

--- a/landing/src/lib/components/LegalLayout.svelte
+++ b/landing/src/lib/components/LegalLayout.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import Header from './Header.svelte';
+	import Footer from './Footer.svelte';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		title: string;
+		effectiveDate?: string;
+		lastUpdated?: string;
+		children: Snippet;
+	}
+
+	let { title, effectiveDate, lastUpdated, children }: Props = $props();
+</script>
+
+<main class="min-h-screen flex flex-col">
+	<Header />
+
+	<!-- Content -->
+	<article class="flex-1 px-6 py-12">
+		<div class="max-w-3xl mx-auto">
+			<!-- Header -->
+			<header class="mb-8">
+				<p class="text-sm text-foreground-faint font-sans mb-2">
+					<a href="/legal" class="hover:text-accent-muted transition-colors">&larr; All Legal Documents</a>
+				</p>
+				<h1 class="text-3xl md:text-4xl font-serif text-foreground mb-2">{title}</h1>
+				{#if effectiveDate || lastUpdated}
+					<p class="text-foreground-faint font-sans text-sm">
+						{#if effectiveDate}Effective Date: {effectiveDate}{/if}
+						{#if effectiveDate && lastUpdated} · {/if}
+						{#if lastUpdated}Last Updated: {lastUpdated}{/if}
+					</p>
+				{/if}
+			</header>
+
+			<!-- Content -->
+			<div class="prose-legal">
+				{@render children()}
+			</div>
+		</div>
+	</article>
+
+	<Footer />
+</main>

--- a/landing/src/lib/components/ThemeToggle.svelte
+++ b/landing/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { theme } from '$lib/stores/theme';
+
+	let isDark = $derived($theme === 'dark');
+</script>
+
+<button
+	onclick={() => theme.toggle()}
+	class="p-2 rounded-lg text-foreground-subtle hover:text-accent-muted hover:bg-surface transition-colors"
+	aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+	title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+>
+	{#if isDark}
+		<!-- Sun icon - shown in dark mode -->
+		<svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<circle cx="12" cy="12" r="5" />
+			<line x1="12" y1="1" x2="12" y2="3" />
+			<line x1="12" y1="21" x2="12" y2="23" />
+			<line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+			<line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+			<line x1="1" y1="12" x2="3" y2="12" />
+			<line x1="21" y1="12" x2="23" y2="12" />
+			<line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+			<line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+		</svg>
+	{:else}
+		<!-- Moon icon - shown in light mode -->
+		<svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+		</svg>
+	{/if}
+</button>

--- a/landing/src/lib/stores/theme.ts
+++ b/landing/src/lib/stores/theme.ts
@@ -1,0 +1,63 @@
+/**
+ * Theme Store for Grove Landing
+ * Manages light/dark theme preferences
+ * Defaults to dark on first visit, remembers user choice thereafter
+ */
+
+import { writable, get } from 'svelte/store';
+import { browser } from '$app/environment';
+
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'grove-theme';
+
+function getInitialTheme(): Theme {
+	if (!browser) return 'dark';
+
+	// Check if user has a stored preference
+	const stored = localStorage.getItem(STORAGE_KEY);
+	if (stored === 'light' || stored === 'dark') {
+		return stored;
+	}
+
+	// First visit: default to dark
+	return 'dark';
+}
+
+function createThemeStore() {
+	const theme = writable<Theme>(getInitialTheme());
+
+	// Apply theme to document
+	function applyTheme(t: Theme) {
+		if (browser) {
+			document.documentElement.classList.toggle('dark', t === 'dark');
+		}
+	}
+
+	// Apply initial theme immediately
+	if (browser) {
+		applyTheme(get(theme));
+
+		// Subscribe to changes
+		theme.subscribe((t) => {
+			applyTheme(t);
+			localStorage.setItem(STORAGE_KEY, t);
+		});
+	}
+
+	function toggle() {
+		theme.update((current) => (current === 'dark' ? 'light' : 'dark'));
+	}
+
+	function setTheme(newTheme: Theme) {
+		theme.set(newTheme);
+	}
+
+	return {
+		subscribe: theme.subscribe,
+		toggle,
+		setTheme
+	};
+}
+
+export const theme = createThemeStore();

--- a/landing/src/routes/+layout.svelte
+++ b/landing/src/routes/+layout.svelte
@@ -1,7 +1,16 @@
-<script>
+<script lang="ts">
 	import '../app.css';
+	// Import theme store to initialize it on page load
+	import { theme } from '$lib/stores/theme';
 
 	let { children } = $props();
+
+	// Access the store to ensure it initializes
+	$effect(() => {
+		// Theme store auto-applies the dark class on initialization
+		// This effect ensures the store is subscribed to
+		const _ = $theme;
+	});
 </script>
 
 <div class="min-h-screen leaf-pattern">

--- a/landing/src/routes/+page.svelte
+++ b/landing/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import EmailSignup from '$lib/components/EmailSignup.svelte';
+	import Footer from '$lib/components/Footer.svelte';
 	import { page } from '$app/stores';
 
 	// Get error from URL if present
@@ -45,14 +46,14 @@
 <main class="min-h-screen flex flex-col items-center justify-center px-6 py-12">
 	<!-- Error Banner -->
 	{#if error}
-		<div class="mb-8 w-full max-w-md p-4 bg-red-50 border border-red-200 rounded-lg">
+		<div class="mb-8 w-full max-w-md p-4 bg-error border border-error rounded-lg">
 			<div class="flex items-start gap-3">
-				<svg class="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
+				<svg class="w-5 h-5 text-error flex-shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
 					<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
 				</svg>
 				<div>
-					<p class="text-red-800 font-sans font-medium">Sign in failed</p>
-					<p class="text-red-600 font-sans text-sm mt-1">{error}</p>
+					<p class="text-error font-sans font-medium">Sign in failed</p>
+					<p class="text-error text-sm mt-1">{error}</p>
 				</div>
 			</div>
 		</div>
@@ -61,7 +62,7 @@
 	<!-- Logo/Brand -->
 	<div class="mb-8">
 		<svg
-			class="w-20 h-20 text-grove-600"
+			class="w-20 h-20 text-accent-muted"
 			viewBox="0 0 100 100"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
@@ -87,27 +88,27 @@
 	</div>
 
 	<!-- Title -->
-	<h1 class="text-4xl md:text-5xl font-serif text-bark mb-3 text-center">Grove</h1>
+	<h1 class="text-4xl md:text-5xl font-serif text-foreground mb-3 text-center">Grove</h1>
 
 	<!-- Tagline -->
-	<p class="text-xl md:text-2xl text-bark/70 font-serif italic mb-12 text-center">
+	<p class="text-xl md:text-2xl text-foreground-muted font-serif italic mb-12 text-center">
 		a place to Be
 	</p>
 
 	<!-- Decorative divider -->
 	<div class="flex items-center gap-4 mb-12">
-		<div class="w-12 h-px bg-grove-300"></div>
-		<svg class="w-5 h-5 text-grove-400" viewBox="0 0 20 20" fill="currentColor">
+		<div class="w-12 h-px bg-divider"></div>
+		<svg class="w-5 h-5 text-accent-subtle" viewBox="0 0 20 20" fill="currentColor">
 			<path
 				d="M10 2C8 6 5 8 2 8c3 2 5 5 5 10 2-4 5-6 8-6-3-2-5-5-5-10z"
 				fill-opacity="0.6"
 			/>
 		</svg>
-		<div class="w-12 h-px bg-grove-300"></div>
+		<div class="w-12 h-px bg-divider"></div>
 	</div>
 
 	<!-- Coming soon text -->
-	<p class="text-bark/60 text-center max-w-md mb-8 font-sans">
+	<p class="text-foreground-subtle text-center max-w-md mb-8 font-sans">
 		Something is growing here. Leave your email to be the first to know when we bloom.
 	</p>
 
@@ -116,26 +117,26 @@
 
 	<!-- Decorative divider -->
 	<div class="flex items-center gap-4 mt-16 mb-12">
-		<div class="w-12 h-px bg-grove-300"></div>
-		<svg class="w-5 h-5 text-grove-400" viewBox="0 0 20 20" fill="currentColor">
+		<div class="w-12 h-px bg-divider"></div>
+		<svg class="w-5 h-5 text-accent-subtle" viewBox="0 0 20 20" fill="currentColor">
 			<path
 				d="M10 2C8 6 5 8 2 8c3 2 5 5 5 10 2-4 5-6 8-6-3-2-5-5-5-10z"
 				fill-opacity="0.6"
 			/>
 		</svg>
-		<div class="w-12 h-px bg-grove-300"></div>
+		<div class="w-12 h-px bg-divider"></div>
 	</div>
 
 	<!-- How It Works - Slide Preview -->
 	<section class="w-full max-w-lg">
-		<h2 class="text-lg font-serif text-bark/70 text-center mb-8">How It Works</h2>
+		<h2 class="text-lg font-serif text-foreground-muted text-center mb-8">How It Works</h2>
 
 		<!-- Slide Container -->
-		<div class="relative bg-white/50 rounded-2xl border border-grove-200 p-8 min-h-[200px]">
+		<div class="relative bg-surface rounded-2xl border border-default p-8 min-h-[200px]">
 			<!-- Slide Content -->
 			<div class="flex flex-col items-center text-center">
 				<!-- Icon -->
-				<div class="w-16 h-16 mb-4 text-grove-600">
+				<div class="w-16 h-16 mb-4 text-accent-muted">
 					{#if slides[currentSlide].icon === 'signup'}
 						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-full h-full">
 							<path stroke-linecap="round" stroke-linejoin="round" d="M19 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zM4 19.235v-.11a6.375 6.375 0 0112.75 0v.109A12.318 12.318 0 0110.374 21c-2.331 0-4.512-.645-6.374-1.766z" />
@@ -152,19 +153,19 @@
 				</div>
 
 				<!-- Step number -->
-				<span class="text-sm font-sans text-grove-500 mb-2">Step {currentSlide + 1}</span>
+				<span class="text-sm font-sans text-accent-subtle mb-2">Step {currentSlide + 1}</span>
 
 				<!-- Title -->
-				<h3 class="text-xl font-serif text-bark mb-2">{slides[currentSlide].title}</h3>
+				<h3 class="text-xl font-serif text-foreground mb-2">{slides[currentSlide].title}</h3>
 
 				<!-- Description -->
-				<p class="text-bark/60 font-sans">{slides[currentSlide].description}</p>
+				<p class="text-foreground-subtle font-sans">{slides[currentSlide].description}</p>
 			</div>
 
 			<!-- Navigation Arrows -->
 			<button
 				onclick={prevSlide}
-				class="absolute left-2 top-1/2 -translate-y-1/2 p-2 text-grove-400 hover:text-grove-600 transition-colors"
+				class="absolute left-2 top-1/2 -translate-y-1/2 p-2 text-accent-subtle hover:text-accent-muted transition-colors"
 				aria-label="Previous slide"
 			>
 				<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
@@ -173,7 +174,7 @@
 			</button>
 			<button
 				onclick={nextSlide}
-				class="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-grove-400 hover:text-grove-600 transition-colors"
+				class="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-accent-subtle hover:text-accent-muted transition-colors"
 				aria-label="Next slide"
 			>
 				<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
@@ -187,7 +188,7 @@
 			{#each slides as _, i}
 				<button
 					onclick={() => goToSlide(i)}
-					class="w-2 h-2 rounded-full transition-colors {currentSlide === i ? 'bg-grove-600' : 'bg-grove-300 hover:bg-grove-400'}"
+					class="w-2 h-2 rounded-full transition-colors {currentSlide === i ? 'bg-accent-muted' : 'bg-divider hover:bg-accent-subtle'}"
 					aria-label="Go to slide {i + 1}"
 				></button>
 			{/each}
@@ -196,10 +197,10 @@
 
 	<!-- Sign In Section -->
 	<div class="mt-16 text-center">
-		<p class="text-bark/50 text-sm font-sans mb-3">Already have an account?</p>
+		<p class="text-foreground-faint text-sm font-sans mb-3">Already have an account?</p>
 		<a
 			href="/auth/login"
-			class="inline-flex items-center gap-2 px-6 py-2.5 bg-grove-600 hover:bg-grove-700 text-white font-sans rounded-lg transition-colors"
+			class="btn-primary inline-flex items-center gap-2"
 		>
 			<svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
 				<path fill-rule="evenodd" d="M3 4.25A2.25 2.25 0 015.25 2h5.5A2.25 2.25 0 0113 4.25v2a.75.75 0 01-1.5 0v-2a.75.75 0 00-.75-.75h-5.5a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h5.5a.75.75 0 00.75-.75v-2a.75.75 0 011.5 0v2A2.25 2.25 0 0110.75 18h-5.5A2.25 2.25 0 013 15.75V4.25z" clip-rule="evenodd" />
@@ -208,70 +209,12 @@
 			Sign In
 		</a>
 	</div>
-
-	<!-- Footer -->
-	<footer class="mt-12 mb-8 flex flex-col items-center gap-6">
-		<!-- Links -->
-		<div class="flex items-center gap-6 text-sm font-sans flex-wrap justify-center">
-			<a
-				href="https://example.grove.place"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-bark/50 hover:text-grove-600 transition-colors"
-				title="See a live example site built with Grove"
-			>
-				Example Site
-			</a>
-			<span class="text-grove-300">·</span>
-			<a
-				href="https://autumnsgrove.com/blog"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-bark/50 hover:text-grove-600 transition-colors"
-				title="Developer's blog and documentation"
-			>
-				Blog
-			</a>
-			<span class="text-grove-300">·</span>
-			<a
-				href="https://github.com/AutumnsGrove/GroveEngine"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-bark/50 hover:text-grove-600 transition-colors flex items-center gap-1"
-				title="View the Grove Engine source code"
-			>
-				<svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-					<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-				</svg>
-				Engine
-			</a>
-			<span class="text-grove-300">·</span>
-			<a
-				href="https://github.com/AutumnsGrove/AutumnsGrove"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-bark/50 hover:text-grove-600 transition-colors flex items-center gap-1"
-				title="View the main website source code"
-			>
-				<svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-					<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-				</svg>
-				Website
-			</a>
-		</div>
-
-		<!-- Footer flourish -->
-		<div class="flex gap-2">
-			{#each [1, 2, 3] as i}
-				<svg
-					class="w-3 h-3 text-grove-300"
-					viewBox="0 0 20 20"
-					fill="currentColor"
-					style="opacity: {0.3 + i * 0.2}"
-				>
-					<circle cx="10" cy="10" r="4" />
-				</svg>
-			{/each}
-		</div>
-	</footer>
 </main>
+
+<!-- Footer with theme toggle -->
+<Footer showExternalLinks={true} />
+
+<style>
+	/* Background color utilities that need to be scoped */
+	.bg-divider { background-color: var(--color-divider); }
+</style>

--- a/landing/src/routes/legal/+page.svelte
+++ b/landing/src/routes/legal/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Header from '$lib/components/Header.svelte';
+	import Footer from '$lib/components/Footer.svelte';
 </script>
 
 <svelte:head>
@@ -7,87 +9,78 @@
 </svelte:head>
 
 <main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-3xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/vision" class="hover:text-grove-600 transition-colors">Vision</a>
-				<a href="/pricing" class="hover:text-grove-600 transition-colors">Pricing</a>
-			</nav>
-		</div>
-	</header>
+	<Header />
 
 	<!-- Content -->
 	<article class="flex-1 px-6 py-12">
 		<div class="max-w-3xl mx-auto">
 			<!-- Header -->
 			<header class="mb-12 text-center">
-				<h1 class="text-4xl md:text-5xl font-serif text-bark mb-4">Legal</h1>
-				<p class="text-lg text-bark/60 font-sans">
+				<h1 class="text-4xl md:text-5xl font-serif text-foreground mb-4">Legal</h1>
+				<p class="text-lg text-foreground-subtle font-sans">
 					The policies that guide how we operate.
 				</p>
 				<div class="flex items-center justify-center gap-4 mt-6">
-					<div class="w-12 h-px bg-grove-300"></div>
-					<svg class="w-4 h-4 text-grove-400" viewBox="0 0 20 20" fill="currentColor">
+					<div class="w-12 h-px bg-divider"></div>
+					<svg class="w-4 h-4 text-accent-subtle" viewBox="0 0 20 20" fill="currentColor">
 						<circle cx="10" cy="10" r="4" />
 					</svg>
-					<div class="w-12 h-px bg-grove-300"></div>
+					<div class="w-12 h-px bg-divider"></div>
 				</div>
 			</header>
 
 			<!-- Policy Links -->
 			<div class="grid gap-4">
-				<a href="/legal/terms" class="card p-6 hover:border-grove-400 transition-colors group">
-					<h2 class="text-lg font-serif text-bark group-hover:text-grove-700 transition-colors mb-2">
+				<a href="/legal/terms" class="card p-6 hover:border-accent transition-colors group">
+					<h2 class="text-lg font-serif text-foreground group-hover:text-accent-muted transition-colors mb-2">
 						Terms of Service
 					</h2>
-					<p class="text-bark/60 font-sans text-sm">
+					<p class="text-foreground-subtle font-sans text-sm">
 						The agreement between you and Grove for using the platform.
 					</p>
 				</a>
 
-				<a href="/legal/privacy" class="card p-6 hover:border-grove-400 transition-colors group">
-					<h2 class="text-lg font-serif text-bark group-hover:text-grove-700 transition-colors mb-2">
+				<a href="/legal/privacy" class="card p-6 hover:border-accent transition-colors group">
+					<h2 class="text-lg font-serif text-foreground group-hover:text-accent-muted transition-colors mb-2">
 						Privacy Policy
 					</h2>
-					<p class="text-bark/60 font-sans text-sm">
+					<p class="text-foreground-subtle font-sans text-sm">
 						How we collect, use, and protect your information. Spoiler: we don't sell your data.
 					</p>
 				</a>
 
-				<a href="/legal/acceptable-use" class="card p-6 hover:border-grove-400 transition-colors group">
-					<h2 class="text-lg font-serif text-bark group-hover:text-grove-700 transition-colors mb-2">
+				<a href="/legal/acceptable-use" class="card p-6 hover:border-accent transition-colors group">
+					<h2 class="text-lg font-serif text-foreground group-hover:text-accent-muted transition-colors mb-2">
 						Acceptable Use Policy
 					</h2>
-					<p class="text-bark/60 font-sans text-sm">
+					<p class="text-foreground-subtle font-sans text-sm">
 						Community guidelines and content standards for a welcoming space.
 					</p>
 				</a>
 
-				<a href="/legal/dmca" class="card p-6 hover:border-grove-400 transition-colors group">
-					<h2 class="text-lg font-serif text-bark group-hover:text-grove-700 transition-colors mb-2">
+				<a href="/legal/dmca" class="card p-6 hover:border-accent transition-colors group">
+					<h2 class="text-lg font-serif text-foreground group-hover:text-accent-muted transition-colors mb-2">
 						DMCA Policy
 					</h2>
-					<p class="text-bark/60 font-sans text-sm">
+					<p class="text-foreground-subtle font-sans text-sm">
 						How we handle copyright claims and takedown requests.
 					</p>
 				</a>
 
-				<a href="/legal/refund" class="card p-6 hover:border-grove-400 transition-colors group">
-					<h2 class="text-lg font-serif text-bark group-hover:text-grove-700 transition-colors mb-2">
+				<a href="/legal/refund" class="card p-6 hover:border-accent transition-colors group">
+					<h2 class="text-lg font-serif text-foreground group-hover:text-accent-muted transition-colors mb-2">
 						Refund & Cancellation Policy
 					</h2>
-					<p class="text-bark/60 font-sans text-sm">
+					<p class="text-foreground-subtle font-sans text-sm">
 						How refunds and cancellations work. No hoops, no hassle.
 					</p>
 				</a>
 
-				<a href="/legal/data-portability" class="card p-6 hover:border-grove-400 transition-colors group">
-					<h2 class="text-lg font-serif text-bark group-hover:text-grove-700 transition-colors mb-2">
+				<a href="/legal/data-portability" class="card p-6 hover:border-accent transition-colors group">
+					<h2 class="text-lg font-serif text-foreground group-hover:text-accent-muted transition-colors mb-2">
 						Data Portability & Separation
 					</h2>
-					<p class="text-bark/60 font-sans text-sm">
+					<p class="text-foreground-subtle font-sans text-sm">
 						Your content is yours. Here's exactly what happens when you leave.
 					</p>
 				</a>
@@ -95,11 +88,11 @@
 
 			<!-- Contact -->
 			<div class="mt-12 text-center">
-				<p class="text-bark/60 font-sans text-sm mb-2">
+				<p class="text-foreground-subtle font-sans text-sm mb-2">
 					Questions about our policies?
 				</p>
-				<p class="text-bark font-sans">
-					<a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">
+				<p class="font-sans">
+					<a href="mailto:autumn@grove.place" class="text-accent-muted hover:text-primary underline">
 						autumn@grove.place
 					</a>
 				</p>
@@ -107,16 +100,9 @@
 		</div>
 	</article>
 
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-3xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/vision" class="hover:text-grove-600 transition-colors">Vision</a>
-				<span class="text-grove-300">·</span>
-				<a href="/pricing" class="hover:text-grove-600 transition-colors">Pricing</a>
-			</div>
-		</div>
-	</footer>
+	<Footer />
 </main>
+
+<style>
+	.bg-divider { background-color: var(--color-divider); }
+</style>

--- a/landing/src/routes/legal/acceptable-use/+page.svelte
+++ b/landing/src/routes/legal/acceptable-use/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import LegalLayout from '$lib/components/LegalLayout.svelte';
 </script>
 
 <svelte:head>
@@ -6,252 +7,212 @@
 	<meta name="description" content="Community guidelines and content standards for Grove. A welcoming space for authentic self-expression." />
 </svelte:head>
 
-<main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-3xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</nav>
+<LegalLayout title="Acceptable Use Policy" effectiveDate="December 10, 2025" lastUpdated="December 10, 2025">
+	<!-- Community Standard -->
+	<div class="card p-6 mb-8 bg-accent border-accent">
+		<h2>Community Standard</h2>
+		<p class="mb-4">
+			Grove is a space for authentic self-expression. We ask that you:
+		</p>
+		<ul class="space-y-1 ml-4">
+			<li>Create content that contributes positively to your corner of the internet</li>
+			<li>Respect others, even when you disagree</li>
+			<li>Remember there's a real person on the other side of every screen</li>
+		</ul>
+		<p class="mt-4">
+			Content that makes others feel unwelcome, unsafe, or targeted based on who they are has no place here.
+		</p>
+	</div>
+
+	<section>
+		<h2>1. Prohibited Content</h2>
+		<p>The following content is <strong>not allowed</strong> on Grove under any circumstances:</p>
+
+		<h3>1.1 Illegal Content</h3>
+		<ul class="space-y-1 ml-4">
+			<li>Child sexual abuse material (CSAM)</li>
+			<li>Content that promotes terrorism or violent extremism</li>
+			<li>Content that facilitates illegal activities</li>
+		</ul>
+
+		<h3>1.2 Harassment and Threats</h3>
+		<ul class="space-y-1 ml-4">
+			<li>Targeted harassment of individuals</li>
+			<li>Doxxing (publishing private information without consent)</li>
+			<li>Threats of violence or harm</li>
+			<li>Stalking or intimidation</li>
+		</ul>
+
+		<h3>1.3 Hate Speech</h3>
+		<p>Content that attacks, demeans, or incites violence against individuals or groups based on race, ethnicity, national origin, religion, gender, gender identity, sexual orientation, disability, age, or any other protected characteristic.</p>
+
+		<h3>1.4 Spam and Malicious Content</h3>
+		<ul class="space-y-1 ml-4">
+			<li>Spam, including repetitive or unsolicited promotional content</li>
+			<li>Malware, viruses, or harmful code</li>
+			<li>Phishing attempts or deceptive practices</li>
+		</ul>
+
+		<h3>1.5 Impersonation and Fraud</h3>
+		<ul class="space-y-1 ml-4">
+			<li>Impersonating another person or organization</li>
+			<li>Creating fake accounts or identities</li>
+			<li>Fraudulent schemes or scams</li>
+		</ul>
+
+		<h3>1.6 Explicit Sexual Content</h3>
+		<ul class="space-y-1 ml-4">
+			<li>Pornography or sexually explicit material</li>
+			<li>Non-consensual intimate imagery</li>
+		</ul>
+		<p class="mt-2"><em>Note: Artistic nudity is permitted with appropriate content warnings.</em></p>
+	</section>
+
+	<section>
+		<h2>2. Content Requiring Warnings</h2>
+		<p>The following content is <strong>allowed</strong> but must include appropriate content warnings:</p>
+		<ul class="space-y-1 ml-4">
+			<li><strong>Artistic Nudity:</strong> Fine art, photography, or illustrations containing nudity (images will have auto-blur applied)</li>
+			<li><strong>Mature Written Content:</strong> Content with mature themes (violence, adult situations, etc.)</li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>3. Commercial Content</h2>
+		<p>Commercial promotion is allowed with restrictions:</p>
+		<ul class="space-y-1 ml-4">
+			<li><strong>Frequency:</strong> Maximum one promotional post per 7 days</li>
+			<li><strong>Location:</strong> Blog posts only — promotional content is not allowed on Meadow</li>
+			<li><strong>Disclosure:</strong> Affiliate links and sponsored content must be clearly disclosed</li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>4. AI-Generated Content</h2>
+		<p><strong>Prohibited:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>AI-generated content presented as purely human-created (deceptive use)</li>
+			<li>Deepfakes or harmful synthetic media</li>
+			<li>AI content used to impersonate real people</li>
+		</ul>
+		<p class="mt-4"><strong>Allowed with Labeling:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>AI-assisted writing with clear disclosure</li>
+			<li>AI-generated images clearly labeled as AI-created</li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>5. Copyright</h2>
+		<ul class="space-y-1 ml-4">
+			<li>Only post content you have the right to share</li>
+			<li>Properly attribute content created by others</li>
+			<li>Respect licenses and terms of use</li>
+		</ul>
+		<p class="mt-2">See our <a href="/legal/dmca">DMCA Policy</a> for copyright claim procedures.</p>
+	</section>
+
+	<section>
+		<h2>6. Enforcement</h2>
+		<p><strong>For Account Violations:</strong></p>
+		<div class="overflow-x-auto my-4">
+			<table>
+				<thead>
+					<tr>
+						<th>Step</th>
+						<th>Action</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>1st violation</td>
+						<td>Warning</td>
+					</tr>
+					<tr>
+						<td>2nd violation</td>
+						<td>Warning</td>
+					</tr>
+					<tr>
+						<td>3rd violation</td>
+						<td>1-week account suspension</td>
+					</tr>
+					<tr>
+						<td>4th violation</td>
+						<td>Account termination</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</header>
+		<p>We reserve the right to immediately suspend or terminate accounts for severe violations (illegal content, threats of violence, CSAM, doxxing).</p>
+	</section>
 
-	<!-- Content -->
-	<article class="flex-1 px-6 py-12">
-		<div class="max-w-3xl mx-auto">
-			<!-- Header -->
-			<header class="mb-8">
-				<p class="text-sm text-bark/50 font-sans mb-2">
-					<a href="/legal" class="hover:text-grove-600 transition-colors">&larr; All Legal Documents</a>
-				</p>
-				<h1 class="text-3xl md:text-4xl font-serif text-bark mb-2">Acceptable Use Policy</h1>
-				<p class="text-bark/50 font-sans text-sm">
-					Effective Date: December 10, 2025 · Last Updated: December 10, 2025
-				</p>
-			</header>
+	<section>
+		<h2>7. Reporting Violations</h2>
+		<p>If you see content that violates this policy, please report it by emailing <a href="mailto:autumn@grove.place">autumn@grove.place</a> with:</p>
+		<ul class="space-y-1 ml-4">
+			<li>A link to the content</li>
+			<li>The specific rule you believe was violated</li>
+			<li>Any additional context</li>
+		</ul>
+		<p class="mt-2">We review all reports and take appropriate action. We do not disclose the identity of reporters.</p>
+	</section>
 
-			<!-- Community Standard -->
-			<div class="card p-6 mb-8 bg-grove-50 border-grove-200">
-				<h2 class="text-lg font-serif text-grove-700 mb-2">Community Standard</h2>
-				<p class="text-bark/70 font-sans mb-4">
-					Grove is a space for authentic self-expression. We ask that you:
-				</p>
-				<ul class="list-disc list-inside space-y-1 ml-4 text-bark/70 font-sans">
-					<li>Create content that contributes positively to your corner of the internet</li>
-					<li>Respect others, even when you disagree</li>
-					<li>Remember there's a real person on the other side of every screen</li>
-				</ul>
-				<p class="text-bark/80 font-sans mt-4 font-medium">
-					Content that makes others feel unwelcome, unsafe, or targeted based on who they are has no place here.
-				</p>
-			</div>
-
-			<!-- Content -->
-			<div class="prose prose-bark max-w-none font-sans text-bark/80 leading-relaxed space-y-8">
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">1. Prohibited Content</h2>
-					<p>The following content is <strong>not allowed</strong> on Grove under any circumstances:</p>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.1 Illegal Content</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Child sexual abuse material (CSAM)</li>
-						<li>Content that promotes terrorism or violent extremism</li>
-						<li>Content that facilitates illegal activities</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.2 Harassment and Threats</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Targeted harassment of individuals</li>
-						<li>Doxxing (publishing private information without consent)</li>
-						<li>Threats of violence or harm</li>
-						<li>Stalking or intimidation</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.3 Hate Speech</h3>
-					<p>Content that attacks, demeans, or incites violence against individuals or groups based on race, ethnicity, national origin, religion, gender, gender identity, sexual orientation, disability, age, or any other protected characteristic.</p>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.4 Spam and Malicious Content</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Spam, including repetitive or unsolicited promotional content</li>
-						<li>Malware, viruses, or harmful code</li>
-						<li>Phishing attempts or deceptive practices</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.5 Impersonation and Fraud</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Impersonating another person or organization</li>
-						<li>Creating fake accounts or identities</li>
-						<li>Fraudulent schemes or scams</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.6 Explicit Sexual Content</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Pornography or sexually explicit material</li>
-						<li>Non-consensual intimate imagery</li>
-					</ul>
-					<p class="mt-2 text-sm italic">Note: Artistic nudity is permitted with appropriate content warnings.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">2. Content Requiring Warnings</h2>
-					<p>The following content is <strong>allowed</strong> but must include appropriate content warnings:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li><strong>Artistic Nudity:</strong> Fine art, photography, or illustrations containing nudity (images will have auto-blur applied)</li>
-						<li><strong>Mature Written Content:</strong> Content with mature themes (violence, adult situations, etc.)</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">3. Commercial Content</h2>
-					<p>Commercial promotion is allowed with restrictions:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li><strong>Frequency:</strong> Maximum one promotional post per 7 days</li>
-						<li><strong>Location:</strong> Blog posts only — promotional content is not allowed on Meadow</li>
-						<li><strong>Disclosure:</strong> Affiliate links and sponsored content must be clearly disclosed</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">4. AI-Generated Content</h2>
-					<p><strong>Prohibited:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>AI-generated content presented as purely human-created (deceptive use)</li>
-						<li>Deepfakes or harmful synthetic media</li>
-						<li>AI content used to impersonate real people</li>
-					</ul>
-					<p class="mt-4"><strong>Allowed with Labeling:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>AI-assisted writing with clear disclosure</li>
-						<li>AI-generated images clearly labeled as AI-created</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">5. Copyright</h2>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Only post content you have the right to share</li>
-						<li>Properly attribute content created by others</li>
-						<li>Respect licenses and terms of use</li>
-					</ul>
-					<p class="mt-2">See our <a href="/legal/dmca" class="text-grove-600 hover:text-grove-700 underline">DMCA Policy</a> for copyright claim procedures.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">6. Enforcement</h2>
-					<p><strong>For Account Violations:</strong></p>
-					<div class="overflow-x-auto my-4">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Step</th>
-									<th class="py-2 px-3 text-left">Action</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">1st violation</td>
-									<td class="py-2 px-3">Warning</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">2nd violation</td>
-									<td class="py-2 px-3">Warning</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">3rd violation</td>
-									<td class="py-2 px-3">1-week account suspension</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">4th violation</td>
-									<td class="py-2 px-3">Account termination</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-					<p>We reserve the right to immediately suspend or terminate accounts for severe violations (illegal content, threats of violence, CSAM, doxxing).</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">7. Reporting Violations</h2>
-					<p>If you see content that violates this policy, please report it by emailing <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a> with:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>A link to the content</li>
-						<li>The specific rule you believe was violated</li>
-						<li>Any additional context</li>
-					</ul>
-					<p class="mt-2">We review all reports and take appropriate action. We do not disclose the identity of reporters.</p>
-				</section>
-
-				<!-- Summary Table -->
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">8. Summary</h2>
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Content Type</th>
-									<th class="py-2 px-3 text-center">Allowed?</th>
-									<th class="py-2 px-3 text-left">Notes</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Original blog posts</td>
-									<td class="py-2 px-3 text-center text-grove-600">Yes</td>
-									<td class="py-2 px-3"></td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Artistic nudity</td>
-									<td class="py-2 px-3 text-center text-grove-600">Yes</td>
-									<td class="py-2 px-3">Content warning required</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Commercial promotion</td>
-									<td class="py-2 px-3 text-center text-grove-600">Yes</td>
-									<td class="py-2 px-3">1x per 7 days, blog only</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Hate speech</td>
-									<td class="py-2 px-3 text-center text-red-600">No</td>
-									<td class="py-2 px-3"></td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Harassment/doxxing</td>
-									<td class="py-2 px-3 text-center text-red-600">No</td>
-									<td class="py-2 px-3"></td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Pornography</td>
-									<td class="py-2 px-3 text-center text-red-600">No</td>
-									<td class="py-2 px-3"></td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Unlabeled AI content</td>
-									<td class="py-2 px-3 text-center text-red-600">No</td>
-									<td class="py-2 px-3">Labeled is allowed</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</section>
-
-				<section class="pt-6 border-t border-grove-200">
-					<p class="italic text-bark/60">
-						Grove is meant to be a welcoming space. These rules exist to keep it that way. Thank you for being part of our community.
-					</p>
-				</section>
-			</div>
+	<!-- Summary Table -->
+	<section>
+		<h2>8. Summary</h2>
+		<div class="overflow-x-auto">
+			<table>
+				<thead>
+					<tr>
+						<th>Content Type</th>
+						<th>Allowed?</th>
+						<th>Notes</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Original blog posts</td>
+						<td>Yes</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Artistic nudity</td>
+						<td>Yes</td>
+						<td>Content warning required</td>
+					</tr>
+					<tr>
+						<td>Commercial promotion</td>
+						<td>Yes</td>
+						<td>1x per 7 days, blog only</td>
+					</tr>
+					<tr>
+						<td>Hate speech</td>
+						<td>No</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Harassment/doxxing</td>
+						<td>No</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Pornography</td>
+						<td>No</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Unlabeled AI content</td>
+						<td>No</td>
+						<td>Labeled is allowed</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</article>
+	</section>
 
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-3xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</div>
-		</div>
-	</footer>
-</main>
+	<section class="pt-6">
+		<p><em>
+			Grove is meant to be a welcoming space. These rules exist to keep it that way. Thank you for being part of our community.
+		</em></p>
+	</section>
+</LegalLayout>

--- a/landing/src/routes/legal/data-portability/+page.svelte
+++ b/landing/src/routes/legal/data-portability/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import LegalLayout from '$lib/components/LegalLayout.svelte';
 </script>
 
 <svelte:head>
@@ -6,227 +7,187 @@
 	<meta name="description" content="Your content is yours. Here's exactly what happens when you leave Grove." />
 </svelte:head>
 
-<main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-3xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</nav>
+<LegalLayout title="Data Portability & Account Separation" effectiveDate="December 2025">
+	<!-- Promise -->
+	<div class="card p-6 mb-8 bg-accent border-accent">
+		<h2>Our Promise</h2>
+		<p>
+			Your content is yours. Your domain is yours. Grove will never hold your data or domain hostage.
+		</p>
+	</div>
+
+	<section>
+		<h2>1. Data Export</h2>
+
+		<h3>What You Receive</h3>
+		<p>When you cancel your subscription (or anytime you request it), you receive a complete export package:</p>
+
+		<p class="mt-4"><strong>Blog Content:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>All blog posts in Markdown format</li>
+			<li>Original images and media files</li>
+			<li>Post metadata (publish dates, tags, status)</li>
+			<li>Site configuration and settings</li>
+		</ul>
+
+		<div class="card p-4 mt-4 bg-accent border-accent">
+			<p class="font-mono text-sm">
+				grove-export-username-YYYY-MM-DD.zip<br/>
+				├── posts/<br/>
+				│&nbsp;&nbsp;&nbsp;├── 2025-01-15-my-first-post.md<br/>
+				│&nbsp;&nbsp;&nbsp;└── ...<br/>
+				├── media/<br/>
+				│&nbsp;&nbsp;&nbsp;├── images/<br/>
+				│&nbsp;&nbsp;&nbsp;└── uploads/<br/>
+				├── config/<br/>
+				│&nbsp;&nbsp;&nbsp;└── site-settings.json<br/>
+				└── README.md (import instructions)
+			</p>
 		</div>
-	</header>
 
-	<!-- Content -->
-	<article class="flex-1 px-6 py-12">
-		<div class="max-w-3xl mx-auto">
-			<!-- Header -->
-			<header class="mb-8">
-				<p class="text-sm text-bark/50 font-sans mb-2">
-					<a href="/legal" class="hover:text-grove-600 transition-colors">&larr; All Legal Documents</a>
-				</p>
-				<h1 class="text-3xl md:text-4xl font-serif text-bark mb-2">Data Portability & Account Separation</h1>
-				<p class="text-bark/50 font-sans text-sm">
-					Effective Date: December 2025
-				</p>
-			</header>
+		<h3>How to Request an Export</h3>
+		<ol class="space-y-1 ml-4">
+			<li><strong>Self-service:</strong> Admin Panel → Settings → Export Data</li>
+			<li><strong>Email:</strong> autumn@grove.place</li>
+			<li><strong>Automatic on cancellation:</strong> Export link sent within 24 hours</li>
+		</ol>
+		<p class="mt-2">Exports are generated within 24 hours and available for download for 30 days.</p>
+	</section>
 
-			<!-- Promise -->
-			<div class="card p-6 mb-8 bg-grove-50 border-grove-200">
-				<h2 class="text-lg font-serif text-grove-700 mb-2">Our Promise</h2>
-				<p class="text-bark/70 font-sans">
-					Your content is yours. Your domain is yours. Grove will never hold your data or domain hostage.
-				</p>
-			</div>
+	<section>
+		<h2>2. Domain Ownership & Transfer</h2>
 
-			<!-- Content -->
-			<div class="prose prose-bark max-w-none font-sans text-bark/80 leading-relaxed space-y-8">
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">1. Data Export</h2>
+		<h3>You Own Your Domain</h3>
+		<p>When Grove registers a custom domain on your behalf (Evergreen tier), <strong>you are the legal owner</strong>. Grove acts as a registrar agent, not the domain owner.</p>
+		<ul class="space-y-1 ml-4 mt-2">
+			<li>The domain is registered with your contact information</li>
+			<li>You receive registrar notifications directly</li>
+			<li>You can transfer the domain at any time</li>
+			<li>Grove cannot sell, redirect, or hold your domain</li>
+		</ul>
 
-					<h3 class="text-lg font-serif text-bark/90 mb-2">What You Receive</h3>
-					<p>When you cancel your subscription (or anytime you request it), you receive a complete export package:</p>
+		<h3>Domain Transfer Process</h3>
+		<p><strong>When you cancel your Evergreen subscription:</strong></p>
+		<ol class="space-y-1 ml-4">
+			<li><strong>Notification:</strong> You'll receive an email explaining your options</li>
+			<li><strong>Transfer window:</strong> 30 days to initiate transfer to another registrar</li>
+			<li><strong>Authorization code:</strong> Provided within 48 hours of request</li>
+			<li><strong>No fees:</strong> Grove charges no transfer fees</li>
+		</ol>
 
-					<p class="mt-4"><strong>Blog Content:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>All blog posts in Markdown format</li>
-						<li>Original images and media files</li>
-						<li>Post metadata (publish dates, tags, status)</li>
-						<li>Site configuration and settings</li>
-					</ul>
+		<p class="mt-4"><strong>To request a domain transfer:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>Email: autumn@grove.place</li>
+			<li>Subject: "Domain Transfer Request - yourdomain.com"</li>
+			<li>We'll respond with your EPP/authorization code within 48 hours</li>
+		</ul>
+	</section>
 
-					<div class="card p-4 bg-bark/5 mt-4">
-						<p class="text-sm font-mono text-bark/70">
-							grove-export-username-YYYY-MM-DD.zip<br/>
-							├── posts/<br/>
-							│&nbsp;&nbsp;&nbsp;├── 2025-01-15-my-first-post.md<br/>
-							│&nbsp;&nbsp;&nbsp;└── ...<br/>
-							├── media/<br/>
-							│&nbsp;&nbsp;&nbsp;├── images/<br/>
-							│&nbsp;&nbsp;&nbsp;└── uploads/<br/>
-							├── config/<br/>
-							│&nbsp;&nbsp;&nbsp;└── site-settings.json<br/>
-							└── README.md (import instructions)
-						</p>
-					</div>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-6">How to Request an Export</h3>
-					<ol class="list-decimal list-inside space-y-1 ml-4">
-						<li><strong>Self-service:</strong> Admin Panel → Settings → Export Data</li>
-						<li><strong>Email:</strong> autumn@grove.place</li>
-						<li><strong>Automatic on cancellation:</strong> Export link sent within 24 hours</li>
-					</ol>
-					<p class="mt-2">Exports are generated within 24 hours and available for download for 30 days.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">2. Domain Ownership & Transfer</h2>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2">You Own Your Domain</h3>
-					<p>When Grove registers a custom domain on your behalf (Evergreen tier), <strong>you are the legal owner</strong>. Grove acts as a registrar agent, not the domain owner.</p>
-					<ul class="list-disc list-inside space-y-1 ml-4 mt-2">
-						<li>The domain is registered with your contact information</li>
-						<li>You receive registrar notifications directly</li>
-						<li>You can transfer the domain at any time</li>
-						<li>Grove cannot sell, redirect, or hold your domain</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-6">Domain Transfer Process</h3>
-					<p><strong>When you cancel your Evergreen subscription:</strong></p>
-					<ol class="list-decimal list-inside space-y-1 ml-4">
-						<li><strong>Notification:</strong> You'll receive an email explaining your options</li>
-						<li><strong>Transfer window:</strong> 30 days to initiate transfer to another registrar</li>
-						<li><strong>Authorization code:</strong> Provided within 48 hours of request</li>
-						<li><strong>No fees:</strong> Grove charges no transfer fees</li>
-					</ol>
-
-					<p class="mt-4"><strong>To request a domain transfer:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Email: autumn@grove.place</li>
-						<li>Subject: "Domain Transfer Request - yourdomain.com"</li>
-						<li>We'll respond with your EPP/authorization code within 48 hours</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">3. Grace Periods</h2>
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Timeline</th>
-									<th class="py-2 px-3 text-left">What Happens</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Day 0</td>
-									<td class="py-2 px-3">Subscription cancelled</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Days 1-30</td>
-									<td class="py-2 px-3">Blog remains accessible, emails forward, domain active</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Days 31-60</td>
-									<td class="py-2 px-3">Blog shows "subscription inactive" message, domain still yours</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Days 61-90</td>
-									<td class="py-2 px-3">Domain preserved but not pointing to Grove</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Day 90+</td>
-									<td class="py-2 px-3">Domain follows registrar's expiration policy if not renewed</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-					<p class="mt-4"><strong>Your domain never disappears without warning.</strong> You'll receive email reminders at 30, 14, and 7 days before any service interruption.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">4. @grove.place Email Addresses</h2>
-					<p>Email addresses like <code>username@grove.place</code> are tied to your Grove subscription.</p>
-					<p class="mt-4"><strong>On cancellation:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Email forwarding stops after 30-day grace period</li>
-						<li>We'll forward a final notice to your personal email</li>
-						<li>The address may be released for future users after 6 months</li>
-					</ul>
-					<p class="mt-4"><strong>Custom domain email</strong> (Oak tier) is entirely yours and unaffected by Grove cancellation.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">5. Data Retention After Cancellation</h2>
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Data Type</th>
-									<th class="py-2 px-3 text-left">Retention Period</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Blog posts & media</td>
-									<td class="py-2 px-3">90 days (exportable anytime)</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Account information</td>
-									<td class="py-2 px-3">90 days (for reactivation)</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Payment history</td>
-									<td class="py-2 px-3">7 years (legal requirements)</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Domain registration</td>
-									<td class="py-2 px-3">Indefinite (you own it)</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-					<p class="mt-4"><strong>After 90 days:</strong> All blog content is permanently deleted from Grove servers. We cannot recover it.</p>
-					<p class="mt-2"><strong>Reactivation:</strong> Within 90 days, you can reactivate your account and restore all content.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">6. No Hostage Situations</h2>
-					<p>Grove commits to the following:</p>
-					<ol class="list-decimal list-inside space-y-1 ml-4">
-						<li><strong>No transfer fees</strong> for domains or data</li>
-						<li><strong>No artificial delays</strong> in providing export files or authorization codes</li>
-						<li><strong>No "pay to leave"</strong> schemes</li>
-						<li><strong>No content held for ransom</strong> under any circumstances</li>
-						<li><strong>Standard formats</strong> for all exports (Markdown, JSON, common image formats)</li>
-					</ol>
-					<p class="mt-4">If you ever feel Grove is not honoring this commitment, contact <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a> directly.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">7. Contact</h2>
-					<p><strong>Email:</strong> <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a></p>
-					<p><strong>Response time:</strong> Within 48 hours</p>
-				</section>
-
-				<section class="pt-6 border-t border-grove-200">
-					<p class="italic text-bark/60">
-						This policy reflects Grove's core value: your content, your ownership, your choice.
-					</p>
-				</section>
-			</div>
+	<section>
+		<h2>3. Grace Periods</h2>
+		<div class="overflow-x-auto">
+			<table>
+				<thead>
+					<tr>
+						<th>Timeline</th>
+						<th>What Happens</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Day 0</td>
+						<td>Subscription cancelled</td>
+					</tr>
+					<tr>
+						<td>Days 1-30</td>
+						<td>Blog remains accessible, emails forward, domain active</td>
+					</tr>
+					<tr>
+						<td>Days 31-60</td>
+						<td>Blog shows "subscription inactive" message, domain still yours</td>
+					</tr>
+					<tr>
+						<td>Days 61-90</td>
+						<td>Domain preserved but not pointing to Grove</td>
+					</tr>
+					<tr>
+						<td>Day 90+</td>
+						<td>Domain follows registrar's expiration policy if not renewed</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</article>
+		<p class="mt-4"><strong>Your domain never disappears without warning.</strong> You'll receive email reminders at 30, 14, and 7 days before any service interruption.</p>
+	</section>
 
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-3xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</div>
+	<section>
+		<h2>4. @grove.place Email Addresses</h2>
+		<p>Email addresses like <code>username@grove.place</code> are tied to your Grove subscription.</p>
+		<p class="mt-4"><strong>On cancellation:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>Email forwarding stops after 30-day grace period</li>
+			<li>We'll forward a final notice to your personal email</li>
+			<li>The address may be released for future users after 6 months</li>
+		</ul>
+		<p class="mt-4"><strong>Custom domain email</strong> (Oak tier) is entirely yours and unaffected by Grove cancellation.</p>
+	</section>
+
+	<section>
+		<h2>5. Data Retention After Cancellation</h2>
+		<div class="overflow-x-auto">
+			<table>
+				<thead>
+					<tr>
+						<th>Data Type</th>
+						<th>Retention Period</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Blog posts & media</td>
+						<td>90 days (exportable anytime)</td>
+					</tr>
+					<tr>
+						<td>Account information</td>
+						<td>90 days (for reactivation)</td>
+					</tr>
+					<tr>
+						<td>Payment history</td>
+						<td>7 years (legal requirements)</td>
+					</tr>
+					<tr>
+						<td>Domain registration</td>
+						<td>Indefinite (you own it)</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</footer>
-</main>
+		<p class="mt-4"><strong>After 90 days:</strong> All blog content is permanently deleted from Grove servers. We cannot recover it.</p>
+		<p class="mt-2"><strong>Reactivation:</strong> Within 90 days, you can reactivate your account and restore all content.</p>
+	</section>
+
+	<section>
+		<h2>6. No Hostage Situations</h2>
+		<p>Grove commits to the following:</p>
+		<ol class="space-y-1 ml-4">
+			<li><strong>No transfer fees</strong> for domains or data</li>
+			<li><strong>No artificial delays</strong> in providing export files or authorization codes</li>
+			<li><strong>No "pay to leave"</strong> schemes</li>
+			<li><strong>No content held for ransom</strong> under any circumstances</li>
+			<li><strong>Standard formats</strong> for all exports (Markdown, JSON, common image formats)</li>
+		</ol>
+		<p class="mt-4">If you ever feel Grove is not honoring this commitment, contact <a href="mailto:autumn@grove.place">autumn@grove.place</a> directly.</p>
+	</section>
+
+	<section>
+		<h2>7. Contact</h2>
+		<p><strong>Email:</strong> <a href="mailto:autumn@grove.place">autumn@grove.place</a></p>
+		<p><strong>Response time:</strong> Within 48 hours</p>
+	</section>
+
+	<section class="pt-6">
+		<p><em>
+			This policy reflects Grove's core value: your content, your ownership, your choice.
+		</em></p>
+	</section>
+</LegalLayout>

--- a/landing/src/routes/legal/dmca/+page.svelte
+++ b/landing/src/routes/legal/dmca/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import LegalLayout from '$lib/components/LegalLayout.svelte';
 </script>
 
 <svelte:head>
@@ -6,136 +7,96 @@
 	<meta name="description" content="How Grove handles copyright claims and takedown requests under the Digital Millennium Copyright Act." />
 </svelte:head>
 
-<main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-3xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</nav>
+<LegalLayout title="DMCA Policy" effectiveDate="December 10, 2025" lastUpdated="December 10, 2025">
+	<section>
+		<h2>Overview</h2>
+		<p>
+			Grove respects the intellectual property rights of others and expects our users to do the same. We respond to notices of alleged copyright infringement in accordance with the Digital Millennium Copyright Act ("DMCA") and other applicable laws.
+		</p>
+	</section>
+
+	<section>
+		<h2>1. Filing a DMCA Takedown Notice</h2>
+		<p>If you are a copyright owner (or authorized to act on behalf of one) and believe that content on Grove infringes your copyright, you may submit a DMCA takedown notice.</p>
+
+		<h3>1.1 Required Information</h3>
+		<p>Your notice must include <strong>all</strong> of the following:</p>
+		<ol class="space-y-2 ml-4">
+			<li><strong>Identification of the copyrighted work</strong> you claim has been infringed</li>
+			<li><strong>Identification of the infringing material</strong> and information to locate it (e.g., the URL)</li>
+			<li><strong>Your contact information</strong> (name, mailing address, telephone, email)</li>
+			<li><strong>A statement</strong> that you have a good faith belief that the use is not authorized</li>
+			<li><strong>A statement</strong> that the information is accurate, and under penalty of perjury, that you are authorized to act on behalf of the copyright owner</li>
+			<li><strong>Your physical or electronic signature</strong></li>
+		</ol>
+
+		<h3>1.2 Where to Send Your Notice</h3>
+		<p><strong>Email:</strong> <a href="mailto:autumn@grove.place">autumn@grove.place</a></p>
+		<p><strong>Subject Line:</strong> DMCA Takedown Notice</p>
+
+		<h3>1.3 What Happens Next</h3>
+		<p>Upon receiving a valid DMCA takedown notice:</p>
+		<ol class="space-y-1 ml-4">
+			<li>We will promptly remove or disable access to the allegedly infringing material</li>
+			<li>We will notify the user who posted the content</li>
+			<li>We will provide the user with information about filing a counter-notification</li>
+		</ol>
+	</section>
+
+	<section>
+		<h2>2. Counter-Notification</h2>
+		<p>If you believe your content was removed by mistake or misidentification, you may file a counter-notification.</p>
+
+		<h3>2.1 Required Information</h3>
+		<ol class="space-y-2 ml-4">
+			<li><strong>Identification of the material</strong> that was removed and its location before removal</li>
+			<li><strong>A statement under penalty of perjury</strong> that you have a good faith belief the material was removed by mistake</li>
+			<li><strong>Your name, address, and telephone number</strong></li>
+			<li><strong>A statement</strong> that you consent to the jurisdiction of federal court and will accept service of process</li>
+			<li><strong>Your physical or electronic signature</strong></li>
+		</ol>
+
+		<h3>2.2 Where to Send Your Counter-Notification</h3>
+		<p><strong>Email:</strong> <a href="mailto:autumn@grove.place">autumn@grove.place</a></p>
+		<p><strong>Subject Line:</strong> DMCA Counter-Notification</p>
+
+		<h3>2.3 What Happens Next</h3>
+		<ol class="space-y-1 ml-4">
+			<li>We will forward a copy to the original complainant</li>
+			<li>We will inform them the material may be restored in 10-14 business days</li>
+			<li>If no court action is filed within that time, we may restore the material</li>
+		</ol>
+	</section>
+
+	<section>
+		<h2>3. Repeat Infringer Policy</h2>
+		<p>Grove maintains a policy of terminating accounts of users who are repeat infringers.</p>
+		<p class="mt-4">A "repeat infringer" is a user who has been the subject of two or more valid DMCA takedown notices for different works, or has had content removed for copyright infringement on multiple occasions.</p>
+		<p class="mt-4">Users identified as repeat infringers will have their accounts terminated and may be permanently banned from Grove.</p>
+	</section>
+
+	<section>
+		<h2>4. Misrepresentation Warning</h2>
+		<div class="card p-4 mb-4 bg-accent border-accent">
+			<p>
+				<strong>Please be aware:</strong> Under Section 512(f) of the DMCA, any person who knowingly materially misrepresents that material is infringing, or that material was removed by mistake, may be subject to liability for damages, including costs and attorneys' fees.
+			</p>
+			<p class="mt-2">
+				Do not file a DMCA notice unless you are certain that the content infringes your copyright. If you are unsure, please consult an attorney before submitting a notice.
+			</p>
 		</div>
-	</header>
+	</section>
 
-	<!-- Content -->
-	<article class="flex-1 px-6 py-12">
-		<div class="max-w-3xl mx-auto">
-			<!-- Header -->
-			<header class="mb-8">
-				<p class="text-sm text-bark/50 font-sans mb-2">
-					<a href="/legal" class="hover:text-grove-600 transition-colors">&larr; All Legal Documents</a>
-				</p>
-				<h1 class="text-3xl md:text-4xl font-serif text-bark mb-2">DMCA Policy</h1>
-				<p class="text-bark/50 font-sans text-sm">
-					Effective Date: December 10, 2025 · Last Updated: December 10, 2025
-				</p>
-			</header>
+	<section>
+		<h2>5. Contact Information</h2>
+		<p>For all DMCA-related inquiries:</p>
+		<p><strong>Email:</strong> <a href="mailto:autumn@grove.place">autumn@grove.place</a></p>
+		<p class="mt-4"><em>Designated Agent registration with U.S. Copyright Office is pending. This policy will be updated once registration is complete.</em></p>
+	</section>
 
-			<!-- Content -->
-			<div class="prose prose-bark max-w-none font-sans text-bark/80 leading-relaxed space-y-8">
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">Overview</h2>
-					<p>
-						Grove respects the intellectual property rights of others and expects our users to do the same. We respond to notices of alleged copyright infringement in accordance with the Digital Millennium Copyright Act ("DMCA") and other applicable laws.
-					</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">1. Filing a DMCA Takedown Notice</h2>
-					<p>If you are a copyright owner (or authorized to act on behalf of one) and believe that content on Grove infringes your copyright, you may submit a DMCA takedown notice.</p>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.1 Required Information</h3>
-					<p>Your notice must include <strong>all</strong> of the following:</p>
-					<ol class="list-decimal list-inside space-y-2 ml-4">
-						<li><strong>Identification of the copyrighted work</strong> you claim has been infringed</li>
-						<li><strong>Identification of the infringing material</strong> and information to locate it (e.g., the URL)</li>
-						<li><strong>Your contact information</strong> (name, mailing address, telephone, email)</li>
-						<li><strong>A statement</strong> that you have a good faith belief that the use is not authorized</li>
-						<li><strong>A statement</strong> that the information is accurate, and under penalty of perjury, that you are authorized to act on behalf of the copyright owner</li>
-						<li><strong>Your physical or electronic signature</strong></li>
-					</ol>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.2 Where to Send Your Notice</h3>
-					<p><strong>Email:</strong> <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a></p>
-					<p><strong>Subject Line:</strong> DMCA Takedown Notice</p>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.3 What Happens Next</h3>
-					<p>Upon receiving a valid DMCA takedown notice:</p>
-					<ol class="list-decimal list-inside space-y-1 ml-4">
-						<li>We will promptly remove or disable access to the allegedly infringing material</li>
-						<li>We will notify the user who posted the content</li>
-						<li>We will provide the user with information about filing a counter-notification</li>
-					</ol>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">2. Counter-Notification</h2>
-					<p>If you believe your content was removed by mistake or misidentification, you may file a counter-notification.</p>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">2.1 Required Information</h3>
-					<ol class="list-decimal list-inside space-y-2 ml-4">
-						<li><strong>Identification of the material</strong> that was removed and its location before removal</li>
-						<li><strong>A statement under penalty of perjury</strong> that you have a good faith belief the material was removed by mistake</li>
-						<li><strong>Your name, address, and telephone number</strong></li>
-						<li><strong>A statement</strong> that you consent to the jurisdiction of federal court and will accept service of process</li>
-						<li><strong>Your physical or electronic signature</strong></li>
-					</ol>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">2.2 Where to Send Your Counter-Notification</h3>
-					<p><strong>Email:</strong> <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a></p>
-					<p><strong>Subject Line:</strong> DMCA Counter-Notification</p>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">2.3 What Happens Next</h3>
-					<ol class="list-decimal list-inside space-y-1 ml-4">
-						<li>We will forward a copy to the original complainant</li>
-						<li>We will inform them the material may be restored in 10-14 business days</li>
-						<li>If no court action is filed within that time, we may restore the material</li>
-					</ol>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">3. Repeat Infringer Policy</h2>
-					<p>Grove maintains a policy of terminating accounts of users who are repeat infringers.</p>
-					<p class="mt-4">A "repeat infringer" is a user who has been the subject of two or more valid DMCA takedown notices for different works, or has had content removed for copyright infringement on multiple occasions.</p>
-					<p class="mt-4">Users identified as repeat infringers will have their accounts terminated and may be permanently banned from Grove.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">4. Misrepresentation Warning</h2>
-					<div class="card p-4 bg-amber-50 border-amber-200">
-						<p class="text-bark/80">
-							<strong>Please be aware:</strong> Under Section 512(f) of the DMCA, any person who knowingly materially misrepresents that material is infringing, or that material was removed by mistake, may be subject to liability for damages, including costs and attorneys' fees.
-						</p>
-						<p class="text-bark/80 mt-2">
-							Do not file a DMCA notice unless you are certain that the content infringes your copyright. If you are unsure, please consult an attorney before submitting a notice.
-						</p>
-					</div>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">5. Contact Information</h2>
-					<p>For all DMCA-related inquiries:</p>
-					<p><strong>Email:</strong> <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a></p>
-					<p class="mt-4 text-sm italic">Designated Agent registration with U.S. Copyright Office is pending. This policy will be updated once registration is complete.</p>
-				</section>
-
-				<section class="pt-6 border-t border-grove-200">
-					<p class="italic text-bark/60">
-						Grove respects creators and their work. If you have questions about copyright and Grove, please reach out.
-					</p>
-				</section>
-			</div>
-		</div>
-	</article>
-
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-3xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</div>
-		</div>
-	</footer>
-</main>
+	<section class="pt-6">
+		<p><em>
+			Grove respects creators and their work. If you have questions about copyright and Grove, please reach out.
+		</em></p>
+	</section>
+</LegalLayout>

--- a/landing/src/routes/legal/privacy/+page.svelte
+++ b/landing/src/routes/legal/privacy/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import LegalLayout from '$lib/components/LegalLayout.svelte';
 </script>
 
 <svelte:head>
@@ -6,263 +7,223 @@
 	<meta name="description" content="Privacy Policy for Grove. Your data belongs to you. We never sell your data." />
 </svelte:head>
 
-<main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-3xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</nav>
+<LegalLayout title="Privacy Policy" effectiveDate="December 10, 2025" lastUpdated="December 11, 2025">
+	<!-- Commitment -->
+	<div class="card p-6 mb-8 bg-accent border-accent">
+		<h2>Our Commitment to Your Privacy</h2>
+		<p>
+			Grove is built on a simple principle: <strong>your data belongs to you</strong>. We collect only what we need to provide the Service, we never sell your data, and we give you full control over your information.
+		</p>
+	</div>
+
+	<section>
+		<h2>1. Information We Collect</h2>
+
+		<h3>1.1 Information You Provide</h3>
+		<p><strong>Account Information:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>Email address (required for authentication)</li>
+			<li>Display name (optional)</li>
+			<li>Profile information you choose to add</li>
+		</ul>
+
+		<p class="mt-4"><strong>Content:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>Blog posts and pages you create</li>
+			<li>Images and media you upload</li>
+			<li>Comments and reactions (if using Meadow)</li>
+		</ul>
+
+		<p class="mt-4"><strong>Payment Information:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>Billing details are processed by Stripe</li>
+			<li>We do not store your credit card numbers</li>
+		</ul>
+
+		<h3>1.2 Information Collected Automatically</h3>
+		<ul class="space-y-1 ml-4">
+			<li>Session tokens (stored as HTTP-only cookies)</li>
+			<li>IP addresses (retained for exactly 1 minute for rate limiting, then discarded)</li>
+			<li>Aggregated, anonymized usage data</li>
+		</ul>
+
+		<h3>1.3 Information We Do NOT Collect</h3>
+		<ul class="space-y-1 ml-4">
+			<li>We do not use tracking pixels or third-party advertising trackers</li>
+			<li>We do not purchase data about you from third parties</li>
+			<li>We do not monitor your activity outside of Grove</li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>2. How We Use Your Information</h2>
+		<div class="overflow-x-auto my-4">
+			<table>
+				<thead>
+					<tr>
+						<th>Purpose</th>
+						<th>Data Used</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Provide the Service</td>
+						<td>Account info, content, session data</td>
+					</tr>
+					<tr>
+						<td>Process payments</td>
+						<td>Billing info (via Stripe)</td>
+					</tr>
+					<tr>
+						<td>Send important updates</td>
+						<td>Email address</td>
+					</tr>
+					<tr>
+						<td>Prevent abuse</td>
+						<td>IP addresses, rate limiting data</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</header>
 
-	<!-- Content -->
-	<article class="flex-1 px-6 py-12">
-		<div class="max-w-3xl mx-auto">
-			<!-- Header -->
-			<header class="mb-8">
-				<p class="text-sm text-bark/50 font-sans mb-2">
-					<a href="/legal" class="hover:text-grove-600 transition-colors">&larr; All Legal Documents</a>
-				</p>
-				<h1 class="text-3xl md:text-4xl font-serif text-bark mb-2">Privacy Policy</h1>
-				<p class="text-bark/50 font-sans text-sm">
-					Effective Date: December 10, 2025 · Last Updated: December 11, 2025
-				</p>
-			</header>
+		<p><strong>We Never Use Your Data To:</strong></p>
+		<ul class="space-y-1 ml-4">
+			<li>Sell to third parties</li>
+			<li>Target you with advertising</li>
+			<li>Build profiles for marketing</li>
+			<li>Train AI models</li>
+		</ul>
+	</section>
 
-			<!-- Commitment -->
-			<div class="card p-6 mb-8 bg-grove-50 border-grove-200">
-				<h2 class="text-lg font-serif text-grove-700 mb-2">Our Commitment to Your Privacy</h2>
-				<p class="text-bark/70 font-sans">
-					Grove is built on a simple principle: <strong>your data belongs to you</strong>. We collect only what we need to provide the Service, we never sell your data, and we give you full control over your information.
-				</p>
-			</div>
+	<section>
+		<h2>3. How We Share Your Information</h2>
+		<p><strong>We will never sell, rent, or trade your personal information.</strong></p>
 
-			<!-- Content -->
-			<div class="prose prose-bark max-w-none font-sans text-bark/80 leading-relaxed space-y-8">
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">1. Information We Collect</h2>
+		<p class="mt-4">We share limited data with trusted service providers:</p>
+		<ul class="space-y-1 ml-4">
+			<li><strong>Cloudflare</strong> — Infrastructure, CDN, security</li>
+			<li><strong>Stripe</strong> — Payment processing</li>
+			<li><strong>Resend</strong> — Email delivery</li>
+			<li><strong>Google</strong> — Authentication (if you use Google Sign-In)</li>
+		</ul>
 
-					<h3 class="text-lg font-serif text-bark/90 mb-2">1.1 Information You Provide</h3>
-					<p><strong>Account Information:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Email address (required for authentication)</li>
-						<li>Display name (optional)</li>
-						<li>Profile information you choose to add</li>
-					</ul>
+		<p class="mt-4">We may disclose information if required by law, such as in response to a valid subpoena or court order.</p>
+	</section>
 
-					<p class="mt-4"><strong>Content:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Blog posts and pages you create</li>
-						<li>Images and media you upload</li>
-						<li>Comments and reactions (if using Meadow)</li>
-					</ul>
-
-					<p class="mt-4"><strong>Payment Information:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Billing details are processed by Stripe</li>
-						<li>We do not store your credit card numbers</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-6">1.2 Information Collected Automatically</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Session tokens (stored as HTTP-only cookies)</li>
-						<li>IP addresses (retained for exactly 1 minute for rate limiting, then discarded)</li>
-						<li>Aggregated, anonymized usage data</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-6">1.3 Information We Do NOT Collect</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>We do not use tracking pixels or third-party advertising trackers</li>
-						<li>We do not purchase data about you from third parties</li>
-						<li>We do not monitor your activity outside of Grove</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">2. How We Use Your Information</h2>
-					<div class="overflow-x-auto my-4">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Purpose</th>
-									<th class="py-2 px-3 text-left">Data Used</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Provide the Service</td>
-									<td class="py-2 px-3">Account info, content, session data</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Process payments</td>
-									<td class="py-2 px-3">Billing info (via Stripe)</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Send important updates</td>
-									<td class="py-2 px-3">Email address</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Prevent abuse</td>
-									<td class="py-2 px-3">IP addresses, rate limiting data</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-
-					<p><strong>We Never Use Your Data To:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Sell to third parties</li>
-						<li>Target you with advertising</li>
-						<li>Build profiles for marketing</li>
-						<li>Train AI models</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">3. How We Share Your Information</h2>
-					<p><strong>We will never sell, rent, or trade your personal information.</strong></p>
-
-					<p class="mt-4">We share limited data with trusted service providers:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li><strong>Cloudflare</strong> — Infrastructure, CDN, security</li>
-						<li><strong>Stripe</strong> — Payment processing</li>
-						<li><strong>Resend</strong> — Email delivery</li>
-						<li><strong>Google</strong> — Authentication (if you use Google Sign-In)</li>
-					</ul>
-
-					<p class="mt-4">We may disclose information if required by law, such as in response to a valid subpoena or court order.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">4. Data Retention</h2>
-					<div class="overflow-x-auto my-4">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Data Type</th>
-									<th class="py-2 px-3 text-left">Retention Period</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">IP addresses</td>
-									<td class="py-2 px-3">1 minute (rate limiting only)</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Sessions</td>
-									<td class="py-2 px-3">7 days (or until logout)</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Account data after deletion</td>
-									<td class="py-2 px-3">30 days, then permanently deleted</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Payment records</td>
-									<td class="py-2 px-3">As required by law (typically 7 years)</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">5. Your Rights and Choices</h2>
-					<ul class="list-disc list-inside space-y-2 ml-4">
-						<li><strong>Access Your Data:</strong> View all your personal information in your account settings</li>
-						<li><strong>Export Your Data:</strong> Export your data at any time in standard formats</li>
-						<li><strong>Correct Your Data:</strong> Update your account information through your settings</li>
-						<li><strong>Delete Your Data:</strong> Request deletion by contacting autumn@grove.place</li>
-						<li><strong>Opt Out:</strong> Unsubscribe from marketing emails at any time</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">6. Data Security</h2>
-					<p>We implement industry-standard security measures:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>All data transmitted over HTTPS/TLS encryption</li>
-						<li>Passwords and authentication codes are hashed</li>
-						<li>HTTP-only, Secure, SameSite=Strict cookies</li>
-						<li>Rate limiting to prevent brute-force attacks</li>
-						<li>Data stored on Cloudflare's SOC 2 Type II certified infrastructure</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">7. Cookies</h2>
-					<p>We use only essential cookies:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li><strong>Session cookie</strong> — Authentication (7 days)</li>
-						<li><strong>CSRF token</strong> — Security (session)</li>
-					</ul>
-					<p class="mt-4">We do not use third-party tracking cookies, advertising cookies, or social media tracking pixels.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">8. Children's Privacy</h2>
-					<p>Grove is not intended for users under 18 years of age. We do not knowingly collect personal information from anyone under 18.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">9. Contact Us</h2>
-					<p>If you have questions about this Privacy Policy, please contact us:</p>
-					<p><strong>Email:</strong> <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a></p>
-				</section>
-
-				<!-- Summary -->
-				<section class="pt-6 border-t border-grove-200">
-					<h2 class="text-xl font-serif text-bark mb-4">Summary</h2>
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm border-collapse">
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Do you sell my data?</td>
-									<td class="py-2 px-3 font-bold text-grove-700">Never.</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Do you use my data for advertising?</td>
-									<td class="py-2 px-3 font-bold text-grove-700">No.</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Can I export my data?</td>
-									<td class="py-2 px-3 font-bold text-grove-700">Yes, anytime.</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Can I delete my account?</td>
-									<td class="py-2 px-3 font-bold text-grove-700">Yes, completely.</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Do you use tracking cookies?</td>
-									<td class="py-2 px-3 font-bold text-grove-700">Only essential cookies for authentication.</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Is my data encrypted?</td>
-									<td class="py-2 px-3 font-bold text-grove-700">Yes, in transit and at rest.</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</section>
-
-				<section class="pt-4">
-					<p class="italic text-bark/60">
-						Your privacy matters. If something in this policy concerns you or doesn't make sense, please reach out.
-					</p>
-				</section>
-			</div>
+	<section>
+		<h2>4. Data Retention</h2>
+		<div class="overflow-x-auto my-4">
+			<table>
+				<thead>
+					<tr>
+						<th>Data Type</th>
+						<th>Retention Period</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>IP addresses</td>
+						<td>1 minute (rate limiting only)</td>
+					</tr>
+					<tr>
+						<td>Sessions</td>
+						<td>7 days (or until logout)</td>
+					</tr>
+					<tr>
+						<td>Account data after deletion</td>
+						<td>30 days, then permanently deleted</td>
+					</tr>
+					<tr>
+						<td>Payment records</td>
+						<td>As required by law (typically 7 years)</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</article>
+	</section>
 
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-3xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</div>
+	<section>
+		<h2>5. Your Rights and Choices</h2>
+		<ul class="space-y-2 ml-4">
+			<li><strong>Access Your Data:</strong> View all your personal information in your account settings</li>
+			<li><strong>Export Your Data:</strong> Export your data at any time in standard formats</li>
+			<li><strong>Correct Your Data:</strong> Update your account information through your settings</li>
+			<li><strong>Delete Your Data:</strong> Request deletion by contacting autumn@grove.place</li>
+			<li><strong>Opt Out:</strong> Unsubscribe from marketing emails at any time</li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>6. Data Security</h2>
+		<p>We implement industry-standard security measures:</p>
+		<ul class="space-y-1 ml-4">
+			<li>All data transmitted over HTTPS/TLS encryption</li>
+			<li>Passwords and authentication codes are hashed</li>
+			<li>HTTP-only, Secure, SameSite=Strict cookies</li>
+			<li>Rate limiting to prevent brute-force attacks</li>
+			<li>Data stored on Cloudflare's SOC 2 Type II certified infrastructure</li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>7. Cookies</h2>
+		<p>We use only essential cookies:</p>
+		<ul class="space-y-1 ml-4">
+			<li><strong>Session cookie</strong> — Authentication (7 days)</li>
+			<li><strong>CSRF token</strong> — Security (session)</li>
+		</ul>
+		<p class="mt-4">We do not use third-party tracking cookies, advertising cookies, or social media tracking pixels.</p>
+	</section>
+
+	<section>
+		<h2>8. Children's Privacy</h2>
+		<p>Grove is not intended for users under 18 years of age. We do not knowingly collect personal information from anyone under 18.</p>
+	</section>
+
+	<section>
+		<h2>9. Contact Us</h2>
+		<p>If you have questions about this Privacy Policy, please contact us:</p>
+		<p><strong>Email:</strong> <a href="mailto:autumn@grove.place">autumn@grove.place</a></p>
+	</section>
+
+	<!-- Summary -->
+	<section class="pt-6">
+		<h2>Summary</h2>
+		<div class="overflow-x-auto">
+			<table>
+				<tbody>
+					<tr>
+						<td>Do you sell my data?</td>
+						<td><strong>Never.</strong></td>
+					</tr>
+					<tr>
+						<td>Do you use my data for advertising?</td>
+						<td><strong>No.</strong></td>
+					</tr>
+					<tr>
+						<td>Can I export my data?</td>
+						<td><strong>Yes, anytime.</strong></td>
+					</tr>
+					<tr>
+						<td>Can I delete my account?</td>
+						<td><strong>Yes, completely.</strong></td>
+					</tr>
+					<tr>
+						<td>Do you use tracking cookies?</td>
+						<td><strong>Only essential cookies for authentication.</strong></td>
+					</tr>
+					<tr>
+						<td>Is my data encrypted?</td>
+						<td><strong>Yes, in transit and at rest.</strong></td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</footer>
-</main>
+	</section>
+
+	<section class="pt-4">
+		<p><em>
+			Your privacy matters. If something in this policy concerns you or doesn't make sense, please reach out.
+		</em></p>
+	</section>
+</LegalLayout>

--- a/landing/src/routes/legal/refund/+page.svelte
+++ b/landing/src/routes/legal/refund/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import LegalLayout from '$lib/components/LegalLayout.svelte';
 </script>
 
 <svelte:head>
@@ -6,233 +7,193 @@
 	<meta name="description" content="How refunds and cancellations work at Grove. No hoops, no hassle." />
 </svelte:head>
 
-<main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-3xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</nav>
+<LegalLayout title="Refund & Cancellation Policy" effectiveDate="December 10, 2025" lastUpdated="December 10, 2025">
+	<!-- Philosophy -->
+	<div class="card p-6 mb-8 bg-accent border-accent">
+		<h2>Our Philosophy</h2>
+		<p>
+			We want you to love Grove. If it's not right for you, we make it easy to get your money back or cancel your subscription. No hoops, no hassle.
+		</p>
+	</div>
+
+	<section>
+		<h2>1. Refund Policy</h2>
+
+		<h3>1.1 Within 14 Days (Full Refund)</h3>
+		<p>If you're not satisfied with Grove, you can request a <strong>full refund within 14 days</strong> of your initial subscription or any renewal payment.</p>
+		<ul class="space-y-1 ml-4">
+			<li>No questions asked</li>
+			<li>Full amount refunded to your original payment method</li>
+			<li>Refund processed within 5-10 business days</li>
+		</ul>
+
+		<h3>1.2 After 14 Days (Pro-Rated Refund)</h3>
+		<p>After the 14-day period, you may still request a refund. We will provide a <strong>pro-rated refund</strong> for the unused portion of your current billing period.</p>
+		<p class="mt-2"><strong>Example:</strong> If you're on the Sapling plan ($12/month) and cancel on day 20 of your billing cycle, you would receive approximately $4 back (10 unused days ÷ 30 days × $12).</p>
+
+		<h3>1.3 How to Request a Refund</h3>
+		<p>Email us at <a href="mailto:autumn@grove.place">autumn@grove.place</a> with subject "Refund Request".</p>
+		<p>We will process your request within <strong>3 business days</strong>.</p>
+	</section>
+
+	<section>
+		<h2>2. Cancellation Policy</h2>
+
+		<h3>2.1 How to Cancel</h3>
+		<p>You can cancel your subscription at any time:</p>
+		<ul class="space-y-1 ml-4">
+			<li><strong>Through your account settings</strong> — Go to Settings → Billing → Cancel Subscription</li>
+			<li><strong>By contacting us</strong> — Email autumn@grove.place</li>
+		</ul>
+
+		<h3>2.2 What Happens When You Cancel</h3>
+		<ul class="space-y-1 ml-4">
+			<li>Your subscription will remain active until the end of your current billing period</li>
+			<li>You will not be charged again</li>
+			<li>You retain full access to your blog until the period ends</li>
+			<li>After your subscription ends, your account will be suspended</li>
+		</ul>
+
+		<h3>2.3 After Cancellation</h3>
+		<div class="overflow-x-auto my-4">
+			<table>
+				<thead>
+					<tr>
+						<th>Timeframe</th>
+						<th>What Happens</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>End of billing period</td>
+						<td>Account suspended, blog goes offline</td>
+					</tr>
+					<tr>
+						<td>30 days after suspension</td>
+						<td>Data archived, available for export</td>
+					</tr>
+					<tr>
+						<td>60 days after suspension</td>
+						<td>Data scheduled for deletion</td>
+					</tr>
+					<tr>
+						<td>90 days after suspension</td>
+						<td>Data permanently deleted</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</header>
+		<p><strong>Want to come back?</strong> You can reactivate your subscription anytime within 90 days and your data will be restored.</p>
+	</section>
 
-	<!-- Content -->
-	<article class="flex-1 px-6 py-12">
-		<div class="max-w-3xl mx-auto">
-			<!-- Header -->
-			<header class="mb-8">
-				<p class="text-sm text-bark/50 font-sans mb-2">
-					<a href="/legal" class="hover:text-grove-600 transition-colors">&larr; All Legal Documents</a>
-				</p>
-				<h1 class="text-3xl md:text-4xl font-serif text-bark mb-2">Refund & Cancellation Policy</h1>
-				<p class="text-bark/50 font-sans text-sm">
-					Effective Date: December 10, 2025 · Last Updated: December 10, 2025
-				</p>
-			</header>
-
-			<!-- Philosophy -->
-			<div class="card p-6 mb-8 bg-grove-50 border-grove-200">
-				<h2 class="text-lg font-serif text-grove-700 mb-2">Our Philosophy</h2>
-				<p class="text-bark/70 font-sans">
-					We want you to love Grove. If it's not right for you, we make it easy to get your money back or cancel your subscription. No hoops, no hassle.
-				</p>
-			</div>
-
-			<!-- Content -->
-			<div class="prose prose-bark max-w-none font-sans text-bark/80 leading-relaxed space-y-8">
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">1. Refund Policy</h2>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2">1.1 Within 14 Days (Full Refund)</h3>
-					<p>If you're not satisfied with Grove, you can request a <strong>full refund within 14 days</strong> of your initial subscription or any renewal payment.</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>No questions asked</li>
-						<li>Full amount refunded to your original payment method</li>
-						<li>Refund processed within 5-10 business days</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.2 After 14 Days (Pro-Rated Refund)</h3>
-					<p>After the 14-day period, you may still request a refund. We will provide a <strong>pro-rated refund</strong> for the unused portion of your current billing period.</p>
-					<p class="mt-2"><strong>Example:</strong> If you're on the Sapling plan ($12/month) and cancel on day 20 of your billing cycle, you would receive approximately $4 back (10 unused days ÷ 30 days × $12).</p>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">1.3 How to Request a Refund</h3>
-					<p>Email us at <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a> with subject "Refund Request".</p>
-					<p>We will process your request within <strong>3 business days</strong>.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">2. Cancellation Policy</h2>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2">2.1 How to Cancel</h3>
-					<p>You can cancel your subscription at any time:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li><strong>Through your account settings</strong> — Go to Settings → Billing → Cancel Subscription</li>
-						<li><strong>By contacting us</strong> — Email autumn@grove.place</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">2.2 What Happens When You Cancel</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Your subscription will remain active until the end of your current billing period</li>
-						<li>You will not be charged again</li>
-						<li>You retain full access to your blog until the period ends</li>
-						<li>After your subscription ends, your account will be suspended</li>
-					</ul>
-
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">2.3 After Cancellation</h3>
-					<div class="overflow-x-auto my-4">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Timeframe</th>
-									<th class="py-2 px-3 text-left">What Happens</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">End of billing period</td>
-									<td class="py-2 px-3">Account suspended, blog goes offline</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">30 days after suspension</td>
-									<td class="py-2 px-3">Data archived, available for export</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">60 days after suspension</td>
-									<td class="py-2 px-3">Data scheduled for deletion</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">90 days after suspension</td>
-									<td class="py-2 px-3">Data permanently deleted</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-					<p><strong>Want to come back?</strong> You can reactivate your subscription anytime within 90 days and your data will be restored.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">3. Grace Period for Failed Payments</h2>
-					<p>If your payment fails:</p>
-					<div class="overflow-x-auto my-4">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Day</th>
-									<th class="py-2 px-3 text-left">What Happens</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Day 1</td>
-									<td class="py-2 px-3">Payment fails, first reminder email sent</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Days 2-7</td>
-									<td class="py-2 px-3">Daily reminder emails sent</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Day 7</td>
-									<td class="py-2 px-3">Grace period ends</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Day 8</td>
-									<td class="py-2 px-3">Account suspended</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-					<p>During the <strong>7-day grace period</strong>, your blog remains online and you can update your payment method.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">4. Data Export</h2>
-					<p>Before or after cancellation, you can export all your data:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Blog posts (Markdown format)</li>
-						<li>Pages</li>
-						<li>Media files</li>
-						<li>Settings</li>
-					</ul>
-					<p class="mt-2"><strong>We recommend exporting your data before your subscription ends</strong> to ensure you have a backup.</p>
-					<p class="mt-2">See our <a href="/legal/data-portability" class="text-grove-600 hover:text-grove-700 underline">Data Portability Policy</a> for full details.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">5. Exceptions</h2>
-					<p>Refunds are <strong>not available</strong> in the following situations:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Account terminated for violation of our <a href="/legal/terms" class="text-grove-600 hover:text-grove-700 underline">Terms of Service</a> or <a href="/legal/acceptable-use" class="text-grove-600 hover:text-grove-700 underline">Acceptable Use Policy</a></li>
-						<li>Fraudulent payment or chargeback abuse</li>
-						<li>Requests made more than 90 days after the original payment</li>
-					</ul>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">6. Contact Us</h2>
-					<p>If you have questions about refunds, cancellations, or billing:</p>
-					<p><strong>Email:</strong> <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a></p>
-					<p>We respond to all billing inquiries within <strong>24 hours</strong>.</p>
-				</section>
-
-				<!-- Summary -->
-				<section class="pt-6 border-t border-grove-200">
-					<h2 class="text-xl font-serif text-bark mb-4">Summary</h2>
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Situation</th>
-									<th class="py-2 px-3 text-left">Policy</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Refund within 14 days</td>
-									<td class="py-2 px-3">Full refund</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Refund after 14 days</td>
-									<td class="py-2 px-3">Pro-rated refund</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Cancel subscription</td>
-									<td class="py-2 px-3">Access until end of billing period</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Failed payment</td>
-									<td class="py-2 px-3">7-day grace period</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Data after cancellation</td>
-									<td class="py-2 px-3">Retained 90 days, then deleted</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Reactivation</td>
-									<td class="py-2 px-3">Available within 90 days</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-				</section>
-
-				<section class="pt-4">
-					<p class="italic text-bark/60">
-						We believe in fair, transparent billing. If you ever have an issue, just reach out — we'll make it right.
-					</p>
-				</section>
-			</div>
+	<section>
+		<h2>3. Grace Period for Failed Payments</h2>
+		<p>If your payment fails:</p>
+		<div class="overflow-x-auto my-4">
+			<table>
+				<thead>
+					<tr>
+						<th>Day</th>
+						<th>What Happens</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Day 1</td>
+						<td>Payment fails, first reminder email sent</td>
+					</tr>
+					<tr>
+						<td>Days 2-7</td>
+						<td>Daily reminder emails sent</td>
+					</tr>
+					<tr>
+						<td>Day 7</td>
+						<td>Grace period ends</td>
+					</tr>
+					<tr>
+						<td>Day 8</td>
+						<td>Account suspended</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</article>
+		<p>During the <strong>7-day grace period</strong>, your blog remains online and you can update your payment method.</p>
+	</section>
 
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-3xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</div>
+	<section>
+		<h2>4. Data Export</h2>
+		<p>Before or after cancellation, you can export all your data:</p>
+		<ul class="space-y-1 ml-4">
+			<li>Blog posts (Markdown format)</li>
+			<li>Pages</li>
+			<li>Media files</li>
+			<li>Settings</li>
+		</ul>
+		<p class="mt-2"><strong>We recommend exporting your data before your subscription ends</strong> to ensure you have a backup.</p>
+		<p class="mt-2">See our <a href="/legal/data-portability">Data Portability Policy</a> for full details.</p>
+	</section>
+
+	<section>
+		<h2>5. Exceptions</h2>
+		<p>Refunds are <strong>not available</strong> in the following situations:</p>
+		<ul class="space-y-1 ml-4">
+			<li>Account terminated for violation of our <a href="/legal/terms">Terms of Service</a> or <a href="/legal/acceptable-use">Acceptable Use Policy</a></li>
+			<li>Fraudulent payment or chargeback abuse</li>
+			<li>Requests made more than 90 days after the original payment</li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>6. Contact Us</h2>
+		<p>If you have questions about refunds, cancellations, or billing:</p>
+		<p><strong>Email:</strong> <a href="mailto:autumn@grove.place">autumn@grove.place</a></p>
+		<p>We respond to all billing inquiries within <strong>24 hours</strong>.</p>
+	</section>
+
+	<!-- Summary -->
+	<section class="pt-6">
+		<h2>Summary</h2>
+		<div class="overflow-x-auto">
+			<table>
+				<thead>
+					<tr>
+						<th>Situation</th>
+						<th>Policy</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Refund within 14 days</td>
+						<td>Full refund</td>
+					</tr>
+					<tr>
+						<td>Refund after 14 days</td>
+						<td>Pro-rated refund</td>
+					</tr>
+					<tr>
+						<td>Cancel subscription</td>
+						<td>Access until end of billing period</td>
+					</tr>
+					<tr>
+						<td>Failed payment</td>
+						<td>7-day grace period</td>
+					</tr>
+					<tr>
+						<td>Data after cancellation</td>
+						<td>Retained 90 days, then deleted</td>
+					</tr>
+					<tr>
+						<td>Reactivation</td>
+						<td>Available within 90 days</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</footer>
-</main>
+	</section>
+
+	<section class="pt-4">
+		<p><em>
+			We believe in fair, transparent billing. If you ever have an issue, just reach out — we'll make it right.
+		</em></p>
+	</section>
+</LegalLayout>

--- a/landing/src/routes/legal/terms/+page.svelte
+++ b/landing/src/routes/legal/terms/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import LegalLayout from '$lib/components/LegalLayout.svelte';
 </script>
 
 <svelte:head>
@@ -6,246 +7,206 @@
 	<meta name="description" content="Terms of Service for the Grove platform. The agreement between you and Grove." />
 </svelte:head>
 
-<main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-3xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</nav>
+<LegalLayout title="Terms of Service" effectiveDate="December 10, 2025" lastUpdated="December 13, 2025">
+	<section>
+		<h2>1. Agreement to Terms</h2>
+		<p>
+			By accessing or using Grove ("the Service"), operated by Autumn ("we," "us," or "our"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you may not use the Service.
+		</p>
+		<p>
+			The Service is offered to users in the United States only. By using the Service, you represent that you are located in the United States.
+		</p>
+	</section>
+
+	<section>
+		<h2>2. Eligibility</h2>
+		<p>
+			You must be at least <strong>18 years of age</strong> to use the Service. By using Grove, you represent and warrant that you meet this age requirement.
+		</p>
+	</section>
+
+	<section>
+		<h2>3. Description of Service</h2>
+		<p>Grove is a multi-tenant blogging platform that provides:</p>
+		<ul>
+			<li>Personal blog hosting on subdomains (username.grove.place)</li>
+			<li>Markdown-based content creation and publishing</li>
+			<li>Media storage and delivery</li>
+			<li>Optional community features (Meadow)</li>
+			<li>Custom domain support (Oak and Evergreen tiers)</li>
+		</ul>
+		<p>The Service is provided on a subscription basis with different tiers offering varying features and limits.</p>
+	</section>
+
+	<section>
+		<h2>4. Account Registration</h2>
+		<h3>4.1 Account Creation</h3>
+		<p>To use certain features of the Service, you must create an account. You agree to:</p>
+		<ul>
+			<li>Provide accurate, current, and complete information</li>
+			<li>Maintain and update your information as needed</li>
+			<li>Keep your login credentials secure</li>
+			<li>Notify us immediately of any unauthorized access</li>
+		</ul>
+
+		<h3>4.2 Account Responsibility</h3>
+		<p>You are solely responsible for all activity that occurs under your account. We are not liable for any loss or damage arising from unauthorized use of your account.</p>
+	</section>
+
+	<section>
+		<h2>5. Subscription and Payment</h2>
+		<h3>5.1 Subscription Tiers</h3>
+		<p>Grove offers the following subscription plans:</p>
+		<div class="overflow-x-auto my-4">
+			<table>
+				<thead>
+					<tr>
+						<th>Plan</th>
+						<th>Price</th>
+						<th>Features</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Seedling</td>
+						<td>$8/month ($82/year)</td>
+						<td>1GB storage, 50 posts, Meadow access, community support</td>
+					</tr>
+					<tr>
+						<td>Sapling</td>
+						<td>$12/month ($122/year)</td>
+						<td>5GB storage, 250 posts, Meadow access, email forwarding, email support</td>
+					</tr>
+					<tr>
+						<td>Oak</td>
+						<td>$25/month ($255/year)</td>
+						<td>20GB storage, unlimited posts, Meadow access, BYOD custom domain, full @grove.place email, priority support</td>
+					</tr>
+					<tr>
+						<td>Evergreen</td>
+						<td>$35/month ($357/year)</td>
+						<td>100GB storage, unlimited posts, Meadow access, custom domain included, full @grove.place email, 8 hours onboarding + priority support</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
-	</header>
+		<p>Yearly plans save 15% — pay for 10 months, get 12.</p>
 
-	<!-- Content -->
-	<article class="flex-1 px-6 py-12">
-		<div class="max-w-3xl mx-auto">
-			<!-- Header -->
-			<header class="mb-8">
-				<p class="text-sm text-bark/50 font-sans mb-2">
-					<a href="/legal" class="hover:text-grove-600 transition-colors">&larr; All Legal Documents</a>
-				</p>
-				<h1 class="text-3xl md:text-4xl font-serif text-bark mb-2">Terms of Service</h1>
-				<p class="text-bark/50 font-sans text-sm">
-					Effective Date: December 10, 2025 · Last Updated: December 13, 2025
-				</p>
-			</header>
+		<h3>5.2 Billing</h3>
+		<ul>
+			<li>Subscriptions are billed monthly in advance</li>
+			<li>Payment is processed through Stripe</li>
+			<li>You authorize us to charge your payment method on a recurring basis</li>
+			<li>Prices may change with 30 days' notice</li>
+		</ul>
 
-			<!-- Content -->
-			<div class="prose prose-bark max-w-none font-sans text-bark/80 leading-relaxed space-y-8">
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">1. Agreement to Terms</h2>
-					<p>
-						By accessing or using Grove ("the Service"), operated by Autumn ("we," "us," or "our"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you may not use the Service.
-					</p>
-					<p>
-						The Service is offered to users in the United States only. By using the Service, you represent that you are located in the United States.
-					</p>
-				</section>
+		<h3>5.3 Failed Payments</h3>
+		<ul>
+			<li>A <strong>7-day grace period</strong> is provided for failed payments</li>
+			<li>During the grace period, you will receive daily reminder emails</li>
+			<li>If payment is not received within the grace period, your account will be suspended</li>
+			<li>Your data will be archived for <strong>30 days</strong> after suspension</li>
+			<li>After 30 days, your data may be permanently deleted</li>
+		</ul>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">2. Eligibility</h2>
-					<p>
-						You must be at least <strong>18 years of age</strong> to use the Service. By using Grove, you represent and warrant that you meet this age requirement.
-					</p>
-				</section>
+	<section>
+		<h2>6. Refunds and Cancellation</h2>
+		<p>Please see our <a href="/legal/refund">Refund & Cancellation Policy</a> for complete details.</p>
+		<p><strong>Summary:</strong></p>
+		<ul>
+			<li><strong>Within 14 days:</strong> Full refund available</li>
+			<li><strong>After 14 days:</strong> Pro-rated refund for unused portion</li>
+			<li>You may cancel your subscription at any time through your account settings</li>
+		</ul>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">3. Description of Service</h2>
-					<p>Grove is a multi-tenant blogging platform that provides:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Personal blog hosting on subdomains (username.grove.place)</li>
-						<li>Markdown-based content creation and publishing</li>
-						<li>Media storage and delivery</li>
-						<li>Optional community features (Meadow)</li>
-						<li>Custom domain support (Oak and Evergreen tiers)</li>
-					</ul>
-					<p>The Service is provided on a subscription basis with different tiers offering varying features and limits.</p>
-				</section>
+	<section>
+		<h2>7. User Content</h2>
+		<h3>7.1 Ownership</h3>
+		<p>You retain all ownership rights to the content you create and publish on Grove ("User Content"). We do not claim ownership of your content.</p>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">4. Account Registration</h2>
-					<h3 class="text-lg font-serif text-bark/90 mb-2">4.1 Account Creation</h3>
-					<p>To use certain features of the Service, you must create an account. You agree to:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Provide accurate, current, and complete information</li>
-						<li>Maintain and update your information as needed</li>
-						<li>Keep your login credentials secure</li>
-						<li>Notify us immediately of any unauthorized access</li>
-					</ul>
+		<h3>7.2 License to Grove</h3>
+		<p>By posting User Content, you grant us a limited, non-exclusive license to host, store, display, and distribute your content solely for the purpose of operating the Service. This license ends when you delete your content or close your account.</p>
 
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">4.2 Account Responsibility</h3>
-					<p>You are solely responsible for all activity that occurs under your account. We are not liable for any loss or damage arising from unauthorized use of your account.</p>
-				</section>
+		<h3>7.3 Content Restrictions</h3>
+		<p>Your use of the Service is subject to our <a href="/legal/acceptable-use">Acceptable Use Policy</a>. You agree not to post content that violates these guidelines.</p>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">5. Subscription and Payment</h2>
-					<h3 class="text-lg font-serif text-bark/90 mb-2">5.1 Subscription Tiers</h3>
-					<p>Grove offers the following subscription plans:</p>
-					<div class="overflow-x-auto my-4">
-						<table class="w-full text-sm border-collapse">
-							<thead>
-								<tr class="border-b border-grove-200">
-									<th class="py-2 px-3 text-left">Plan</th>
-									<th class="py-2 px-3 text-left">Price</th>
-									<th class="py-2 px-3 text-left">Features</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Seedling</td>
-									<td class="py-2 px-3">$8/month ($82/year)</td>
-									<td class="py-2 px-3">1GB storage, 50 posts, Meadow access, community support</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Sapling</td>
-									<td class="py-2 px-3">$12/month ($122/year)</td>
-									<td class="py-2 px-3">5GB storage, 250 posts, Meadow access, email forwarding, email support</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Oak</td>
-									<td class="py-2 px-3">$25/month ($255/year)</td>
-									<td class="py-2 px-3">20GB storage, unlimited posts, Meadow access, BYOD custom domain, full @grove.place email, priority support</td>
-								</tr>
-								<tr class="border-b border-grove-100">
-									<td class="py-2 px-3">Evergreen</td>
-									<td class="py-2 px-3">$35/month ($357/year)</td>
-									<td class="py-2 px-3">100GB storage, unlimited posts, Meadow access, custom domain included, full @grove.place email, 8 hours onboarding + priority support</td>
-								</tr>
-							</tbody>
-						</table>
-					</div>
-					<p>Yearly plans save 15% — pay for 10 months, get 12.</p>
+	<section>
+		<h2>8. Data and Privacy</h2>
+		<p>Your privacy is important to us. Please review our <a href="/legal/privacy">Privacy Policy</a> to understand how we collect, use, and protect your information.</p>
+		<p><strong>Key Points:</strong></p>
+		<ul>
+			<li>We never sell your data</li>
+			<li>We collect only what's necessary to provide the Service</li>
+			<li>You can export your data at any time</li>
+			<li>You can request deletion of your account and data</li>
+		</ul>
+	</section>
 
-					<h3 class="text-lg font-serif text-bark/90 mb-2">5.2 Billing</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>Subscriptions are billed monthly in advance</li>
-						<li>Payment is processed through Stripe</li>
-						<li>You authorize us to charge your payment method on a recurring basis</li>
-						<li>Prices may change with 30 days' notice</li>
-					</ul>
+	<section>
+		<h2>9. Intellectual Property</h2>
+		<p>The Service, including its design, features, and underlying technology, is owned by us and protected by intellectual property laws. You may not copy, modify, or reverse engineer any part of the Service.</p>
+		<p>The Grove platform code is available under the GNU Affero General Public License v3.0 (AGPL-3.0).</p>
+	</section>
 
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">5.3 Failed Payments</h3>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>A <strong>7-day grace period</strong> is provided for failed payments</li>
-						<li>During the grace period, you will receive daily reminder emails</li>
-						<li>If payment is not received within the grace period, your account will be suspended</li>
-						<li>Your data will be archived for <strong>30 days</strong> after suspension</li>
-						<li>After 30 days, your data may be permanently deleted</li>
-					</ul>
-				</section>
+	<section>
+		<h2>10. DMCA and Copyright</h2>
+		<p>We respect intellectual property rights and respond to valid copyright complaints. Please see our <a href="/legal/dmca">DMCA Policy</a> for information on filing takedown notices and counter-notifications.</p>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">6. Refunds and Cancellation</h2>
-					<p>Please see our <a href="/legal/refund" class="text-grove-600 hover:text-grove-700 underline">Refund & Cancellation Policy</a> for complete details.</p>
-					<p><strong>Summary:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li><strong>Within 14 days:</strong> Full refund available</li>
-						<li><strong>After 14 days:</strong> Pro-rated refund for unused portion</li>
-						<li>You may cancel your subscription at any time through your account settings</li>
-					</ul>
-				</section>
+	<section>
+		<h2>11. Third-Party Services</h2>
+		<p>The Service integrates with third-party services including:</p>
+		<ul>
+			<li><strong>Cloudflare</strong> — Infrastructure and content delivery</li>
+			<li><strong>Stripe</strong> — Payment processing</li>
+			<li><strong>Resend</strong> — Email delivery</li>
+			<li><strong>Google</strong> — Authentication</li>
+		</ul>
+		<p>Your use of these services is subject to their respective terms and privacy policies.</p>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">7. User Content</h2>
-					<h3 class="text-lg font-serif text-bark/90 mb-2">7.1 Ownership</h3>
-					<p>You retain all ownership rights to the content you create and publish on Grove ("User Content"). We do not claim ownership of your content.</p>
+	<section>
+		<h2>12. Disclaimer of Warranties</h2>
+		<p class="uppercase">
+			THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR SECURE.
+		</p>
+	</section>
 
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">7.2 License to Grove</h3>
-					<p>By posting User Content, you grant us a limited, non-exclusive license to host, store, display, and distribute your content solely for the purpose of operating the Service. This license ends when you delete your content or close your account.</p>
+	<section>
+		<h2>13. Limitation of Liability</h2>
+		<p class="uppercase">
+			TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES. OUR TOTAL LIABILITY SHALL NOT EXCEED THE AMOUNT YOU PAID US IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
+		</p>
+	</section>
 
-					<h3 class="text-lg font-serif text-bark/90 mb-2 mt-4">7.3 Content Restrictions</h3>
-					<p>Your use of the Service is subject to our <a href="/legal/acceptable-use" class="text-grove-600 hover:text-grove-700 underline">Acceptable Use Policy</a>. You agree not to post content that violates these guidelines.</p>
-				</section>
+	<section>
+		<h2>14. Termination</h2>
+		<p>You may terminate your account at any time by canceling your subscription and requesting account deletion.</p>
+		<p>We may terminate or suspend your account if you violate these Terms, engage in fraudulent activity, or fail to pay after the grace period.</p>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">8. Data and Privacy</h2>
-					<p>Your privacy is important to us. Please review our <a href="/legal/privacy" class="text-grove-600 hover:text-grove-700 underline">Privacy Policy</a> to understand how we collect, use, and protect your information.</p>
-					<p><strong>Key Points:</strong></p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li>We never sell your data</li>
-						<li>We collect only what's necessary to provide the Service</li>
-						<li>You can export your data at any time</li>
-						<li>You can request deletion of your account and data</li>
-					</ul>
-				</section>
+	<section>
+		<h2>15. Dispute Resolution</h2>
+		<p>These Terms are governed by the laws of the State of Georgia, United States. Before filing any legal claim, you agree to contact us at autumn@grove.place to attempt to resolve the dispute informally.</p>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">9. Intellectual Property</h2>
-					<p>The Service, including its design, features, and underlying technology, is owned by us and protected by intellectual property laws. You may not copy, modify, or reverse engineer any part of the Service.</p>
-					<p>The Grove platform code is available under the GNU Affero General Public License v3.0 (AGPL-3.0).</p>
-				</section>
+	<section>
+		<h2>16. Changes to Terms</h2>
+		<p>We may update these Terms from time to time. We will notify you of material changes by posting the updated Terms and sending an email. Your continued use of the Service constitutes acceptance of the updated Terms.</p>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">10. DMCA and Copyright</h2>
-					<p>We respect intellectual property rights and respond to valid copyright complaints. Please see our <a href="/legal/dmca" class="text-grove-600 hover:text-grove-700 underline">DMCA Policy</a> for information on filing takedown notices and counter-notifications.</p>
-				</section>
+	<section>
+		<h2>17. Contact Us</h2>
+		<p>If you have questions about these Terms, please contact us at:</p>
+		<p><strong>Email:</strong> <a href="mailto:autumn@grove.place">autumn@grove.place</a></p>
+	</section>
 
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">11. Third-Party Services</h2>
-					<p>The Service integrates with third-party services including:</p>
-					<ul class="list-disc list-inside space-y-1 ml-4">
-						<li><strong>Cloudflare</strong> — Infrastructure and content delivery</li>
-						<li><strong>Stripe</strong> — Payment processing</li>
-						<li><strong>Resend</strong> — Email delivery</li>
-						<li><strong>Google</strong> — Authentication</li>
-					</ul>
-					<p>Your use of these services is subject to their respective terms and privacy policies.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">12. Disclaimer of Warranties</h2>
-					<p class="uppercase text-sm">
-						THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR SECURE.
-					</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">13. Limitation of Liability</h2>
-					<p class="uppercase text-sm">
-						TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES. OUR TOTAL LIABILITY SHALL NOT EXCEED THE AMOUNT YOU PAID US IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
-					</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">14. Termination</h2>
-					<p>You may terminate your account at any time by canceling your subscription and requesting account deletion.</p>
-					<p>We may terminate or suspend your account if you violate these Terms, engage in fraudulent activity, or fail to pay after the grace period.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">15. Dispute Resolution</h2>
-					<p>These Terms are governed by the laws of the State of Georgia, United States. Before filing any legal claim, you agree to contact us at autumn@grove.place to attempt to resolve the dispute informally.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">16. Changes to Terms</h2>
-					<p>We may update these Terms from time to time. We will notify you of material changes by posting the updated Terms and sending an email. Your continued use of the Service constitutes acceptance of the updated Terms.</p>
-				</section>
-
-				<section>
-					<h2 class="text-xl font-serif text-bark mb-4">17. Contact Us</h2>
-					<p>If you have questions about these Terms, please contact us at:</p>
-					<p><strong>Email:</strong> <a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">autumn@grove.place</a></p>
-				</section>
-
-				<section class="pt-6 border-t border-grove-200">
-					<p class="italic text-bark/60">
-						By using Grove, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service.
-					</p>
-				</section>
-			</div>
-		</div>
-	</article>
-
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-3xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</div>
-		</div>
-	</footer>
-</main>
+	<section class="pt-6">
+		<p><em>
+			By using Grove, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service.
+		</em></p>
+	</section>
+</LegalLayout>

--- a/landing/src/routes/pricing/+page.svelte
+++ b/landing/src/routes/pricing/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Header from '$lib/components/Header.svelte';
+	import Footer from '$lib/components/Footer.svelte';
 </script>
 
 <svelte:head>
@@ -7,32 +9,23 @@
 </svelte:head>
 
 <main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-4xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/vision" class="hover:text-grove-600 transition-colors">Vision</a>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</nav>
-		</div>
-	</header>
+	<Header maxWidth="wide" />
 
 	<!-- Content -->
 	<article class="flex-1 px-6 py-12">
 		<div class="max-w-4xl mx-auto">
 			<!-- Header -->
 			<header class="mb-12 text-center">
-				<h1 class="text-4xl md:text-5xl font-serif text-bark mb-4">Pricing</h1>
-				<p class="text-lg text-bark/60 font-sans">
+				<h1 class="text-4xl md:text-5xl font-serif text-foreground mb-4">Pricing</h1>
+				<p class="text-lg text-foreground-subtle font-sans">
 					A home for writers at every level.
 				</p>
 				<div class="flex items-center justify-center gap-4 mt-6">
-					<div class="w-12 h-px bg-grove-300"></div>
-					<svg class="w-4 h-4 text-grove-400" viewBox="0 0 20 20" fill="currentColor">
+					<div class="w-12 h-px bg-divider"></div>
+					<svg class="w-4 h-4 text-accent-subtle" viewBox="0 0 20 20" fill="currentColor">
 						<circle cx="10" cy="10" r="4" />
 					</svg>
-					<div class="w-12 h-px bg-grove-300"></div>
+					<div class="w-12 h-px bg-divider"></div>
 				</div>
 			</header>
 
@@ -40,118 +33,118 @@
 			<div class="overflow-x-auto mb-8">
 				<table class="w-full text-left border-collapse">
 					<thead>
-						<tr class="border-b-2 border-grove-200">
-							<th class="py-4 px-4 font-serif text-bark"></th>
+						<tr class="border-b-2 border-default">
+							<th class="py-4 px-4 font-serif text-foreground"></th>
 							<th class="py-4 px-4 text-center">
-								<div class="font-serif text-bark">Seedling</div>
-								<div class="text-2xl font-sans font-bold text-grove-600">$8<span class="text-sm font-normal text-bark/50">/mo</span></div>
+								<div class="font-serif text-foreground">Seedling</div>
+								<div class="text-2xl font-sans font-bold text-accent-muted">$8<span class="text-sm font-normal text-foreground-faint">/mo</span></div>
 							</th>
 							<th class="py-4 px-4 text-center">
-								<div class="font-serif text-bark">Sapling</div>
-								<div class="text-2xl font-sans font-bold text-grove-600">$12<span class="text-sm font-normal text-bark/50">/mo</span></div>
+								<div class="font-serif text-foreground">Sapling</div>
+								<div class="text-2xl font-sans font-bold text-accent-muted">$12<span class="text-sm font-normal text-foreground-faint">/mo</span></div>
 							</th>
 							<th class="py-4 px-4 text-center">
-								<div class="font-serif text-bark">Oak</div>
-								<div class="text-2xl font-sans font-bold text-grove-600">$25<span class="text-sm font-normal text-bark/50">/mo</span></div>
+								<div class="font-serif text-foreground">Oak</div>
+								<div class="text-2xl font-sans font-bold text-accent-muted">$25<span class="text-sm font-normal text-foreground-faint">/mo</span></div>
 							</th>
 							<th class="py-4 px-4 text-center">
-								<div class="font-serif text-bark">Evergreen</div>
-								<div class="text-2xl font-sans font-bold text-grove-600">$35<span class="text-sm font-normal text-bark/50">/mo</span></div>
+								<div class="font-serif text-foreground">Evergreen</div>
+								<div class="text-2xl font-sans font-bold text-accent-muted">$35<span class="text-sm font-normal text-foreground-faint">/mo</span></div>
 							</th>
 						</tr>
 					</thead>
 					<tbody class="text-sm font-sans">
-						<tr class="border-b border-grove-100">
-							<td class="py-3 px-4 text-bark/70">Blog Posts</td>
-							<td class="py-3 px-4 text-center text-bark">50</td>
-							<td class="py-3 px-4 text-center text-bark">250</td>
-							<td class="py-3 px-4 text-center text-bark">Unlimited</td>
-							<td class="py-3 px-4 text-center text-bark">Unlimited</td>
+						<tr class="border-b border-subtle">
+							<td class="py-3 px-4 text-foreground-muted">Blog Posts</td>
+							<td class="py-3 px-4 text-center text-foreground">50</td>
+							<td class="py-3 px-4 text-center text-foreground">250</td>
+							<td class="py-3 px-4 text-center text-foreground">Unlimited</td>
+							<td class="py-3 px-4 text-center text-foreground">Unlimited</td>
 						</tr>
-						<tr class="border-b border-grove-100 bg-grove-50/30">
-							<td class="py-3 px-4 text-bark/70">Storage</td>
-							<td class="py-3 px-4 text-center text-bark">1 GB</td>
-							<td class="py-3 px-4 text-center text-bark">5 GB</td>
-							<td class="py-3 px-4 text-center text-bark">20 GB</td>
-							<td class="py-3 px-4 text-center text-bark">100 GB</td>
+						<tr class="border-b border-subtle bg-surface">
+							<td class="py-3 px-4 text-foreground-muted">Storage</td>
+							<td class="py-3 px-4 text-center text-foreground">1 GB</td>
+							<td class="py-3 px-4 text-center text-foreground">5 GB</td>
+							<td class="py-3 px-4 text-center text-foreground">20 GB</td>
+							<td class="py-3 px-4 text-center text-foreground">100 GB</td>
 						</tr>
-						<tr class="border-b border-grove-100">
-							<td class="py-3 px-4 text-bark/70">Meadow</td>
-							<td class="py-3 px-4 text-center text-grove-600">
+						<tr class="border-b border-subtle">
+							<td class="py-3 px-4 text-foreground-muted">Meadow</td>
+							<td class="py-3 px-4 text-center text-accent-muted">
 								<svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 								</svg>
 							</td>
-							<td class="py-3 px-4 text-center text-grove-600">
+							<td class="py-3 px-4 text-center text-accent-muted">
 								<svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 								</svg>
 							</td>
-							<td class="py-3 px-4 text-center text-grove-600">
+							<td class="py-3 px-4 text-center text-accent-muted">
 								<svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 								</svg>
 							</td>
-							<td class="py-3 px-4 text-center text-grove-600">
-								<svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-								</svg>
-							</td>
-						</tr>
-						<tr class="border-b border-grove-100 bg-grove-50/30">
-							<td class="py-3 px-4 text-bark/70">Custom Domain</td>
-							<td class="py-3 px-4 text-center text-bark/30">—</td>
-							<td class="py-3 px-4 text-center text-bark/30">—</td>
-							<td class="py-3 px-4 text-center text-bark">BYOD</td>
-							<td class="py-3 px-4 text-center text-grove-600">
+							<td class="py-3 px-4 text-center text-accent-muted">
 								<svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 								</svg>
 							</td>
 						</tr>
-						<tr class="border-b border-grove-100">
-							<td class="py-3 px-4 text-bark/70">@grove.place Email</td>
-							<td class="py-3 px-4 text-center text-bark/30">—</td>
-							<td class="py-3 px-4 text-center text-bark">Forward</td>
-							<td class="py-3 px-4 text-center text-bark">Full</td>
-							<td class="py-3 px-4 text-center text-bark">Full</td>
+						<tr class="border-b border-subtle bg-surface">
+							<td class="py-3 px-4 text-foreground-muted">Custom Domain</td>
+							<td class="py-3 px-4 text-center text-foreground-faint">—</td>
+							<td class="py-3 px-4 text-center text-foreground-faint">—</td>
+							<td class="py-3 px-4 text-center text-foreground">BYOD</td>
+							<td class="py-3 px-4 text-center text-accent-muted">
+								<svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+								</svg>
+							</td>
 						</tr>
-						<tr class="border-b border-grove-100 bg-grove-50/30">
-							<td class="py-3 px-4 text-bark/70">Support</td>
-							<td class="py-3 px-4 text-center text-bark">Community</td>
-							<td class="py-3 px-4 text-center text-bark">Email</td>
-							<td class="py-3 px-4 text-center text-bark">Priority</td>
-							<td class="py-3 px-4 text-center text-bark">8hrs + Priority</td>
+						<tr class="border-b border-subtle">
+							<td class="py-3 px-4 text-foreground-muted">@grove.place Email</td>
+							<td class="py-3 px-4 text-center text-foreground-faint">—</td>
+							<td class="py-3 px-4 text-center text-foreground">Forward</td>
+							<td class="py-3 px-4 text-center text-foreground">Full</td>
+							<td class="py-3 px-4 text-center text-foreground">Full</td>
 						</tr>
-						<tr class="border-b-2 border-grove-200">
-							<td class="py-3 px-4 text-bark/70 italic">Best for</td>
-							<td class="py-3 px-4 text-center text-bark/60 italic">Curious</td>
-							<td class="py-3 px-4 text-center text-bark/60 italic">Hobbyists</td>
-							<td class="py-3 px-4 text-center text-bark/60 italic">Serious Bloggers</td>
-							<td class="py-3 px-4 text-center text-bark/60 italic">Professionals</td>
+						<tr class="border-b border-subtle bg-surface">
+							<td class="py-3 px-4 text-foreground-muted">Support</td>
+							<td class="py-3 px-4 text-center text-foreground">Community</td>
+							<td class="py-3 px-4 text-center text-foreground">Email</td>
+							<td class="py-3 px-4 text-center text-foreground">Priority</td>
+							<td class="py-3 px-4 text-center text-foreground">8hrs + Priority</td>
+						</tr>
+						<tr class="border-b-2 border-default">
+							<td class="py-3 px-4 text-foreground-muted italic">Best for</td>
+							<td class="py-3 px-4 text-center text-foreground-subtle italic">Curious</td>
+							<td class="py-3 px-4 text-center text-foreground-subtle italic">Hobbyists</td>
+							<td class="py-3 px-4 text-center text-foreground-subtle italic">Serious Bloggers</td>
+							<td class="py-3 px-4 text-center text-foreground-subtle italic">Professionals</td>
 						</tr>
 						<tr>
-							<td class="py-4 px-4 text-bark/70">Yearly</td>
-							<td class="py-4 px-4 text-center font-medium text-grove-700">$82</td>
-							<td class="py-4 px-4 text-center font-medium text-grove-700">$122</td>
-							<td class="py-4 px-4 text-center font-medium text-grove-700">$255</td>
-							<td class="py-4 px-4 text-center font-medium text-grove-700">$357</td>
+							<td class="py-4 px-4 text-foreground-muted">Yearly</td>
+							<td class="py-4 px-4 text-center font-medium text-accent-muted">$82</td>
+							<td class="py-4 px-4 text-center font-medium text-accent-muted">$122</td>
+							<td class="py-4 px-4 text-center font-medium text-accent-muted">$255</td>
+							<td class="py-4 px-4 text-center font-medium text-accent-muted">$357</td>
 						</tr>
 					</tbody>
 				</table>
 			</div>
 
-			<p class="text-center text-sm text-bark/50 font-sans mb-12">
+			<p class="text-center text-sm text-foreground-faint font-sans mb-12">
 				Yearly plans save 15% — pay for 10 months, get 12.
 			</p>
 
 			<!-- Details Box -->
 			<div class="card p-8">
-				<h2 class="text-xl font-serif text-bark mb-6">The Fine Print</h2>
+				<h2 class="text-xl font-serif text-foreground mb-6">The Fine Print</h2>
 
-				<div class="space-y-6 text-sm font-sans text-bark/70">
+				<div class="space-y-6 text-sm font-sans text-foreground-muted">
 					<div>
-						<h3 class="font-medium text-bark mb-2">Custom Domains</h3>
+						<h3 class="font-medium text-foreground mb-2">Custom Domains</h3>
 						<p>
 							<strong>Oak (BYOD):</strong> Bring a domain you already own at no extra cost.
 							<strong>Evergreen:</strong> We find and register the perfect domain for you. Registration included for domains up to $100/year.
@@ -159,7 +152,7 @@
 					</div>
 
 					<div>
-						<h3 class="font-medium text-bark mb-2">@grove.place Email</h3>
+						<h3 class="font-medium text-foreground mb-2">@grove.place Email</h3>
 						<p>
 							<strong>Forward:</strong> Emails to you@grove.place forward to your personal inbox.
 							<strong>Full:</strong> Send and receive as you@grove.place — a professional email address included with your blog.
@@ -167,7 +160,7 @@
 					</div>
 
 					<div>
-						<h3 class="font-medium text-bark mb-2">Support Hours (Evergreen)</h3>
+						<h3 class="font-medium text-foreground mb-2">Support Hours (Evergreen)</h3>
 						<p>
 							Evergreen includes 8 hours of hands-on support in your first month — setup help, customization, whatever you need.
 							After that, priority email support with faster response times.
@@ -175,7 +168,7 @@
 					</div>
 
 					<div>
-						<h3 class="font-medium text-bark mb-2">What's Included in Every Tier</h3>
+						<h3 class="font-medium text-foreground mb-2">What's Included in Every Tier</h3>
 						<ul class="list-disc list-inside space-y-1 mt-2">
 							<li>Markdown blog posts with live preview</li>
 							<li>Image hosting with automatic WebP compression</li>
@@ -187,11 +180,11 @@
 						</ul>
 					</div>
 
-					<div class="pt-4 border-t border-grove-200">
-						<h3 class="font-medium text-bark mb-2">Your Data, Your Ownership</h3>
+					<div class="pt-4 border-t border-default">
+						<h3 class="font-medium text-foreground mb-2">Your Data, Your Ownership</h3>
 						<p>
 							Grove is designed around portability. Export everything at any time. If we ever register a domain for you, you own it — transfer it whenever you want, no fees, no questions.
-							See our <a href="/legal/data-portability" class="text-grove-600 hover:text-grove-700 underline">Data Portability Policy</a> for details.
+							See our <a href="/legal/data-portability" class="text-accent-muted hover:text-primary underline">Data Portability Policy</a> for details.
 						</p>
 					</div>
 				</div>
@@ -199,11 +192,11 @@
 
 			<!-- Contact -->
 			<div class="mt-12 text-center">
-				<p class="text-bark/60 font-sans text-sm mb-2">
+				<p class="text-foreground-subtle font-sans text-sm mb-2">
 					Need something beyond Evergreen? Multiple domains, team collaboration, white-label options?
 				</p>
-				<p class="text-bark font-sans">
-					<a href="mailto:autumn@grove.place" class="text-grove-600 hover:text-grove-700 underline">
+				<p class="font-sans">
+					<a href="mailto:autumn@grove.place" class="text-accent-muted hover:text-primary underline">
 						Let's talk.
 					</a>
 				</p>
@@ -211,16 +204,9 @@
 		</div>
 	</article>
 
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-4xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/vision" class="hover:text-grove-600 transition-colors">Vision</a>
-				<span class="text-grove-300">·</span>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</div>
-		</div>
-	</footer>
+	<Footer maxWidth="wide" />
 </main>
+
+<style>
+	.bg-divider { background-color: var(--color-divider); }
+</style>

--- a/landing/src/routes/vision/+page.svelte
+++ b/landing/src/routes/vision/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import EmailSignup from '$lib/components/EmailSignup.svelte';
+	import Header from '$lib/components/Header.svelte';
+	import Footer from '$lib/components/Footer.svelte';
 </script>
 
 <svelte:head>
@@ -8,53 +10,44 @@
 </svelte:head>
 
 <main class="min-h-screen flex flex-col">
-	<!-- Header -->
-	<header class="py-6 px-6 border-b border-grove-200">
-		<div class="max-w-3xl mx-auto flex items-center justify-between">
-			<a href="/" class="text-xl font-serif text-bark hover:text-grove-600 transition-colors">Grove</a>
-			<nav class="flex items-center gap-6 text-sm font-sans text-bark/60">
-				<a href="/pricing" class="hover:text-grove-600 transition-colors">Pricing</a>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</nav>
-		</div>
-	</header>
+	<Header />
 
 	<!-- Content -->
 	<article class="flex-1 px-6 py-12">
 		<div class="max-w-3xl mx-auto">
 			<!-- Vision Header -->
 			<header class="mb-12 text-center">
-				<p class="text-bark/50 font-sans text-sm uppercase tracking-wide mb-3">A Vision Document</p>
-				<h1 class="text-4xl md:text-5xl font-serif text-bark mb-6">Why This Exists</h1>
+				<p class="text-foreground-faint font-sans text-sm uppercase tracking-wide mb-3">A Vision Document</p>
+				<h1 class="text-4xl md:text-5xl font-serif text-foreground mb-6">Why This Exists</h1>
 				<div class="flex items-center justify-center gap-4">
-					<div class="w-12 h-px bg-grove-300"></div>
-					<svg class="w-4 h-4 text-grove-400" viewBox="0 0 20 20" fill="currentColor">
+					<div class="w-12 h-px bg-divider"></div>
+					<svg class="w-4 h-4 text-accent-subtle" viewBox="0 0 20 20" fill="currentColor">
 						<circle cx="10" cy="10" r="4" />
 					</svg>
-					<div class="w-12 h-px bg-grove-300"></div>
+					<div class="w-12 h-px bg-divider"></div>
 				</div>
 			</header>
 
 			<!-- Intro -->
 			<div class="prose prose-bark max-w-none">
-				<p class="text-lg text-bark/80 font-sans leading-relaxed mb-8">
+				<p class="text-lg text-foreground-muted font-sans leading-relaxed mb-8">
 					The internet used to be a place of personal expression. Geocities. Angelfire. Blogs with personality.
 					Somewhere along the way, we traded that for algorithms, engagement metrics, and platforms that own our words.
 				</p>
 
-				<p class="text-lg text-bark/80 font-sans leading-relaxed mb-12">
-					<strong class="text-grove-700">Grove.place is a return to something simpler.</strong> A place where people can plant their thoughts and watch them grow.
+				<p class="text-lg text-foreground-muted font-sans leading-relaxed mb-12">
+					<strong class="text-accent-muted">Grove.place is a return to something simpler.</strong> A place where people can plant their thoughts and watch them grow.
 					No ads. No tracking. No algorithmic feeds deciding who sees what. Just writers and readers, meeting in a digital grove.
 				</p>
 
 				<!-- The Vision -->
 				<section class="mb-12">
-					<h2 class="text-2xl font-serif text-bark mb-4">The Vision</h2>
-					<p class="text-bark/70 font-sans leading-relaxed">
+					<h2 class="text-2xl font-serif text-foreground mb-4">The Vision</h2>
+					<p class="text-foreground-muted font-sans leading-relaxed">
 						<em>A forest of voices.</em> Every user is a tree in the grove. Some are saplings just starting out.
 						Some are ancient oaks with deep roots. All are welcome. All have space to grow.
 					</p>
-					<p class="text-bark/70 font-sans leading-relaxed mt-4">
+					<p class="text-foreground-muted font-sans leading-relaxed mt-4">
 						The platform should feel like walking through a peaceful forest at golden hour. Calm. Intentional.
 						A refuge from the noise of social media.
 					</p>
@@ -62,36 +55,36 @@
 
 				<!-- Core Values -->
 				<section class="mb-12">
-					<h2 class="text-2xl font-serif text-bark mb-6">Core Values</h2>
+					<h2 class="text-2xl font-serif text-foreground mb-6">Core Values</h2>
 
 					<div class="grid gap-6">
 						<div class="card p-6">
-							<h3 class="text-lg font-serif text-grove-700 mb-2">Accessibility</h3>
-							<p class="text-bark/70 font-sans leading-relaxed">
+							<h3 class="text-lg font-serif text-accent-muted mb-2">Accessibility</h3>
+							<p class="text-foreground-muted font-sans leading-relaxed">
 								Everyone deserves a voice online. Pricing should never be the barrier that stops someone from sharing their story.
 								The basic tier exists so that anyone who wants to write can afford to write.
 							</p>
 						</div>
 
 						<div class="card p-6">
-							<h3 class="text-lg font-serif text-grove-700 mb-2">Ownership</h3>
-							<p class="text-bark/70 font-sans leading-relaxed">
+							<h3 class="text-lg font-serif text-accent-muted mb-2">Ownership</h3>
+							<p class="text-foreground-muted font-sans leading-relaxed">
 								Your words are yours. Your data is yours. You can export everything, anytime.
 								If you leave, you take your roots with you.
 							</p>
 						</div>
 
 						<div class="card p-6">
-							<h3 class="text-lg font-serif text-grove-700 mb-2">Simplicity</h3>
-							<p class="text-bark/70 font-sans leading-relaxed">
+							<h3 class="text-lg font-serif text-accent-muted mb-2">Simplicity</h3>
+							<p class="text-foreground-muted font-sans leading-relaxed">
 								No feature bloat. No endless settings. Write in Markdown. Upload images. Publish. That's it.
 								The technology should disappear into the background.
 							</p>
 						</div>
 
 						<div class="card p-6">
-							<h3 class="text-lg font-serif text-grove-700 mb-2">Community Without Toxicity</h3>
-							<p class="text-bark/70 font-sans leading-relaxed">
+							<h3 class="text-lg font-serif text-accent-muted mb-2">Community Without Toxicity</h3>
+							<p class="text-foreground-muted font-sans leading-relaxed">
 								Intentionally queer-friendly. Welcoming to all. No engagement metrics breeding outrage.
 								No viral mechanics rewarding the loudest voice. Just people, sharing what matters to them.
 							</p>
@@ -101,63 +94,63 @@
 
 				<!-- Meadow Section -->
 				<section class="mb-12">
-					<h2 class="text-2xl font-serif text-bark mb-4">On Community — Meadow</h2>
+					<h2 class="text-2xl font-serif text-foreground mb-4">On Community — Meadow</h2>
 
-					<div class="bg-grove-50 border border-grove-200 rounded-xl p-6 mb-6">
-						<p class="text-bark/80 font-sans leading-relaxed italic">
+					<div class="bg-accent border border-accent rounded-xl p-6 mb-6">
+						<p class="text-foreground-muted font-sans leading-relaxed italic">
 							A forest is not a collection of isolated trees.
 						</p>
-						<p class="text-bark/70 font-sans leading-relaxed mt-4">
+						<p class="text-foreground-muted font-sans leading-relaxed mt-4">
 							Beneath the surface, roots intermingle. Trees share nutrients through mycorrhizal networks —
 							the "wood wide web" that connects an entire forest into a single living organism.
 							The oldest trees nurture the saplings. The seasonal cycles nourish new growth.
 						</p>
 					</div>
 
-					<p class="text-bark/70 font-sans leading-relaxed mb-6">
-						<strong class="text-grove-700">Meadow is the roots.</strong> It's optional. Your blog exists independently, complete on its own.
+					<p class="text-foreground-muted font-sans leading-relaxed mb-6">
+						<strong class="text-accent-muted">Meadow is the roots.</strong> It's optional. Your blog exists independently, complete on its own.
 						But if you choose, you can connect — follow friends, see their posts in a simple chronological feed,
 						leave reactions that only they can see.
 					</p>
 
-					<h3 class="text-lg font-serif text-bark mb-4">What Makes This Different</h3>
-					<ul class="space-y-3 text-bark/70 font-sans">
+					<h3 class="text-lg font-serif text-foreground mb-4">What Makes This Different</h3>
+					<ul class="space-y-3 text-foreground-muted font-sans">
 						<li class="flex items-start gap-3">
-							<span class="text-grove-600 mt-1">•</span>
+							<span class="text-accent-muted mt-1">•</span>
 							<span><strong>No public metrics.</strong> Follower counts aren't displayed. Like counts don't create hierarchies. Your worth isn't measured by engagement.</span>
 						</li>
 						<li class="flex items-start gap-3">
-							<span class="text-grove-600 mt-1">•</span>
+							<span class="text-accent-muted mt-1">•</span>
 							<span><strong>No algorithm.</strong> The feed is chronological. Your friends' posts appear in order. Nothing is hidden or boosted based on "engagement potential."</span>
 						</li>
 						<li class="flex items-start gap-3">
-							<span class="text-grove-600 mt-1">•</span>
+							<span class="text-accent-muted mt-1">•</span>
 							<span><strong>Private encouragement.</strong> Reactions and comments are visible to the author only. Feedback becomes encouragement, not performance.</span>
 						</li>
 						<li class="flex items-start gap-3">
-							<span class="text-grove-600 mt-1">•</span>
+							<span class="text-accent-muted mt-1">•</span>
 							<span><strong>Full control.</strong> Want to see friends' posts but disable interactions on yours? Fine. Want to hide from discovery entirely? Fine. Every setting is yours to configure.</span>
 						</li>
 						<li class="flex items-start gap-3">
-							<span class="text-grove-600 mt-1">•</span>
+							<span class="text-accent-muted mt-1">•</span>
 							<span><strong>Built on open standards.</strong> Your blog isn't locked into Grove. The connections between blogs use the same portable technology that powers podcasts and news readers. If you ever leave, your followers can still follow you wherever you go.</span>
 						</li>
 					</ul>
 				</section>
 
 				<!-- Closing -->
-				<section class="text-center py-8 border-t border-grove-200">
-					<p class="text-bark/60 font-sans italic mb-2">
+				<section class="text-center py-8 border-t border-default">
+					<p class="text-foreground-subtle font-sans italic mb-2">
 						Encouragement without performance. Connection without competition.
 					</p>
-					<p class="text-grove-700 font-serif text-lg">
+					<p class="text-accent-muted font-serif text-lg">
 						A forest of voices. A place to be.
 					</p>
 				</section>
 
 				<!-- Call to Action -->
 				<section class="text-center py-8">
-					<p class="text-bark/70 font-sans leading-relaxed mb-6">
+					<p class="text-foreground-muted font-sans leading-relaxed mb-6">
 						We're not open yet, but we're growing.<br />
 						Leave your email to join us when Grove blooms.
 					</p>
@@ -169,16 +162,9 @@
 		</div>
 	</article>
 
-	<!-- Footer -->
-	<footer class="py-8 border-t border-grove-200">
-		<div class="max-w-3xl mx-auto px-6">
-			<div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50">
-				<a href="/" class="hover:text-grove-600 transition-colors">Home</a>
-				<span class="text-grove-300">·</span>
-				<a href="/pricing" class="hover:text-grove-600 transition-colors">Pricing</a>
-				<span class="text-grove-300">·</span>
-				<a href="/legal" class="hover:text-grove-600 transition-colors">Legal</a>
-			</div>
-		</div>
-	</footer>
+	<Footer />
 </main>
+
+<style>
+	.bg-divider { background-color: var(--color-divider); }
+</style>

--- a/landing/tailwind.config.js
+++ b/landing/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
+	darkMode: 'class',
 	theme: {
 		extend: {
 			colors: {


### PR DESCRIPTION
- Add theme store with dark mode default for first visits
- Create ThemeToggle component with sun/moon icons in footer
- Unify Header and Footer components across all landing pages
- Convert all pages to use CSS custom properties for theming
- Add comprehensive light/dark mode color tokens in app.css
- Create LegalLayout component for consistent legal page styling

Theme preference persists to localStorage and updates live
without page reload.