### PR TITLE
fix(landing): address theme toggle PR feedback

### DIFF
--- a/landing/src/app.css
+++ b/landing/src/app.css
@@ -163,6 +163,10 @@
 	}
 
 	body {
+		/* Fallbacks for older browsers without CSS custom property support */
+		background-color: #1a1915;
+		color: #f5f2ea;
+		/* Modern browsers use CSS variables */
 		background-color: var(--color-background);
 		color: var(--color-foreground);
 		-webkit-font-smoothing: antialiased;
@@ -231,7 +235,10 @@
    ═══════════════════════════════════════════════════════════════ */
 
 /* Text color utilities using CSS variables */
-.text-foreground { color: var(--color-foreground); }
+.text-foreground {
+	color: #f5f2ea; /* Fallback for older browsers */
+	color: var(--color-foreground);
+}
 .text-foreground-muted { color: var(--color-foreground-muted); }
 .text-foreground-subtle { color: var(--color-foreground-subtle); }
 .text-foreground-faint { color: var(--color-foreground-faint); }

--- a/landing/src/app.html
+++ b/landing/src/app.html
@@ -1,6 +1,19 @@
 <!doctype html>
 <html lang="en">
 	<head>
+		<!-- Blocking script to prevent FOUC (flash of unstyled content) -->
+		<script>
+			try {
+				const stored = localStorage.getItem('grove-theme');
+				// Default to dark if no stored preference (matches theme store default)
+				if (stored === 'dark' || !stored) {
+					document.documentElement.classList.add('dark');
+				}
+			} catch (e) {
+				// localStorage unavailable, default to dark
+				document.documentElement.classList.add('dark');
+			}
+		</script>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/landing/src/lib/stores/theme.ts
+++ b/landing/src/lib/stores/theme.ts
@@ -2,6 +2,13 @@
  * Theme Store for Grove Landing
  * Manages light/dark theme preferences
  * Defaults to dark on first visit, remembers user choice thereafter
+ *
+ * Note: This is a global singleton store. The subscription created in
+ * createThemeStore() intentionally persists for the application lifetime.
+ * This is safe because:
+ * 1. The store module is only executed once per page load
+ * 2. SvelteKit's SPA navigation doesn't re-execute module-level code
+ * 3. The subscription is required to sync localStorage with theme changes
  */
 
 import { writable, get } from 'svelte/store';
@@ -38,7 +45,7 @@ function createThemeStore() {
 	if (browser) {
 		applyTheme(get(theme));
 
-		// Subscribe to changes
+		// Global subscription - intentionally never unsubscribed (see module docstring)
 		theme.subscribe((t) => {
 			applyTheme(t);
 			localStorage.setItem(STORAGE_KEY, t);


### PR DESCRIPTION
- Add blocking script in app.html to prevent FOUC (flash of unstyled
  content) by applying dark class before first paint
- Document intentional global subscription pattern in theme store
- Add CSS fallbacks for critical custom properties (body and
  .text-foreground) for older browser compatibility