### PR TITLE
fix(landing): fix broken links preventing knowledge base build

### DIFF
--- a/docs/help-center/articles/my-site-isnt-loading.md
+++ b/docs/help-center/articles/my-site-isnt-loading.md
@@ -86,7 +86,7 @@ Custom domain issues have their own quirks. Common culprits:
 - **Domain expired:** Check that your domain registration is current with your registrar.
 - **DNS provider issues:** Sometimes the problem is upstream. Try checking your registrar's status page.
 
-See [Custom Domain Troubleshooting](/help/custom-domain-issues) for more specific guidance.
+If you're still having trouble with your custom domain, [contact us](/support) with your domain name and we'll help you troubleshoot.
 
 ## Still stuck?
 

--- a/docs/help-center/articles/writing-your-first-post.md
+++ b/docs/help-center/articles/writing-your-first-post.md
@@ -45,7 +45,7 @@ Grove uses Markdown for formatting, but you don't need to know it. The editor ha
 
 If you just want to write paragraphs, you can ignore all of that. Plain text works fine.
 
-Want to learn more? See our [Markdown Guide](/help/formatting-your-posts) for all the formatting options available.
+Want to learn more? The toolbar has buttons for all common formatting options, so you can just explore as you write.
 
 ## Don't overthink it
 

--- a/docs/legal/terms-of-service.md
+++ b/docs/legal/terms-of-service.md
@@ -126,7 +126,7 @@ Your privacy is important to us. Please review our [Privacy Policy](https://grov
 The Service, including its design, features, and underlying technology, is owned by us and protected by intellectual property laws. You may not copy, modify, or reverse engineer any part of the Service.
 
 ### 9.2 Open Source
-The Grove platform code is available under the [GNU Affero General Public License v3.0 (AGPL-3.0)](../../LICENSE). This allows you to view and learn from the code while ensuring that any modifications to the platform remain open source.
+The Grove platform code is available under the [GNU Affero General Public License v3.0 (AGPL-3.0)](https://github.com/AutumnsGrove/GroveEngine/blob/main/LICENSE). This allows you to view and learn from the code while ensuring that any modifications to the platform remain open source.
 
 ---
 

--- a/docs/specs/CONTENT-MODERATION.md
+++ b/docs/specs/CONTENT-MODERATION.md
@@ -18,7 +18,7 @@
 
 ## Overview
 
-Grove uses automated content moderation to enforce our [Acceptable Use Policy](../Legal/ACCEPTABLE-USE-POLICY.md) while maintaining strict privacy protections. This system is designed with a **privacy-first architecture**: no human eyes on user data, no retention of content, and fully encrypted processing.
+Grove uses automated content moderation to enforce our [Acceptable Use Policy](/knowledge/legal/acceptable-use-policy) while maintaining strict privacy protections. This system is designed with a **privacy-first architecture**: no human eyes on user data, no retention of content, and fully encrypted processing.
 
 ---
 
@@ -650,7 +650,7 @@ We're sorry for the inconvenience. If you have any questions, please reply to th
 
 ### 13.2 Policy Integration
 
-This system enforces the [Acceptable Use Policy](../Legal/ACCEPTABLE-USE-POLICY.md). Any AUP changes must be reflected in:
+This system enforces the [Acceptable Use Policy](/knowledge/legal/acceptable-use-policy). Any AUP changes must be reflected in:
 - Category definitions (Section 6)
 - Prompt template (Section 6.2)
 - Severity mappings (Section 7)

--- a/landing/src/routes/knowledge/legal/+page.server.ts
+++ b/landing/src/routes/knowledge/legal/+page.server.ts
@@ -1,0 +1,7 @@
+import { legalDocs } from "$lib/data/knowledge-base";
+
+export async function load() {
+  return {
+    legalDocs,
+  };
+}

--- a/landing/src/routes/knowledge/legal/+page.svelte
+++ b/landing/src/routes/knowledge/legal/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  export let data;
+  const { legalDocs } = data;
+</script>
+
+<svelte:head>
+  <title>Legal & Policies - Grove Knowledge Base</title>
+  <meta name="description" content="Legal documents, terms of service, privacy policy, and other policies for Grove platform" />
+</svelte:head>
+
+<div class="min-h-screen bg-gradient-to-b from-purple-50 to-white">
+  <div class="max-w-6xl mx-auto px-4 py-12">
+    <!-- Breadcrumb -->
+    <nav class="flex items-center space-x-2 text-sm text-gray-600 mb-8">
+      <a href="/knowledge" class="hover:text-purple-600">Knowledge Base</a>
+      <span>/</span>
+      <span class="text-gray-900">Legal & Policies</span>
+    </nav>
+
+    <!-- Header -->
+    <div class="mb-12">
+      <h1 class="text-4xl font-bold text-gray-900 mb-4">Legal & Policies</h1>
+      <p class="text-xl text-gray-600 max-w-3xl">
+        Our terms of service, privacy policy, and other legal documents.
+        We believe in transparency and keeping these documents readable and straightforward.
+      </p>
+    </div>
+
+    <!-- Legal Docs List -->
+    <div class="grid gap-6">
+      {#each legalDocs as doc}
+        <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+          <div class="flex items-start justify-between mb-4">
+            <div class="flex-1">
+              <h2 class="text-xl font-semibold text-gray-900 mb-2">
+                <a href="/knowledge/legal/{doc.slug}" class="hover:text-purple-600">
+                  {doc.title}
+                </a>
+              </h2>
+              {#if doc.description}
+                <p class="text-gray-600 mb-3">{doc.description}</p>
+              {/if}
+              <p class="text-gray-500 text-sm">{doc.excerpt}</p>
+            </div>
+            <div class="ml-6 text-right">
+              <div class="text-sm text-gray-500 mb-1">{doc.readingTime} min read</div>
+              {#if doc.lastUpdated}
+                <div class="text-xs text-gray-400">Updated {doc.lastUpdated}</div>
+              {/if}
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <a
+              href="/knowledge/legal/{doc.slug}"
+              class="inline-flex items-center text-purple-600 hover:text-purple-700 font-medium"
+            >
+              Read document
+              <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </a>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+              Legal Document
+            </span>
+          </div>
+        </article>
+      {/each}
+    </div>
+
+    <!-- Contact CTA -->
+    <div class="mt-12 bg-purple-50 rounded-lg p-8 text-center">
+      <h3 class="text-xl font-semibold text-gray-900 mb-2">Questions about our policies?</h3>
+      <p class="text-gray-600 mb-4">
+        If you have questions about our terms or policies, or need clarification on anything, please reach out.
+      </p>
+      <a href="mailto:autumn@grove.place" class="inline-flex items-center px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors">
+        Contact Us
+        <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+      </a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Fix internal document links in CONTENT-MODERATION.md to use correct
  knowledge base routes instead of relative paths
- Remove broken links to non-existent help articles (formatting-your-posts,
  custom-domain-issues) and reword content
- Fix LICENSE link in terms-of-service to use GitHub URL
- Add missing /knowledge/legal index page that was causing build to fail

This fixes the build error that was blocking deployment of the full
knowledge base content (commit c59b11f).