### PR TITLE
fix(landing): polish assets and fix dark mode in Asset Viewer

### DIFF
--- a/landing/src/lib/components/nature/creatures/Bird.svelte
+++ b/landing/src/lib/components/nature/creatures/Bird.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { bark, earth, accents } from '../palette';
+	import { bark, accents } from '../palette';
 
 	interface Props {
 		class?: string;
@@ -19,54 +19,71 @@
 		facing = 'right'
 	}: Props = $props();
 
-	const body = bodyColor ?? bark.bark;
-	const breast = breastColor ?? earth.clay;
-	const beak = beakColor ?? accents.flower.yellow;
+	// American Robin colors
+	const body = bodyColor ?? '#4a4a4a'; // Dark gray-brown upper body
+	const breast = breastColor ?? '#c2410c'; // Bright orange-red breast (amber-600)
+	const beak = beakColor ?? '#f59e0b'; // Yellow-orange beak
+	const legColor = bark.darkBark;
 
 	const scaleX = facing === 'left' ? -1 : 1;
 </script>
 
-<!-- Perched bird -->
+<!-- American Robin - perched -->
 <svg
 	class="{className} {animate ? 'bob' : ''}"
 	xmlns="http://www.w3.org/2000/svg"
-	viewBox="0 0 50 50"
+	viewBox="0 0 50 55"
 	style="transform: scaleX({scaleX})"
 >
-	<!-- Tail feathers -->
-	<path fill={body} d="M5 28 Q0 32 2 38 Q8 36 12 30 Q8 28 5 28" />
+	<!-- Tail feathers - dark -->
+	<path fill={body} d="M2 30 Q0 34 3 40 Q10 38 14 32 Q8 30 2 30" />
 
-	<!-- Body -->
-	<ellipse fill={body} cx="22" cy="30" rx="15" ry="12" />
+	<!-- Body - dark gray back -->
+	<ellipse fill={body} cx="22" cy="30" rx="14" ry="11" />
 
-	<!-- Wing -->
-	<path fill={bark.darkBark} d="M15 25 Q10 30 12 38 Q20 36 25 28 Q20 24 15 25" opacity="0.7" />
+	<!-- Wing detail - slightly darker -->
+	<path fill="#3a3a3a" d="M12 26 Q8 32 11 38 Q18 36 22 30 Q17 25 12 26" opacity="0.8" />
 
-	<!-- Breast -->
-	<ellipse fill={breast} cx="28" cy="32" rx="8" ry="9" />
+	<!-- Orange-red breast - signature robin color -->
+	<ellipse fill={breast} cx="30" cy="33" rx="9" ry="10" />
+	<!-- Breast highlight -->
+	<ellipse fill={breast} cx="31" cy="31" rx="6" ry="6" opacity="0.9" />
 
-	<!-- Head -->
-	<circle fill={body} cx="35" cy="20" r="10" />
+	<!-- White lower belly -->
+	<ellipse fill="#f5f5f5" cx="30" cy="42" rx="5" ry="3" opacity="0.8" />
 
+	<!-- Head - dark gray -->
+	<circle fill={body} cx="36" cy="20" r="10" />
+
+	<!-- White eye-ring (robin signature) -->
+	<circle fill="white" cx="40" cy="18" r="3.5" />
 	<!-- Eye -->
-	<circle fill="white" cx="38" cy="18" r="3" />
-	<circle fill={bark.darkBark} cx="39" cy="18" r="1.5" />
+	<circle fill="#1a1a1a" cx="40" cy="18" r="2" />
+	<!-- Eye highlight -->
+	<circle fill="white" cx="41" cy="17" r="0.7" />
 
-	<!-- Beak -->
-	<path fill={beak} d="M44 20 L50 22 L44 24 Z" />
+	<!-- White crescent below eye -->
+	<path fill="white" d="M38 22 Q40 23 42 22 Q41 24 39 24 Q38 23 38 22" opacity="0.6" />
 
-	<!-- Legs -->
-	<path fill="none" stroke={bark.warmBark} stroke-width="1.5" d="M20 42 L20 50 M18 48 L22 48" />
-	<path fill="none" stroke={bark.warmBark} stroke-width="1.5" d="M28 42 L28 50 M26 48 L30 48" />
+	<!-- Beak - yellow-orange -->
+	<path fill={beak} d="M45 20 L52 22 L45 24 Z" />
+	<!-- Beak detail line -->
+	<line x1="45" y1="22" x2="50" y2="22" stroke="#b45309" stroke-width="0.5" />
+
+	<!-- Legs - dark -->
+	<g fill="none" stroke={legColor} stroke-width="1.5">
+		<path d="M22 41 L22 50 M20 48 L24 48" />
+		<path d="M28 41 L28 50 M26 48 L30 48" />
+	</g>
 </svg>
 
 <style>
 	@keyframes bob {
 		0%, 100% { transform: translateY(0); }
-		50% { transform: translateY(-2px); }
+		50% { transform: translateY(-1.5px); }
 	}
 
 	.bob {
-		animation: bob 1.5s ease-in-out infinite;
+		animation: bob 2s ease-in-out infinite;
 	}
 </style>

--- a/landing/src/lib/components/nature/ground/Rock.svelte
+++ b/landing/src/lib/components/nature/ground/Rock.svelte
@@ -18,21 +18,37 @@
 	const shadowColor = earth.slate;
 </script>
 
