### PR TITLE
feat(landing): add falling leaves to forest page

### DIFF
--- a/landing/src/lib/components/nature/botanical/FallingLeavesLayer.svelte
+++ b/landing/src/lib/components/nature/botanical/FallingLeavesLayer.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import type { Season } from '../palette';
+	import LeafFalling from './LeafFalling.svelte';
+
+	type TreeType = 'logo' | 'pine' | 'aspen' | 'birch' | 'cherry';
+	type LeafVariant = 'simple' | 'maple' | 'cherry' | 'aspen' | 'pine';
+
+	interface Tree {
+		id: number;
+		x: number;
+		y: number;
+		size: number;
+		treeType: TreeType;
+		zIndex?: number;
+	}
+
+	interface FallingLeaf {
+		id: number;
+		x: number;
+		y: number;
+		size: number;
+		variant: LeafVariant;
+		duration: number;
+		delay: number;
+		drift: number;
+		opacity: number;
+	}
+
+	interface Props {
+		trees: Tree[];
+		season?: Season;
+		/** Minimum leaves per tree */
+		minLeavesPerTree?: number;
+		/** Maximum leaves per tree */
+		maxLeavesPerTree?: number;
+		/** Base z-index for the leaf layer (should be below trees) */
+		zIndex?: number;
+	}
+
+	let {
+		trees,
+		season = 'summer',
+		minLeavesPerTree = 2,
+		maxLeavesPerTree = 5,
+		zIndex = 0
+	}: Props = $props();
+
+	// Map tree types to appropriate leaf variants
+	function getLeafVariant(treeType: TreeType): LeafVariant {
+		switch (treeType) {
+			case 'cherry':
+				return 'cherry';
+			case 'aspen':
+			case 'birch':
+				return 'aspen';
+			case 'pine':
+				return 'pine';
+			case 'logo':
+			default:
+				// Logo and default get a mix of simple and maple
+				return Math.random() > 0.5 ? 'simple' : 'maple';
+		}
+	}
+
+	// Generate falling leaves based on tree positions
+	function generateLeaves(treesData: Tree[]): FallingLeaf[] {
+		const leaves: FallingLeaf[] = [];
+		let leafId = 0;
+
+		for (const tree of treesData) {
+			// Random number of leaves per tree within the configured range
+			const baseLeafCount = minLeavesPerTree + Math.floor(Math.random() * (maxLeavesPerTree - minLeavesPerTree + 1));
+
+			// More leaves for bigger/closer trees, fewer for distant ones
+			const treeDepth = tree.zIndex ?? 1;
+			const depthMultiplier = 0.5 + (treeDepth / 5) * 0.8; // 0.5x for far trees, up to 1.3x for close ones
+			const leafCount = Math.ceil(baseLeafCount * depthMultiplier);
+
+			// Scale leaf size based on tree size (bigger trees = bigger leaves for perspective)
+			const treeSizeFactor = tree.size / 100; // Normalize around 100px tree size
+			const baseLeafSize = 6 + treeSizeFactor * 8; // 6-14px base depending on tree size
+			const leafSizeVariation = 6 + treeSizeFactor * 4; // Additional random variation
+
+			for (let i = 0; i < leafCount; i++) {
+				// Spawn leaves around the tree crown area
+				// Offset from tree center, weighted toward the canopy
+				const xOffset = (Math.random() - 0.5) * (tree.size / 12); // Horizontal spread based on tree size
+				const yOffset = Math.random() * (tree.size / 30); // Start higher up in the canopy
+
+				leaves.push({
+					id: leafId++,
+					x: tree.x + xOffset,
+					y: tree.y - yOffset, // Above the tree base
+					size: baseLeafSize + Math.random() * leafSizeVariation,
+					variant: getLeafVariant(tree.treeType),
+					duration: 6 + Math.random() * 8, // 6-14 seconds to fall
+					delay: Math.random() * 12, // Staggered start over 12 seconds
+					drift: (Math.random() - 0.5) * 80, // -40 to +40 horizontal drift
+					opacity: 0.5 + Math.random() * 0.4 // 0.5-0.9 opacity
+				});
+			}
+		}
+
+		return leaves;
+	}
+
+	// Reactive leaves - regenerates when trees or season changes
+	let fallingLeaves = $derived(generateLeaves(trees));
+</script>
+
+<!-- Falling leaves layer - positioned behind trees -->
+<div
+	class="absolute inset-0 pointer-events-none overflow-hidden"
+	style="z-index: {zIndex};"
+>
+	{#each fallingLeaves as leaf (leaf.id)}
+		<div
+			class="absolute"
+			style="
+				left: {leaf.x}%;
+				top: {leaf.y}%;
+				opacity: {leaf.opacity};
+				width: {leaf.size}px;
+				height: {leaf.size}px;
+			"
+		>
+			<LeafFalling
+				class="w-full h-full"
+				variant={leaf.variant}
+				{season}
+				duration={leaf.duration}
+				delay={leaf.delay}
+				drift={leaf.drift}
+				animate={true}
+			/>
+		</div>
+	{/each}
+</div>

--- a/landing/src/lib/components/nature/botanical/LeafFalling.svelte
+++ b/landing/src/lib/components/nature/botanical/LeafFalling.svelte
@@ -1,13 +1,21 @@
 <script lang="ts">
 	import type { Season } from '../palette';
-	import { autumn, greens } from '../palette';
+	import { autumn, greens, pinks, autumnReds } from '../palette';
+
+	type LeafVariant = 'simple' | 'maple' | 'cherry' | 'aspen' | 'pine';
 
 	interface Props {
 		class?: string;
 		color?: string;
 		season?: Season;
 		animate?: boolean;
-		variant?: 'simple' | 'maple';
+		variant?: LeafVariant;
+		/** Animation duration in seconds */
+		duration?: number;
+		/** Animation delay in seconds */
+		delay?: number;
+		/** Horizontal drift amount (positive = right, negative = left) */
+		drift?: number;
 	}
 
 	let {
@@ -15,15 +23,39 @@
 		color,
 		season = 'autumn',
 		animate = true,
-		variant = 'simple'
+		variant = 'simple',
+		duration = 5,
+		delay = 0,
+		drift = 30
 	}: Props = $props();
 
-	// Falling leaves are typically autumn colors
-	const autumnColors = [autumn.rust, autumn.amber, autumn.gold, autumn.pumpkin];
-	const defaultColor = season === 'autumn'
-		? autumnColors[Math.floor(Math.random() * autumnColors.length)]
-		: greens.grove;
-	const leafColor = color ?? defaultColor;
+	// Color palettes for different leaf types
+	const autumnColors = [autumn.rust, autumn.amber, autumn.gold, autumn.pumpkin, autumn.ember];
+	const summerColors = [greens.grove, greens.meadow, greens.spring, greens.deepGreen];
+	const cherryAutumnColors = [autumnReds.crimson, autumnReds.scarlet, autumnReds.rose];
+	const cherrySpringColors = [pinks.pink, pinks.rose, pinks.blush, pinks.palePink];
+	const aspenAutumnColors = [autumn.gold, autumn.honey, autumn.straw, autumn.amber];
+
+	// Get default color based on variant and season
+	function getDefaultColor(): string {
+		if (variant === 'cherry') {
+			const colors = season === 'autumn' ? cherryAutumnColors : cherrySpringColors;
+			return colors[Math.floor(Math.random() * colors.length)];
+		}
+		if (variant === 'aspen') {
+			const colors = season === 'autumn' ? aspenAutumnColors : summerColors;
+			return colors[Math.floor(Math.random() * colors.length)];
+		}
+		if (variant === 'pine') {
+			// Pine stays green year-round (evergreen)
+			return summerColors[Math.floor(Math.random() * summerColors.length)];
+		}
+		// Default (simple, maple)
+		const colors = season === 'autumn' ? autumnColors : summerColors;
+		return colors[Math.floor(Math.random() * colors.length)];
+	}
+
+	const leafColor = color ?? getDefaultColor();
 </script>
 
 <!-- Falling leaf with spin/flutter animation -->
@@ -31,55 +63,79 @@
 	class="{className} {animate ? 'fall' : ''}"
 	xmlns="http://www.w3.org/2000/svg"
 	viewBox="0 0 30 35"
+	style="--fall-duration: {duration}s; --fall-delay: {delay}s; --fall-drift: {drift}px;"
 >
 	<g class={animate ? 'spin' : ''}>
 		{#if variant === 'simple'}
+			<!-- Simple oval leaf -->
 			<ellipse fill={leafColor} cx="15" cy="15" rx="12" ry="14" />
 			<path fill="none" stroke="rgba(0,0,0,0.2)" stroke-width="0.8" d="M15 3 L15 29" />
-		{:else}
+		{:else if variant === 'maple'}
 			<!-- Maple shape -->
 			<path
 				fill={leafColor}
 				d="M15 2
 				   L16 7 L22 4 L19 10 L28 9 L21 15 L28 18 L19 19 L24 28 L15 22 L6 28 L11 19 L2 18 L9 15 L2 9 L11 10 L8 4 L14 7 Z"
 			/>
+		{:else if variant === 'cherry'}
+			<!-- Cherry blossom petal - soft rounded oval -->
+			<ellipse fill={leafColor} cx="15" cy="13" rx="10" ry="12" />
+			<!-- Subtle petal notch at tip -->
+			<path fill={leafColor} d="M15 2 Q12 6 15 8 Q18 6 15 2" />
+		{:else if variant === 'aspen'}
+			<!-- Aspen/Birch - rounded heart shape -->
+			<path
+				fill={leafColor}
+				d="M15 4 Q8 4 6 12 Q4 20 15 28 Q26 20 24 12 Q22 4 15 4"
+			/>
+			<path fill="none" stroke="rgba(0,0,0,0.15)" stroke-width="0.6" d="M15 6 L15 26" />
+		{:else if variant === 'pine'}
+			<!-- Pine needle cluster - thin elongated shapes -->
+			<path fill={leafColor} d="M15 2 L16 28 L14 28 Z" />
+			<path fill={leafColor} d="M10 4 L16 26 L14 27 Z" opacity="0.8" />
+			<path fill={leafColor} d="M20 4 L14 26 L16 27 Z" opacity="0.8" />
 		{/if}
 
-		<!-- Stem -->
-		<path fill="none" stroke="rgba(0,0,0,0.3)" stroke-width="1.5" d="M15 28 L15 35" />
+		<!-- Stem (not for pine needles) -->
+		{#if variant !== 'pine'}
+			<path fill="none" stroke="rgba(0,0,0,0.3)" stroke-width="1.5" d="M15 28 L15 35" />
+		{/if}
 	</g>
 </svg>
 
 <style>
 	@keyframes fall {
 		0% {
-			transform: translateY(-20px) translateX(0);
+			transform: translateY(-10px) translateX(0);
 			opacity: 0;
 		}
-		10% {
-			opacity: 1;
+		5% {
+			opacity: 0.9;
+		}
+		95% {
+			opacity: 0.6;
 		}
 		100% {
-			transform: translateY(100px) translateX(30px);
-			opacity: 0.5;
+			transform: translateY(100vh) translateX(var(--fall-drift, 30px));
+			opacity: 0;
 		}
 	}
 
 	@keyframes spin {
 		0% { transform: rotate(0deg) rotateY(0deg); }
-		25% { transform: rotate(15deg) rotateY(90deg); }
-		50% { transform: rotate(-10deg) rotateY(180deg); }
-		75% { transform: rotate(20deg) rotateY(270deg); }
+		25% { transform: rotate(20deg) rotateY(90deg); }
+		50% { transform: rotate(-15deg) rotateY(180deg); }
+		75% { transform: rotate(25deg) rotateY(270deg); }
 		100% { transform: rotate(0deg) rotateY(360deg); }
 	}
 
 	.fall {
-		animation: fall 5s ease-in-out infinite;
+		animation: fall var(--fall-duration, 5s) ease-in-out infinite;
 		animation-delay: var(--fall-delay, 0s);
 	}
 
 	.spin {
 		transform-origin: center center;
-		animation: spin 3s ease-in-out infinite;
+		animation: spin calc(var(--fall-duration, 5s) * 0.6) ease-in-out infinite;
 	}
 </style>

--- a/landing/src/routes/forest/+page.svelte
+++ b/landing/src/routes/forest/+page.svelte
@@ -9,6 +9,9 @@
 	import TreeAspen from '$lib/components/nature/trees/TreeAspen.svelte';
 	import TreeBirch from '$lib/components/nature/trees/TreeBirch.svelte';
 
+	// Falling leaves
+	import FallingLeavesLayer from '$lib/components/nature/botanical/FallingLeavesLayer.svelte';
+
 	// Sky
 	import Cloud from '$lib/components/nature/sky/Cloud.svelte';
 
@@ -249,6 +252,15 @@
 
 		<!-- Forest container -->
 		<div class="relative w-full h-[70vh] min-h-[500px]">
+			<!-- Falling leaves layer - behind trees -->
+			<FallingLeavesLayer
+				trees={forestTrees}
+				{season}
+				minLeavesPerTree={2}
+				maxLeavesPerTree={5}
+				zIndex={0}
+			/>
+
 			<!-- Trees -->
 			{#each forestTrees as tree (tree.id)}
 				<div


### PR DESCRIPTION
Add season-aware falling leaves that spawn from tree positions:
- Enhanced LeafFalling component with cherry, aspen, and pine variants
- New FallingLeavesLayer component for managing leaf animations
- Leaves render behind trees (z-index 0)
- Random 2-5 leaves per tree with size based on tree depth
- Colors match tree types and respond to season toggle