### PR TITLE
fix(forest): reduce falling leaves distance and move toggle to bottom right

### DIFF
--- a/landing/src/lib/components/nature/botanical/FallingLeavesLayer.svelte
+++ b/landing/src/lib/components/nature/botanical/FallingLeavesLayer.svelte
@@ -8,7 +8,7 @@
 	// Animation constants
 	const LEAF_OPACITY = { min: 0.4, max: 0.75 } as const;
 	const FALL_DURATION = { min: 8, max: 14 } as const;
-	const FALL_DISTANCE = { min: 25, max: 45 } as const;
+	const FALL_DISTANCE = { min: 12, max: 20 } as const;
 	const DRIFT_RANGE = 60; // -30 to +30
 	const SPAWN_DELAY_MAX = 15;
 

--- a/landing/src/routes/forest/+page.svelte
+++ b/landing/src/routes/forest/+page.svelte
@@ -268,8 +268,8 @@
 	<Header />
 
 	<article class="flex-1 relative overflow-hidden">
-		<!-- Season Toggle - Inline with title -->
-		<div class="absolute top-6 right-6 z-40">
+		<!-- Season Toggle - Bottom right corner -->
+		<div class="absolute bottom-6 right-6 z-40">
 			<button
 				onclick={toggleSeason}
 				class="p-2 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm shadow-lg border border-white/20 hover:scale-110 transition-transform"


### PR DESCRIPTION
- Reduced fall distance from 25-45vh to 12-20vh so leaves stay within forest bounds
- Moved season toggle button from top-right to bottom-right to avoid obscuring title text