-<!-- Rock/stone -->
+<!-- Rock/stone - matte natural appearance -->
 <svg class={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 40">
 	{#if variant === 'round'}
-		<!-- Rounded boulder -->
-		<ellipse fill={rockColor} cx="30" cy="25" rx="28" ry="15" />
-		<ellipse fill={highlightColor} cx="24" cy="20" rx="10" ry="6" opacity="0.4" />
-		<ellipse fill={shadowColor} cx="38" cy="30" rx="12" ry="5" opacity="0.3" />
+		<!-- Rounded boulder with natural matte finish -->
+		<ellipse fill={rockColor} cx="30" cy="26" rx="27" ry="14" />
+		<!-- Subtle surface variation instead of shiny highlight -->
+		<ellipse fill={highlightColor} cx="22" cy="22" rx="8" ry="4" opacity="0.15" />
+		<ellipse fill={highlightColor} cx="35" cy="20" rx="5" ry="3" opacity="0.1" />
+		<!-- Darker underside shadow -->
+		<ellipse fill={shadowColor} cx="30" cy="32" rx="20" ry="5" opacity="0.15" />
+		<!-- Surface texture marks -->
+		<path fill={shadowColor} d="M18 24 Q20 26 22 24" opacity="0.12" stroke={shadowColor} stroke-width="0.5" />
+		<path fill={shadowColor} d="M38 22 Q40 24 42 23" opacity="0.1" stroke={shadowColor} stroke-width="0.5" />
 	{:else if variant === 'flat'}
-		<!-- Flat stepping stone -->
-		<ellipse fill={rockColor} cx="30" cy="28" rx="28" ry="12" />
-		<ellipse fill={highlightColor} cx="25" cy="25" rx="15" ry="6" opacity="0.3" />
+		<!-- Flat stepping stone with weathered look -->
+		<ellipse fill={rockColor} cx="30" cy="28" rx="27" ry="11" />
+		<!-- Subtle worn surface -->
+		<ellipse fill={highlightColor} cx="24" cy="26" rx="12" ry="4" opacity="0.12" />
+		<ellipse fill={highlightColor} cx="38" cy="25" rx="6" ry="3" opacity="0.08" />
+		<!-- Surface cracks/weathering -->
+		<path fill="none" stroke={shadowColor} stroke-width="0.5" d="M20 28 L28 27" opacity="0.15" />
+		<path fill="none" stroke={shadowColor} stroke-width="0.5" d="M35 29 L40 28" opacity="0.12" />
 	{:else}
-		<!-- Jagged rock -->
-		<polygon fill={rockColor} points="5,40 15,20 25,35 35,10 45,25 55,15 58,40" />
-		<polygon fill={highlightColor} points="15,20 25,35 35,10 30,18 22,28" opacity="0.3" />
-		<polygon fill={shadowColor} points="35,10 45,25 55,15 58,40 45,40 40,30" opacity="0.3" />
+		<!-- Jagged rock with rough texture -->
+		<polygon fill={rockColor} points="5,40 15,22 28,38 38,12 48,28 55,18 58,40" />
+		<!-- Muted face highlights -->
+		<polygon fill={highlightColor} points="15,22 28,38 38,12 32,20 24,32" opacity="0.12" />
+		<!-- Shadowed face -->
+		<polygon fill={shadowColor} points="38,12 48,28 55,18 58,40 48,38 44,25" opacity="0.15" />
+		<!-- Surface texture -->
+		<path fill="none" stroke={shadowColor} stroke-width="0.5" d="M22 30 L26 28" opacity="0.15" />
+		<path fill="none" stroke={shadowColor} stroke-width="0.5" d="M42 25 L46 28" opacity="0.12" />
 	{/if}
 </svg>

--- a/landing/src/lib/components/nature/sky/CloudWispy.svelte
+++ b/landing/src/lib/components/nature/sky/CloudWispy.svelte
@@ -7,7 +7,7 @@
 	}
 
 	let {
-		class: className = 'w-20 h-4',
+		class: className = 'w-20 h-6',
 		color = 'white',
 		animate = true,
 		speed = 'slow'
@@ -20,31 +20,50 @@
 	}[speed];
 </script>
 
-<!-- Thin wispy cloud / cirrus -->
+<!-- Thin wispy cirrus cloud -->
 <svg
 	class="{className} {animate ? 'drift' : ''}"
 	xmlns="http://www.w3.org/2000/svg"
-	viewBox="0 0 120 25"
+	viewBox="0 0 120 30"
 	style="--drift-duration: {duration}"
 >
-	<g opacity="0.6">
-		<!-- Wispy strands -->
-		<path
-			fill={color}
-			d="M0 15 Q20 10 40 14 Q60 8 80 12 Q100 6 120 10 L120 14 Q95 10 75 16 Q55 12 35 18 Q15 14 0 18 Z"
-		/>
-		<path
-			fill={color}
-			d="M10 8 Q30 5 50 9 Q70 3 90 7 Q110 2 115 6 L112 10 Q88 6 68 11 Q48 5 28 12 Q12 8 10 12 Z"
-			opacity="0.7"
-		/>
+	<!-- Main wispy cloud body - soft feathery shapes -->
+	<g opacity="0.5">
+		<!-- Central wisp strand with soft cloud-like bulges -->
+		<ellipse fill={color} cx="60" cy="15" rx="50" ry="4" opacity="0.4" />
+
+		<!-- Feathery tendrils extending from main body -->
+		<ellipse fill={color} cx="25" cy="13" rx="18" ry="5" opacity="0.5" />
+		<ellipse fill={color} cx="50" cy="11" rx="15" ry="4" opacity="0.45" />
+		<ellipse fill={color} cx="75" cy="14" rx="20" ry="5" opacity="0.5" />
+		<ellipse fill={color} cx="100" cy="12" rx="15" ry="4" opacity="0.4" />
+
+		<!-- Upper wisps -->
+		<ellipse fill={color} cx="35" cy="8" rx="12" ry="3" opacity="0.35" />
+		<ellipse fill={color} cx="65" cy="7" rx="10" ry="3" opacity="0.3" />
+		<ellipse fill={color} cx="90" cy="9" rx="14" ry="3" opacity="0.35" />
+
+		<!-- Lower tendrils for depth -->
+		<ellipse fill={color} cx="40" cy="18" rx="10" ry="2.5" opacity="0.3" />
+		<ellipse fill={color} cx="70" cy="19" rx="12" ry="3" opacity="0.35" />
+		<ellipse fill={color} cx="95" cy="17" rx="8" ry="2" opacity="0.25" />
+
+		<!-- Fine wispy edges -->
+		<ellipse fill={color} cx="15" cy="14" rx="8" ry="2" opacity="0.25" />
+		<ellipse fill={color} cx="110" cy="13" rx="8" ry="2" opacity="0.25" />
+	</g>
+
+	<!-- Secondary wisp layer for more depth -->
+	<g opacity="0.35">
+		<ellipse fill={color} cx="45" cy="20" rx="25" ry="3" opacity="0.4" />
+		<ellipse fill={color} cx="80" cy="6" rx="20" ry="2.5" opacity="0.35" />
 	</g>
 </svg>
 
 <style>
 	@keyframes drift {
 		0% { transform: translateX(0); }
-		100% { transform: translateX(30px); }
+		100% { transform: translateX(20px); }
 	}
 
 	.drift {

--- a/landing/src/lib/components/nature/structural/Lantern.svelte
+++ b/landing/src/lib/components/nature/structural/Lantern.svelte
@@ -24,23 +24,33 @@
 <!-- Lantern -->
 <svg class={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 60">
 	{#if variant === 'hanging'}
-		<!-- Hanging hook -->
-		<path fill="none" stroke={frame} stroke-width="2" d="M20 0 Q20 5 15 8 L15 12" />
-		<path fill="none" stroke={frame} stroke-width="2" d="M20 0 Q20 5 25 8 L25 12" />
+		<!-- Top finial (attachment point) -->
+		<circle fill={frame} cx="20" cy="3" r="2.5" />
 
-		<!-- Lantern top -->
-		<polygon fill={frame} points="10,12 20,5 30,12" />
+		<!-- Hanging arms connecting finial to lantern roof -->
+		<path fill="none" stroke={frame} stroke-width="2" d="M17.5 3.5 Q12 7 12 12" />
+		<path fill="none" stroke={frame} stroke-width="2" d="M22.5 3.5 Q28 7 28 12" />
+
+		<!-- Lantern top cap -->
+		<polygon fill={frame} points="10,12 20,6 30,12" />
+
+		<!-- Small decorative cap finial connecting to arms -->
+		<circle fill={frame} cx="20" cy="6" r="1.5" />
 	{:else if variant === 'post'}
 		<!-- Post -->
 		<rect fill={frame} x="17" y="40" width="6" height="20" />
+		<!-- Top finial -->
+		<circle fill={frame} cx="20" cy="9" r="2" />
 		<!-- Lantern top -->
-		<polygon fill={frame} points="10,18 20,10 30,18" />
+		<polygon fill={frame} points="10,18 20,11 30,18" />
 	{:else}
 		<!-- Standing base -->
 		<rect fill={frame} x="12" y="52" width="16" height="4" rx="1" />
 		<rect fill={frame} x="17" y="48" width="6" height="6" />
+		<!-- Top finial -->
+		<circle fill={frame} cx="20" cy="9" r="2" />
 		<!-- Lantern top -->
-		<polygon fill={frame} points="10,18 20,10 30,18" />
+		<polygon fill={frame} points="10,18 20,11 30,18" />
 	{/if}
 
 	<!-- Lantern body frame -->
@@ -63,9 +73,6 @@
 
 	<!-- Bottom cap -->
 	<rect fill={frame} x="8" y="48" width="24" height="3" rx="1" />
-
-	<!-- Top finial -->
-	<circle fill={frame} cx="20" cy="8" r="2" />
 </svg>
 
 <style>

--- a/landing/src/lib/components/nature/trees/TreeAspen.svelte
+++ b/landing/src/lib/components/nature/trees/TreeAspen.svelte
@@ -19,106 +19,113 @@
 	}: Props = $props();
 
 	// Aspen turns brilliant gold/yellow in autumn
-	// Trees use 'currentColor' for summer to allow CSS inheritance (e.g., themed containers)
-	// This is intentional for consistency with Logo component and backward compatibility
 	const defaultColor = season === 'autumn' ? autumn.gold : 'currentColor';
 	const foliageColor = color ?? defaultColor;
 
 	// Aspen bark is pale cream/greenish-white with dark marks
 	const actualTrunkColor = trunkColor ?? '#e8e4d9';
 	const barkMarkColor = '#4a4a4a';
+
+	// Slightly darker shade for leaf depth
+	const leafShadow = season === 'autumn' ? autumn.amber : greens.grove;
 </script>
 
-<!-- Aspen tree - slender trunk with quivering round leaves -->
+<!-- Aspen tree - slender trunk with quivering round/heart-shaped leaves -->
 <svg class={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 140">
 	<!-- Trunk - slender with characteristic bark marks -->
-	<rect fill={actualTrunkColor} x="44" y="55" width="12" height="85" rx="2" />
+	<rect fill={actualTrunkColor} x="46" y="60" width="8" height="80" rx="2" />
 
 	<!-- Bark marks (aspen "eyes") -->
-	<ellipse fill={barkMarkColor} cx="48" cy="75" rx="2" ry="1" />
-	<ellipse fill={barkMarkColor} cx="52" cy="95" rx="2.5" ry="1" />
-	<ellipse fill={barkMarkColor} cx="47" cy="115" rx="2" ry="1" />
+	<ellipse fill={barkMarkColor} cx="49" cy="78" rx="2" ry="1" opacity="0.6" />
+	<ellipse fill={barkMarkColor} cx="51" cy="98" rx="2.5" ry="1" opacity="0.5" />
+	<ellipse fill={barkMarkColor} cx="48" cy="118" rx="2" ry="1" opacity="0.6" />
 
 	<!-- Upper branches hint -->
-	<path
-		fill={actualTrunkColor}
-		d="M50 55 Q42 50 35 52 Q40 48 44 45 Q47 48 50 50"
-	/>
-	<path
-		fill={actualTrunkColor}
-		d="M50 55 Q58 50 65 52 Q60 48 56 45 Q53 48 50 50"
-	/>
+	<path fill={actualTrunkColor} d="M50 60 Q44 55 38 58 L42 52 Q47 54 50 55 Z" />
+	<path fill={actualTrunkColor} d="M50 60 Q56 55 62 58 L58 52 Q53 54 50 55 Z" />
 
-	<!-- Leaf clusters - round/heart-shaped aspen leaves -->
-	<!-- Each cluster gets the quiver animation with slight delay variation -->
+	<!-- Individual aspen leaves - round/heart shaped with pointed tips -->
+	<!-- Each group quivers independently like real aspen leaves -->
 
-	<!-- Left side leaves -->
+	<!-- Left branch cluster -->
 	<g class={animate ? 'quiver quiver-1' : ''}>
-		<ellipse fill={foliageColor} cx="28" cy="38" rx="10" ry="9" />
-		<ellipse fill={foliageColor} cx="22" cy="28" rx="8" ry="7" />
-		<ellipse fill={foliageColor} cx="18" cy="42" rx="7" ry="6" />
+		<!-- Individual leaf shapes (teardrop/heart) -->
+		<path fill={foliageColor} d="M22 40 Q18 35 22 28 Q26 35 22 40 Z" />
+		<path fill={foliageColor} d="M28 32 Q24 27 28 20 Q32 27 28 32 Z" />
+		<path fill={foliageColor} d="M18 32 Q14 27 18 22 Q22 27 18 32 Z" />
+		<path fill={foliageColor} d="M25 45 Q21 40 25 35 Q29 40 25 45 Z" />
+		<path fill={foliageColor} d="M16 42 Q12 37 16 32 Q20 37 16 42 Z" />
 	</g>
 
 	<g class={animate ? 'quiver quiver-2' : ''}>
-		<ellipse fill={foliageColor} cx="35" cy="22" rx="9" ry="8" />
-		<ellipse fill={foliageColor} cx="28" cy="12" rx="7" ry="6" />
+		<path fill={foliageColor} d="M32 28 Q28 23 32 16 Q36 23 32 28 Z" />
+		<path fill={foliageColor} d="M26 18 Q22 13 26 8 Q30 13 26 18 Z" />
+		<path fill={foliageColor} d="M35 38 Q31 33 35 28 Q39 33 35 38 Z" />
+		<path fill={foliageColor} d="M22 12 Q18 7 22 2 Q26 7 22 12 Z" />
 	</g>
 
-	<!-- Center leaves -->
+	<!-- Center top cluster -->
 	<g class={animate ? 'quiver quiver-3' : ''}>
-		<ellipse fill={foliageColor} cx="50" cy="15" rx="12" ry="10" />
-		<ellipse fill={foliageColor} cx="50" cy="5" rx="8" ry="6" />
+		<path fill={foliageColor} d="M50 18 Q46 12 50 5 Q54 12 50 18 Z" />
+		<path fill={foliageColor} d="M44 22 Q40 16 44 10 Q48 16 44 22 Z" />
+		<path fill={foliageColor} d="M56 22 Q52 16 56 10 Q60 16 56 22 Z" />
+		<path fill={foliageColor} d="M50 28 Q46 22 50 16 Q54 22 50 28 Z" />
+		<path fill={foliageColor} d="M42 32 Q38 26 42 20 Q46 26 42 32 Z" />
+		<path fill={foliageColor} d="M58 32 Q54 26 58 20 Q62 26 58 32 Z" />
 	</g>
 
+	<!-- Center middle cluster -->
 	<g class={animate ? 'quiver quiver-1' : ''}>
-		<ellipse fill={foliageColor} cx="50" cy="32" rx="11" ry="9" />
-		<ellipse fill={foliageColor} cx="45" cy="45" rx="8" ry="7" />
-		<ellipse fill={foliageColor} cx="55" cy="45" rx="8" ry="7" />
+		<path fill={foliageColor} d="M50 38 Q46 32 50 26 Q54 32 50 38 Z" />
+		<path fill={foliageColor} d="M44 45 Q40 39 44 33 Q48 39 44 45 Z" />
+		<path fill={foliageColor} d="M56 45 Q52 39 56 33 Q60 39 56 45 Z" />
+		<path fill={foliageColor} d="M48 52 Q44 46 48 40 Q52 46 48 52 Z" />
+		<path fill={foliageColor} d="M52 52 Q48 46 52 40 Q56 46 52 52 Z" />
 	</g>
 
-	<!-- Right side leaves -->
+	<!-- Right branch cluster -->
 	<g class={animate ? 'quiver quiver-2' : ''}>
-		<ellipse fill={foliageColor} cx="72" cy="38" rx="10" ry="9" />
-		<ellipse fill={foliageColor} cx="78" cy="28" rx="8" ry="7" />
-		<ellipse fill={foliageColor} cx="82" cy="42" rx="7" ry="6" />
+		<path fill={foliageColor} d="M78 40 Q74 35 78 28 Q82 35 78 40 Z" />
+		<path fill={foliageColor} d="M72 32 Q68 27 72 20 Q76 27 72 32 Z" />
+		<path fill={foliageColor} d="M82 32 Q78 27 82 22 Q86 27 82 32 Z" />
+		<path fill={foliageColor} d="M75 45 Q71 40 75 35 Q79 40 75 45 Z" />
+		<path fill={foliageColor} d="M84 42 Q80 37 84 32 Q88 37 84 42 Z" />
 	</g>
 
 	<g class={animate ? 'quiver quiver-3' : ''}>
-		<ellipse fill={foliageColor} cx="65" cy="22" rx="9" ry="8" />
-		<ellipse fill={foliageColor} cx="72" cy="12" rx="7" ry="6" />
+		<path fill={foliageColor} d="M68 28 Q64 23 68 16 Q72 23 68 28 Z" />
+		<path fill={foliageColor} d="M74 18 Q70 13 74 8 Q78 13 74 18 Z" />
+		<path fill={foliageColor} d="M65 38 Q61 33 65 28 Q69 33 65 38 Z" />
+		<path fill={foliageColor} d="M78 12 Q74 7 78 2 Q82 7 78 12 Z" />
 	</g>
 </svg>
 
 <style>
 	/* Aspen leaves famously "quiver" in the slightest breeze */
 	@keyframes quiver {
-		0%,
-		100% {
+		0%, 100% {
 			transform: rotate(0deg) translateX(0);
 		}
-		25% {
-			transform: rotate(0.5deg) translateX(0.3px);
+		20% {
+			transform: rotate(0.8deg) translateX(0.4px);
 		}
-		50% {
-			transform: rotate(-0.5deg) translateX(-0.3px);
+		40% {
+			transform: rotate(-0.6deg) translateX(-0.3px);
 		}
-		75% {
-			transform: rotate(0.3deg) translateX(0.2px);
+		60% {
+			transform: rotate(0.5deg) translateX(0.2px);
+		}
+		80% {
+			transform: rotate(-0.4deg) translateX(-0.2px);
 		}
 	}
 
 	.quiver {
 		transform-origin: center bottom;
-		animation: quiver 2s ease-in-out infinite;
+		animation: quiver 2.5s ease-in-out infinite;
 	}
 
-	.quiver-1 {
-		animation-delay: 0s;
-	}
-	.quiver-2 {
-		animation-delay: 0.3s;
-	}
-	.quiver-3 {
-		animation-delay: 0.6s;
-	}
+	.quiver-1 { animation-delay: 0s; }
+	.quiver-2 { animation-delay: 0.4s; }
+	.quiver-3 { animation-delay: 0.8s; }
 </style>

--- a/landing/src/lib/components/nature/trees/TreeBirch.svelte
+++ b/landing/src/lib/components/nature/trees/TreeBirch.svelte
@@ -19,8 +19,6 @@
 	}: Props = $props();
 
 	// Birch turns brilliant golden yellow in autumn
-	// Trees use 'currentColor' for summer to allow CSS inheritance (e.g., themed containers)
-	// This is intentional for consistency with Logo component and backward compatibility
 	const defaultColor = season === 'autumn' ? autumn.gold : 'currentColor';
 	const foliageColor = color ?? defaultColor;
 
@@ -29,76 +27,97 @@
 	const barkMarkColor = '#2d2d2d';
 </script>
 
-<!-- Birch tree - white bark with horizontal marks, delicate foliage -->
+<!-- Birch tree - white bark with horizontal marks, small triangular leaves -->
 <svg class={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 140">
 	<!-- Main trunk - characteristic white birch bark -->
-	<rect fill={actualTrunkColor} x="43" y="50" width="14" height="90" rx="2" />
+	<rect fill={actualTrunkColor} x="45" y="55" width="10" height="85" rx="2" />
 
 	<!-- Bark marks (horizontal lenticels - birch signature) -->
-	<line x1="44" y1="60" x2="56" y2="60" stroke={barkMarkColor} stroke-width="1.5" opacity="0.6" />
-	<line x1="45" y1="72" x2="55" y2="72" stroke={barkMarkColor} stroke-width="1" opacity="0.5" />
-	<line x1="44" y1="85" x2="56" y2="85" stroke={barkMarkColor} stroke-width="1.5" opacity="0.6" />
-	<line x1="46" y1="98" x2="54" y2="98" stroke={barkMarkColor} stroke-width="1" opacity="0.5" />
-	<line x1="44" y1="112" x2="56" y2="112" stroke={barkMarkColor} stroke-width="1.5" opacity="0.6" />
-	<line x1="45" y1="125" x2="55" y2="125" stroke={barkMarkColor} stroke-width="1" opacity="0.5" />
+	<line x1="46" y1="65" x2="54" y2="65" stroke={barkMarkColor} stroke-width="1.5" opacity="0.5" />
+	<line x1="47" y1="78" x2="53" y2="78" stroke={barkMarkColor} stroke-width="1" opacity="0.4" />
+	<line x1="46" y1="92" x2="54" y2="92" stroke={barkMarkColor} stroke-width="1.5" opacity="0.5" />
+	<line x1="47" y1="105" x2="53" y2="105" stroke={barkMarkColor} stroke-width="1" opacity="0.4" />
+	<line x1="46" y1="118" x2="54" y2="118" stroke={barkMarkColor} stroke-width="1.5" opacity="0.5" />
+	<line x1="47" y1="130" x2="53" y2="130" stroke={barkMarkColor} stroke-width="1" opacity="0.4" />
 
 	<!-- Peeling bark texture hints -->
-	<path fill="none" stroke={barkMarkColor} stroke-width="0.5" d="M43 78 Q41 82 43 86" opacity="0.3" />
-	<path fill="none" stroke={barkMarkColor} stroke-width="0.5" d="M57 105 Q59 109 57 113" opacity="0.3" />
+	<path fill="none" stroke={barkMarkColor} stroke-width="0.5" d="M45 83 Q43 87 45 91" opacity="0.25" />
+	<path fill="none" stroke={barkMarkColor} stroke-width="0.5" d="M55 108 Q57 112 55 116" opacity="0.25" />
 
-	<!-- Branch structure -->
-	<path fill={actualTrunkColor} d="M50 50 Q40 45 30 48 Q35 42 42 40 Q46 44 50 45" />
-	<path fill={actualTrunkColor} d="M50 50 Q60 45 70 48 Q65 42 58 40 Q54 44 50 45" />
-	<path fill="none" stroke={actualTrunkColor} stroke-width="2" d="M45 42 Q38 32 32 28" />
-	<path fill="none" stroke={actualTrunkColor} stroke-width="2" d="M55 42 Q62 32 68 28" />
-	<path fill="none" stroke={actualTrunkColor} stroke-width="1.5" d="M48 38 Q42 25 38 18" />
-	<path fill="none" stroke={actualTrunkColor} stroke-width="1.5" d="M52 38 Q58 25 62 18" />
+	<!-- Delicate branch structure -->
+	<path fill="none" stroke={actualTrunkColor} stroke-width="3" d="M50 55 Q42 48 32 42" />
+	<path fill="none" stroke={actualTrunkColor} stroke-width="3" d="M50 55 Q58 48 68 42" />
+	<path fill="none" stroke={actualTrunkColor} stroke-width="2" d="M50 50 Q44 38 38 28" />
+	<path fill="none" stroke={actualTrunkColor} stroke-width="2" d="M50 50 Q56 38 62 28" />
+	<path fill="none" stroke={actualTrunkColor} stroke-width="1.5" d="M46 42 Q40 32 35 22" />
+	<path fill="none" stroke={actualTrunkColor} stroke-width="1.5" d="M54 42 Q60 32 65 22" />
 
-	<!-- Foliage clusters - delicate, airy birch leaves -->
-	<!-- Left side -->
+	<!-- Birch leaves - small diamond/triangular shapes -->
+	<!-- Left side clusters -->
 	<g class={animate ? 'sway sway-1' : ''}>
-		<ellipse fill={foliageColor} cx="25" cy="42" rx="12" ry="10" />
-		<ellipse fill={foliageColor} cx="18" cy="32" rx="10" ry="8" />
-		<ellipse fill={foliageColor} cx="30" cy="28" rx="9" ry="7" />
+		<!-- Diamond-shaped leaves pointing down -->
+		<path fill={foliageColor} d="M25 45 L30 38 L35 45 L30 50 Z" />
+		<path fill={foliageColor} d="M18 38 L22 32 L26 38 L22 43 Z" />
+		<path fill={foliageColor} d="M28 35 L32 28 L36 35 L32 40 Z" />
+		<path fill={foliageColor} d="M15 46 L19 40 L23 46 L19 51 Z" />
+		<path fill={foliageColor} d="M32 48 L36 42 L40 48 L36 53 Z" />
 	</g>
 
-	<!-- Center top -->
 	<g class={animate ? 'sway sway-2' : ''}>
-		<ellipse fill={foliageColor} cx="50" cy="18" rx="14" ry="12" />
-		<ellipse fill={foliageColor} cx="42" cy="10" rx="10" ry="8" />
-		<ellipse fill={foliageColor} cx="58" cy="10" rx="10" ry="8" />
-		<ellipse fill={foliageColor} cx="50" cy="5" rx="8" ry="6" />
+		<path fill={foliageColor} d="M30 28 L34 22 L38 28 L34 33 Z" />
+		<path fill={foliageColor} d="M22 25 L26 19 L30 25 L26 30 Z" />
+		<path fill={foliageColor} d="M26 15 L29 10 L32 15 L29 19 Z" />
+		<path fill={foliageColor} d="M35 20 L38 15 L41 20 L38 24 Z" />
 	</g>
 
-	<!-- Right side -->
+	<!-- Center top cluster -->
 	<g class={animate ? 'sway sway-3' : ''}>
-		<ellipse fill={foliageColor} cx="75" cy="42" rx="12" ry="10" />
-		<ellipse fill={foliageColor} cx="82" cy="32" rx="10" ry="8" />
-		<ellipse fill={foliageColor} cx="70" cy="28" rx="9" ry="7" />
+		<path fill={foliageColor} d="M47 18 L50 12 L53 18 L50 23 Z" />
+		<path fill={foliageColor} d="M42 22 L45 16 L48 22 L45 27 Z" />
+		<path fill={foliageColor} d="M52 22 L55 16 L58 22 L55 27 Z" />
+		<path fill={foliageColor} d="M50 8 L52 4 L54 8 L52 11 Z" />
+		<path fill={foliageColor} d="M44 12 L47 7 L50 12 L47 16 Z" />
+		<path fill={foliageColor} d="M50 12 L53 7 L56 12 L53 16 Z" />
 	</g>
 
-	<!-- Middle foliage connecting branches -->
+	<!-- Center middle -->
 	<g class={animate ? 'sway sway-1' : ''}>
-		<ellipse fill={foliageColor} cx="38" cy="22" rx="10" ry="8" />
-		<ellipse fill={foliageColor} cx="62" cy="22" rx="10" ry="8" />
+		<path fill={foliageColor} d="M47 32 L50 26 L53 32 L50 37 Z" />
+		<path fill={foliageColor} d="M40 35 L43 29 L46 35 L43 40 Z" />
+		<path fill={foliageColor} d="M54 35 L57 29 L60 35 L57 40 Z" />
+		<path fill={foliageColor} d="M45 45 L48 40 L51 45 L48 49 Z" />
+		<path fill={foliageColor} d="M49 45 L52 40 L55 45 L52 49 Z" />
 	</g>
 
-	<!-- Lower foliage near trunk -->
-	<ellipse fill={foliageColor} cx="35" cy="48" rx="8" ry="6" />
-	<ellipse fill={foliageColor} cx="65" cy="48" rx="8" ry="6" />
+	<!-- Right side clusters -->
+	<g class={animate ? 'sway sway-2' : ''}>
+		<path fill={foliageColor} d="M75 45 L70 38 L65 45 L70 50 Z" />
+		<path fill={foliageColor} d="M82 38 L78 32 L74 38 L78 43 Z" />
+		<path fill={foliageColor} d="M72 35 L68 28 L64 35 L68 40 Z" />
+		<path fill={foliageColor} d="M85 46 L81 40 L77 46 L81 51 Z" />
+		<path fill={foliageColor} d="M68 48 L64 42 L60 48 L64 53 Z" />
+	</g>
+
+	<g class={animate ? 'sway sway-3' : ''}>
+		<path fill={foliageColor} d="M70 28 L66 22 L62 28 L66 33 Z" />
+		<path fill={foliageColor} d="M78 25 L74 19 L70 25 L74 30 Z" />
+		<path fill={foliageColor} d="M74 15 L71 10 L68 15 L71 19 Z" />
+		<path fill={foliageColor} d="M65 20 L62 15 L59 20 L62 24 Z" />
+	</g>
 </svg>
 
 <style>
 	@keyframes sway {
-		0%, 100% { transform: translateX(0); }
-		50% { transform: translateX(1px); }
+		0%, 100% { transform: translateX(0) rotate(0deg); }
+		50% { transform: translateX(0.8px) rotate(0.3deg); }
 	}
 
 	.sway {
-		animation: sway 3s ease-in-out infinite;
+		transform-origin: center bottom;
+		animation: sway 3.5s ease-in-out infinite;
 	}
 
 	.sway-1 { animation-delay: 0s; }
-	.sway-2 { animation-delay: 0.3s; }
-	.sway-3 { animation-delay: 0.6s; }
+	.sway-2 { animation-delay: 0.4s; }
+	.sway-3 { animation-delay: 0.8s; }
 </style>

--- a/landing/src/routes/forest/+page.svelte
+++ b/landing/src/routes/forest/+page.svelte
@@ -9,23 +9,6 @@
 	import TreeAspen from '$lib/components/nature/trees/TreeAspen.svelte';
 	import TreeBirch from '$lib/components/nature/trees/TreeBirch.svelte';
 
-	// Ground elements
-	import Mushroom from '$lib/components/nature/ground/Mushroom.svelte';
-	import Fern from '$lib/components/nature/ground/Fern.svelte';
-	import Bush from '$lib/components/nature/ground/Bush.svelte';
-	import GrassTuft from '$lib/components/nature/ground/GrassTuft.svelte';
-	import Rock from '$lib/components/nature/ground/Rock.svelte';
-	import FlowerWild from '$lib/components/nature/ground/FlowerWild.svelte';
-
-	// Creatures
-	import Firefly from '$lib/components/nature/creatures/Firefly.svelte';
-	import Butterfly from '$lib/components/nature/creatures/Butterfly.svelte';
-	import BirdFlying from '$lib/components/nature/creatures/BirdFlying.svelte';
-	import Bee from '$lib/components/nature/creatures/Bee.svelte';
-
-	// Botanical
-	import LeafFalling from '$lib/components/nature/botanical/LeafFalling.svelte';
-
 	// Sky
 	import Cloud from '$lib/components/nature/sky/Cloud.svelte';
 
@@ -36,8 +19,6 @@
 		autumn,
 		pinks,
 		autumnReds,
-		earth,
-		natural,
 		type Season
 	} from '$lib/components/nature/palette';
 
@@ -252,32 +233,6 @@
 			<Cloud class="w-32 h-16" animate={true} speed="slow" />
 		</div>
 
-		<!-- Flying creatures (spring/summer) or falling leaves (autumn) -->
-		{#if isAutumn}
-			<div class="absolute top-20 left-1/4" style="--fall-delay: 0s">
-				<LeafFalling class="w-6 h-6" season="autumn" variant="maple" />
-			</div>
-			<div class="absolute top-32 left-1/2" style="--fall-delay: 1s">
-				<LeafFalling class="w-5 h-5" season="autumn" variant="simple" />
-			</div>
-			<div class="absolute top-24 right-1/3" style="--fall-delay: 2s">
-				<LeafFalling class="w-6 h-6" season="autumn" variant="maple" />
-			</div>
-		{:else}
-			<div class="absolute top-24 left-1/4">
-				<BirdFlying class="w-8 h-4" animate={true} />
-			</div>
-			<div class="absolute top-16 right-1/4">
-				<BirdFlying class="w-6 h-3" animate={true} facing="left" />
-			</div>
-			<div class="absolute top-40 left-[15%]">
-				<Butterfly class="w-8 h-8" animate={true} />
-			</div>
-			<div class="absolute top-32 right-[20%]">
-				<Bee class="w-6 h-6" animate={true} />
-			</div>
-		{/if}
-
 		<!-- Distant mountains/hills silhouette -->
 		<div class="absolute inset-x-0 top-20 h-40">
 			<svg class="w-full h-full" viewBox="0 0 1200 160" preserveAspectRatio="none">
@@ -322,39 +277,6 @@
 					{/if}
 				</div>
 			{/each}
-
-			<!-- Ground decorations -->
-			<div class="absolute bottom-[22%] left-[10%] z-[6]">
-				<Mushroom class="w-8 h-10" />
-			</div>
-			<div class="absolute bottom-[18%] left-[25%] z-[6]">
-				<Fern class="w-6 h-10" {season} />
-			</div>
-			<div class="absolute bottom-[20%] right-[30%] z-[6]">
-				<Rock class="w-10 h-6" variant="round" />
-			</div>
-			<div class="absolute bottom-[15%] right-[15%] z-[6]">
-				<Bush class="w-12 h-10" {season} />
-			</div>
-			<div class="absolute bottom-[25%] left-[45%] z-[6]">
-				<GrassTuft class="w-6 h-8" {season} />
-			</div>
-			{#if !isAutumn}
-				<div class="absolute bottom-[22%] right-[45%] z-[6]">
-					<FlowerWild class="w-5 h-8" />
-				</div>
-			{/if}
-
-			<!-- Fireflies -->
-			<div class="absolute bottom-[35%] left-1/4 z-[7]">
-				<Firefly class="w-4 h-4" animate={true} intensity="subtle" />
-			</div>
-			<div class="absolute bottom-[30%] right-1/3 z-[7]">
-				<Firefly class="w-3 h-3" animate={true} intensity="bright" />
-			</div>
-			<div class="absolute bottom-[40%] left-1/2 z-[7]">
-				<Firefly class="w-4 h-4" animate={true} />
-			</div>
 		</div>
 
 		<!-- Ground -->

--- a/landing/src/routes/tools/+page.svelte
+++ b/landing/src/routes/tools/+page.svelte
@@ -232,7 +232,7 @@
 	<meta name="description" content="Preview and customize Grove nature assets" />
 </svelte:head>
 
-<main class="min-h-screen flex flex-col bg-background">
+<main class="min-h-screen flex flex-col bg-page">
 	<Header />
 
 	<article class="flex-1 px-6 py-8">
@@ -271,7 +271,7 @@
 							id="asset-selector"
 							bind:value={selectedAsset}
 							onchange={onAssetChange}
-							class="w-full px-4 py-2 rounded-lg border border-divider bg-background text-foreground font-sans focus:outline-none focus:ring-2 focus:ring-accent-subtle"
+							class="w-full px-4 py-2 rounded-lg border border-divider bg-surface-elevated text-foreground font-sans focus:outline-none focus:ring-2 focus:ring-accent-subtle"
 							aria-label="Select asset to preview"
 						>
 							{#each categories as category}
@@ -308,7 +308,7 @@
 													bind:value={propValues[prop]}
 													placeholder="#16a34a"
 													pattern="^#[0-9A-Fa-f]{6}$"
-													class="flex-1 px-3 py-2 rounded-lg border border-divider bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-accent-subtle invalid:border-red-500"
+													class="flex-1 px-3 py-2 rounded-lg border border-divider bg-surface-elevated text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-accent-subtle invalid:border-red-500"
 													aria-label="{prop} hex color value"
 												/>
 											</div>
@@ -343,7 +343,7 @@
 										<!-- Dropdown for enums -->
 										<select
 											bind:value={propValues[prop]}
-											class="w-full px-3 py-2 rounded-lg border border-divider bg-background text-foreground font-sans text-sm focus:outline-none focus:ring-2 focus:ring-accent-subtle"
+											class="w-full px-3 py-2 rounded-lg border border-divider bg-surface-elevated text-foreground font-sans text-sm focus:outline-none focus:ring-2 focus:ring-accent-subtle"
 											aria-label="Select {prop} option"
 										>
 											<option value={undefined}>Default</option>
@@ -369,7 +369,7 @@
 											type="text"
 											bind:value={propValues[prop]}
 											placeholder="Default"
-											class="w-full px-3 py-2 rounded-lg border border-divider bg-background text-foreground font-sans text-sm focus:outline-none focus:ring-2 focus:ring-accent-subtle"
+											class="w-full px-3 py-2 rounded-lg border border-divider bg-surface-elevated text-foreground font-sans text-sm focus:outline-none focus:ring-2 focus:ring-accent-subtle"
 										/>
 									{/if}
 								</div>


### PR DESCRIPTION
- Fix dark mode text input readability by using bg-surface-elevated
- Redesign TreeAspen with realistic teardrop/heart-shaped quivering leaves
- Redesign TreeBirch with diamond-shaped leaves on delicate branches
- Update Rock component with matte finish (reduced shine/highlights)
- Redesign Bird as American Robin with orange-red breast and dark gray body
- Improve CloudWispy with soft elliptical shapes for proper cirrus appearance
- Fix Lantern hanging variant with connected finial and curved arms
- Simplify /forest page to only show trees (removed ground decorations,
  creatures, fireflies, and falling leaves)