### PR TITLE
feat(landing): add help redirect routes to knowledge base

### DIFF
--- a/landing/src/routes/desk/+server.ts
+++ b/landing/src/routes/desk/+server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = () => {
+	redirect(301, '/knowledge');
+};

--- a/landing/src/routes/help/+server.ts
+++ b/landing/src/routes/help/+server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = () => {
+	redirect(301, '/knowledge');
+};

--- a/landing/src/routes/helpme/+server.ts
+++ b/landing/src/routes/helpme/+server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = () => {
+	redirect(301, '/knowledge');
+};

--- a/landing/src/routes/support/+server.ts
+++ b/landing/src/routes/support/+server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = () => {
+	redirect(301, '/knowledge');
+};


### PR DESCRIPTION
Add convenience redirect routes /help, /desk, /support, and /helpme
that all redirect (301) to /knowledge for easier discoverability.