### PR TITLE
fix(landing): improve knowledge base readability and add dark mode support

### DIFF
--- a/landing/src/lib/components/Header.svelte
+++ b/landing/src/lib/components/Header.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import Logo from './Logo.svelte';
+	import ThemeToggle from './ThemeToggle.svelte';
 
 	// Determine current page for highlighting
 	let currentPath = $derived($page.url.pathname);
@@ -49,6 +50,7 @@
 			>
 				Credits
 			</a>
+			<ThemeToggle />
 		</nav>
 	</div>
 </header>

--- a/landing/src/routes/knowledge/+page.svelte
+++ b/landing/src/routes/knowledge/+page.svelte
@@ -19,12 +19,12 @@
   <meta name="description" content="Learn about Grove's features, specifications, and how to use our platform" />
 </svelte:head>
 
-<div class="min-h-screen bg-gradient-to-b from-green-50 to-white">
+<div class="min-h-screen bg-page">
   <div class="max-w-6xl mx-auto px-4 py-12">
     <!-- Header -->
     <div class="text-center mb-12">
-      <h1 class="text-4xl font-bold text-gray-900 mb-4">Knowledge Base</h1>
-      <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+      <h1 class="text-4xl font-bold text-foreground mb-4">Knowledge Base</h1>
+      <p class="text-xl text-foreground-muted max-w-3xl mx-auto">
         Everything you need to know about Grove - from technical specifications to user guides
       </p>
     </div>
@@ -36,16 +36,16 @@
           type="text"
           bind:value={searchQuery}
           placeholder="Search documentation..."
-          class="w-full px-4 py-3 pl-12 pr-20 text-gray-900 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
+          class="w-full px-4 py-3 pl-12 pr-20 text-foreground bg-surface-elevated border border-default rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent"
         />
         <div class="absolute inset-y-0 left-0 flex items-center pl-4">
-          <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-5 h-5 text-foreground-subtle" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </div>
         <button
           type="submit"
-          class="absolute inset-y-0 right-0 flex items-center pr-4 text-green-600 hover:text-green-700 font-medium"
+          class="absolute inset-y-0 right-0 flex items-center pr-4 text-accent hover:text-accent-muted font-medium"
         >
           Search
         </button>
@@ -55,31 +55,31 @@
     <!-- Categories -->
     <div class="grid md:grid-cols-3 gap-8">
       <!-- Technical Specifications -->
-      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+      <div class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
         <div class="flex items-center mb-4">
-          <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mr-4">
-            <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-12 h-12 bg-accent/10 rounded-lg flex items-center justify-center mr-4">
+            <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
             </svg>
           </div>
           <div>
-            <h2 class="text-xl font-semibold text-gray-900">Technical Specifications</h2>
-            <p class="text-sm text-gray-500">{specs.length} documents</p>
+            <h2 class="text-xl font-semibold text-foreground">Technical Specifications</h2>
+            <p class="text-sm text-foreground-subtle">{specs.length} documents</p>
           </div>
         </div>
-        <p class="text-gray-600 mb-4">
+        <p class="text-foreground-muted mb-4">
           Detailed technical documentation about Grove's architecture, features, and implementation details.
         </p>
         <div class="space-y-2 mb-4">
           {#each specs.slice(0, 3) as spec}
             <div class="text-sm">
-              <a href="/knowledge/specs/{spec.slug}" class="text-green-600 hover:text-green-700 font-medium">
+              <a href="/knowledge/specs/{spec.slug}" class="text-accent hover:text-accent-muted font-medium transition-colors">
                 {spec.title}
               </a>
             </div>
           {/each}
         </div>
-        <a href="/knowledge/specs" class="inline-flex items-center text-green-600 hover:text-green-700 font-medium">
+        <a href="/knowledge/specs" class="inline-flex items-center text-accent hover:text-accent-muted font-medium transition-colors">
           View all specifications
           <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -88,31 +88,31 @@
       </div>
 
       <!-- Help Articles -->
-      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+      <div class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
         <div class="flex items-center mb-4">
-          <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mr-4">
-            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mr-4">
+            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
           <div>
-            <h2 class="text-xl font-semibold text-gray-900">Help Center</h2>
-            <p class="text-sm text-gray-500">{helpArticles.length} articles</p>
+            <h2 class="text-xl font-semibold text-foreground">Help Center</h2>
+            <p class="text-sm text-foreground-subtle">{helpArticles.length} articles</p>
           </div>
         </div>
-        <p class="text-gray-600 mb-4">
+        <p class="text-foreground-muted mb-4">
           Step-by-step guides and answers to common questions about using Grove.
         </p>
         <div class="space-y-2 mb-4">
           {#each helpArticles.slice(0, 3) as article}
             <div class="text-sm">
-              <a href="/knowledge/help/{article.slug}" class="text-blue-600 hover:text-blue-700 font-medium">
+              <a href="/knowledge/help/{article.slug}" class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
                 {article.title}
               </a>
             </div>
           {/each}
         </div>
-        <a href="/knowledge/help" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium">
+        <a href="/knowledge/help" class="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
           Browse all articles
           <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -121,31 +121,31 @@
       </div>
 
       <!-- Legal Documents -->
-      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+      <div class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
         <div class="flex items-center mb-4">
-          <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mr-4">
-            <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center mr-4">
+            <svg class="w-6 h-6 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
             </svg>
           </div>
           <div>
-            <h2 class="text-xl font-semibold text-gray-900">Legal & Policies</h2>
-            <p class="text-sm text-gray-500">{legalDocs.length} documents</p>
+            <h2 class="text-xl font-semibold text-foreground">Legal & Policies</h2>
+            <p class="text-sm text-foreground-subtle">{legalDocs.length} documents</p>
           </div>
         </div>
-        <p class="text-gray-600 mb-4">
+        <p class="text-foreground-muted mb-4">
           Terms of service, privacy policy, and other legal documents that govern your use of Grove.
         </p>
         <div class="space-y-2 mb-4">
           {#each legalDocs.slice(0, 3) as doc}
             <div class="text-sm">
-              <a href="/knowledge/legal/{doc.slug}" class="text-purple-600 hover:text-purple-700 font-medium">
+              <a href="/knowledge/legal/{doc.slug}" class="text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 font-medium transition-colors">
                 {doc.title}
               </a>
             </div>
           {/each}
         </div>
-        <a href="/knowledge/legal" class="inline-flex items-center text-purple-600 hover:text-purple-700 font-medium">
+        <a href="/knowledge/legal" class="inline-flex items-center text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 font-medium transition-colors">
           View all policies
           <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -156,18 +156,18 @@
 
     <!-- Quick Links -->
     <div class="mt-12 text-center">
-      <h3 class="text-lg font-semibold text-gray-900 mb-4">Quick Links</h3>
+      <h3 class="text-lg font-semibold text-foreground mb-4">Quick Links</h3>
       <div class="flex flex-wrap justify-center gap-4">
-        <a href="/knowledge/specs/CONTENT-MODERATION" class="px-4 py-2 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors">
+        <a href="/knowledge/specs/CONTENT-MODERATION" class="px-4 py-2 bg-accent/10 text-accent rounded-lg hover:bg-accent/20 transition-colors">
           Content Moderation
         </a>
-        <a href="/knowledge/help/what-is-grove" class="px-4 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors">
+        <a href="/knowledge/help/what-is-grove" class="px-4 py-2 bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-lg hover:bg-blue-200 dark:hover:bg-blue-900/40 transition-colors">
           What is Grove?
         </a>
-        <a href="/knowledge/help/writing-your-first-post" class="px-4 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors">
+        <a href="/knowledge/help/writing-your-first-post" class="px-4 py-2 bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-lg hover:bg-blue-200 dark:hover:bg-blue-900/40 transition-colors">
           Writing Your First Post
         </a>
-        <a href="/vision" class="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors">
+        <a href="/vision" class="px-4 py-2 bg-surface-elevated text-foreground-muted border border-default rounded-lg hover:bg-surface transition-colors">
           Our Vision
         </a>
       </div>

--- a/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
+++ b/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
@@ -15,52 +15,52 @@
   <meta name="description" content={doc?.description || doc?.excerpt || ''} />
 </svelte:head>
 
-<div class="min-h-screen bg-gray-50">
+<div class="min-h-screen bg-page">
   <div class="max-w-4xl mx-auto px-4 py-12">
     {#if doc}
       <!-- Breadcrumb -->
-      <nav class="flex items-center space-x-2 text-sm text-gray-600 mb-8" aria-label="Breadcrumb">
-        <a href="/knowledge" class="hover:text-gray-900">Knowledge Base</a>
+      <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8" aria-label="Breadcrumb">
+        <a href="/knowledge" class="hover:text-foreground transition-colors">Knowledge Base</a>
         <span aria-hidden="true">/</span>
-        <a href="/knowledge/{category}" class="hover:text-gray-900">{categoryTitle}</a>
+        <a href="/knowledge/{category}" class="hover:text-foreground transition-colors">{categoryTitle}</a>
         <span aria-hidden="true">/</span>
-        <span class="text-gray-900" aria-current="page">{doc.title}</span>
+        <span class="text-foreground" aria-current="page">{doc.title}</span>
       </nav>
 
       <!-- Article Header -->
       <header class="mb-8">
         <div class="flex items-center gap-3 mb-4">
           {#if category === 'specs'}
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-accent/10 text-accent dark:bg-accent/20 dark:text-accent-text">
               Technical Spec
             </span>
           {:else if category === 'help'}
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
               Help Article
             </span>
           {:else}
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800">
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300">
               Legal Document
             </span>
           {/if}
           {#if doc.lastUpdated}
-            <span class="text-sm text-gray-500">Updated {doc.lastUpdated}</span>
+            <span class="text-sm text-foreground-subtle">Updated {doc.lastUpdated}</span>
           {/if}
-          <span class="text-sm text-gray-500">{doc.readingTime} min read</span>
+          <span class="text-sm text-foreground-subtle">{doc.readingTime} min read</span>
         </div>
-        <h1 class="text-4xl font-bold text-gray-900 mb-4">{doc.title}</h1>
+        <h1 class="text-4xl font-bold text-foreground mb-4">{doc.title}</h1>
         {#if doc.description}
-          <p class="text-xl text-gray-600">{doc.description}</p>
+          <p class="text-xl text-foreground-muted">{doc.description}</p>
         {/if}
       </header>
 
       <!-- Article Content -->
-      <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-8 mb-8">
-        <div class="prose prose-lg max-w-none prose-headings:text-gray-900 prose-p:text-gray-700 prose-a:text-blue-600 prose-strong:text-gray-900 prose-ul:text-gray-700 prose-ol:text-gray-700 prose-li:text-gray-700">
+      <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-8 mb-8">
+        <div class="prose prose-lg max-w-none prose-headings:text-foreground prose-p:text-foreground-muted prose-a:text-accent-muted hover:prose-a:text-accent prose-strong:text-foreground prose-ul:text-foreground-muted prose-ol:text-foreground-muted prose-li:text-foreground-muted">
           {#if doc.html}
             {@html doc.html}
           {:else}
-            <p class="text-gray-700 leading-relaxed">{doc.excerpt}</p>
+            <p class="text-foreground-muted leading-relaxed">{doc.excerpt}</p>
           {/if}
         </div>
       </article>
@@ -69,7 +69,7 @@
       <footer class="flex items-center justify-between">
         <a
           href="/knowledge/{category}"
-          class="inline-flex items-center text-gray-600 hover:text-gray-900"
+          class="inline-flex items-center text-foreground-muted hover:text-foreground transition-colors"
           aria-label="Return to {categoryTitle}"
         >
           <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -81,7 +81,7 @@
         <div class="flex gap-4">
           <a
             href="mailto:autumn@grove.place"
-            class="text-gray-600 hover:text-gray-900"
+            class="text-foreground-muted hover:text-foreground transition-colors"
             aria-label="Contact support via email"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -93,18 +93,18 @@
     {:else}
       <!-- 404 -->
       <div class="text-center py-12">
-        <h1 class="text-4xl font-bold text-gray-900 mb-4">Document Not Found</h1>
-        <p class="text-xl text-gray-600 mb-8">
+        <h1 class="text-4xl font-bold text-foreground mb-4">Document Not Found</h1>
+        <p class="text-xl text-foreground-muted mb-8">
           The document you're looking for doesn't exist or has been moved.
         </p>
         <div class="flex gap-4 justify-center">
-          <a href="/knowledge" class="px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors">
+          <a href="/knowledge" class="px-4 py-2 bg-foreground text-background rounded-lg hover:bg-foreground-muted transition-colors">
             Knowledge Base Home
           </a>
-          <a href="/knowledge/specs" class="px-4 py-2 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors">
+          <a href="/knowledge/specs" class="px-4 py-2 bg-accent/10 text-accent rounded-lg hover:bg-accent/20 transition-colors">
             Browse Specs
           </a>
-          <a href="/knowledge/help" class="px-4 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors">
+          <a href="/knowledge/help" class="px-4 py-2 bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-lg hover:bg-blue-200 dark:hover:bg-blue-900/40 transition-colors">
             Browse Help
           </a>
         </div>

--- a/landing/src/routes/knowledge/help/+page.svelte
+++ b/landing/src/routes/knowledge/help/+page.svelte
@@ -10,44 +10,44 @@
   <meta name="description" content="Help articles and guides for using Grove platform" />
 </svelte:head>
 
-<div class="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+<div class="min-h-screen bg-page">
   <div class="max-w-6xl mx-auto px-4 py-12">
     <!-- Breadcrumb -->
-    <nav class="flex items-center space-x-2 text-sm text-gray-600 mb-8">
-      <a href="/knowledge" class="hover:text-blue-600">Knowledge Base</a>
+    <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
+      <a href="/knowledge" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Knowledge Base</a>
       <span>/</span>
-      <span class="text-gray-900">Help Center</span>
+      <span class="text-foreground">Help Center</span>
     </nav>
 
     <!-- Header -->
     <div class="mb-12">
-      <h1 class="text-4xl font-bold text-gray-900 mb-4">Help Center</h1>
-      <p class="text-xl text-gray-600 max-w-3xl">
-        Step-by-step guides and answers to common questions about using Grove. 
+      <h1 class="text-4xl font-bold text-foreground mb-4">Help Center</h1>
+      <p class="text-xl text-foreground-muted max-w-3xl">
+        Step-by-step guides and answers to common questions about using Grove.
         Whether you're just getting started or need help with a specific feature, you'll find it here.
       </p>
     </div>
 
     <!-- Getting Started Section -->
     <section class="mb-12">
-      <h2 class="text-2xl font-semibold text-gray-900 mb-6">Getting Started</h2>
+      <h2 class="text-2xl font-semibold text-foreground mb-6">Getting Started</h2>
       <div class="grid gap-4">
         {#each articles.filter(a => ['what-is-grove', 'writing-your-first-post', 'choosing-your-plan'].includes(a.slug)) as article}
-          <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">
-              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600">
+          <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+            <h3 class="text-lg font-semibold text-foreground mb-2">
+              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                 {article.title}
               </a>
             </h3>
-            <p class="text-gray-600 mb-3">{article.excerpt}</p>
+            <p class="text-foreground-muted mb-3">{article.excerpt}</p>
             <div class="flex items-center justify-between">
-              <a href="/knowledge/help/{article.slug}" class="text-blue-600 hover:text-blue-700 font-medium">
+              <a href="/knowledge/help/{article.slug}" class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
                 Read more
                 <svg class="w-4 h-4 ml-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                 </svg>
               </a>
-              <span class="text-sm text-gray-500">{article.readingTime} min read</span>
+              <span class="text-sm text-foreground-subtle">{article.readingTime} min read</span>
             </div>
           </article>
         {/each}
@@ -56,24 +56,24 @@
 
     <!-- Writing & Publishing -->
     <section class="mb-12">
-      <h2 class="text-2xl font-semibold text-gray-900 mb-6">Writing & Publishing</h2>
+      <h2 class="text-2xl font-semibold text-foreground mb-6">Writing & Publishing</h2>
       <div class="grid gap-4">
         {#each articles.filter(a => ['drafts-and-scheduling', 'tags-and-organization', 'exporting-your-content'].includes(a.slug)) as article}
-          <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">
-              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600">
+          <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+            <h3 class="text-lg font-semibold text-foreground mb-2">
+              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                 {article.title}
               </a>
             </h3>
-            <p class="text-gray-600 mb-3">{article.excerpt}</p>
+            <p class="text-foreground-muted mb-3">{article.excerpt}</p>
             <div class="flex items-center justify-between">
-              <a href="/knowledge/help/{article.slug}" class="text-blue-600 hover:text-blue-700 font-medium">
+              <a href="/knowledge/help/{article.slug}" class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
                 Read more
                 <svg class="w-4 h-4 ml-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                 </svg>
               </a>
-              <span class="text-sm text-gray-500">{article.readingTime} min read</span>
+              <span class="text-sm text-foreground-subtle">{article.readingTime} min read</span>
             </div>
           </article>
         {/each}
@@ -82,24 +82,24 @@
 
     <!-- Community & Social -->
     <section class="mb-12">
-      <h2 class="text-2xl font-semibold text-gray-900 mb-6">Community & Social</h2>
+      <h2 class="text-2xl font-semibold text-foreground mb-6">Community & Social</h2>
       <div class="grid gap-4">
         {#each articles.filter(a => ['opting-into-the-feed', 'reactions-and-voting', 'understanding-replies-vs-comments'].includes(a.slug)) as article}
-          <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">
-              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600">
+          <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+            <h3 class="text-lg font-semibold text-foreground mb-2">
+              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                 {article.title}
               </a>
             </h3>
-            <p class="text-gray-600 mb-3">{article.excerpt}</p>
+            <p class="text-foreground-muted mb-3">{article.excerpt}</p>
             <div class="flex items-center justify-between">
-              <a href="/knowledge/help/{article.slug}" class="text-blue-600 hover:text-blue-700 font-medium">
+              <a href="/knowledge/help/{article.slug}" class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
                 Read more
                 <svg class="w-4 h-4 ml-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                 </svg>
               </a>
-              <span class="text-sm text-gray-500">{article.readingTime} min read</span>
+              <span class="text-sm text-foreground-subtle">{article.readingTime} min read</span>
             </div>
           </article>
         {/each}
@@ -108,24 +108,24 @@
 
     <!-- Troubleshooting -->
     <section class="mb-12">
-      <h2 class="text-2xl font-semibold text-gray-900 mb-6">Troubleshooting</h2>
+      <h2 class="text-2xl font-semibold text-foreground mb-6">Troubleshooting</h2>
       <div class="grid gap-4">
         {#each articles.filter(a => ['my-site-isnt-loading'].includes(a.slug)) as article}
-          <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">
-              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600">
+          <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+            <h3 class="text-lg font-semibold text-foreground mb-2">
+              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                 {article.title}
               </a>
             </h3>
-            <p class="text-gray-600 mb-3">{article.excerpt}</p>
+            <p class="text-foreground-muted mb-3">{article.excerpt}</p>
             <div class="flex items-center justify-between">
-              <a href="/knowledge/help/{article.slug}" class="text-blue-600 hover:text-blue-700 font-medium">
+              <a href="/knowledge/help/{article.slug}" class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
                 Read more
                 <svg class="w-4 h-4 ml-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                 </svg>
               </a>
-              <span class="text-sm text-gray-500">{article.readingTime} min read</span>
+              <span class="text-sm text-foreground-subtle">{article.readingTime} min read</span>
             </div>
           </article>
         {/each}
@@ -134,17 +134,17 @@
 
     <!-- All Articles -->
     <section>
-      <h2 class="text-2xl font-semibold text-gray-900 mb-6">All Help Articles</h2>
+      <h2 class="text-2xl font-semibold text-foreground mb-6">All Help Articles</h2>
       <div class="grid md:grid-cols-2 gap-4">
         {#each articles as article}
-          <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 hover:shadow-md transition-shadow">
-            <h3 class="font-semibold text-gray-900 mb-1">
-              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600">
+          <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-4 hover:shadow-md transition-shadow">
+            <h3 class="font-semibold text-foreground mb-1">
+              <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                 {article.title}
               </a>
             </h3>
-            <p class="text-sm text-gray-600 mb-2">{article.excerpt}</p>
-            <div class="flex items-center justify-between text-xs text-gray-500">
+            <p class="text-sm text-foreground-muted mb-2">{article.excerpt}</p>
+            <div class="flex items-center justify-between text-xs text-foreground-subtle">
               <span>{article.readingTime} min read</span>
               {#if article.lastUpdated}
                 <span>Updated {article.lastUpdated}</span>
@@ -156,12 +156,12 @@
     </section>
 
     <!-- Contact Support -->
-    <div class="mt-12 bg-blue-50 rounded-lg p-8 text-center">
-      <h3 class="text-xl font-semibold text-gray-900 mb-2">Need more help?</h3>
-      <p class="text-gray-600 mb-4">
+    <div class="mt-12 bg-blue-50 dark:bg-blue-900/20 rounded-lg p-8 text-center border border-blue-200 dark:border-blue-800">
+      <h3 class="text-xl font-semibold text-foreground mb-2">Need more help?</h3>
+      <p class="text-foreground-muted mb-4">
         Can't find what you're looking for? Contact our support team and we'll get back to you within 48 hours.
       </p>
-      <a href="mailto:autumn@grove.place" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+      <a href="mailto:autumn@grove.place" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors">
         Contact Support
         <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />

--- a/landing/src/routes/knowledge/legal/+page.svelte
+++ b/landing/src/routes/knowledge/legal/+page.svelte
@@ -8,19 +8,19 @@
   <meta name="description" content="Legal documents, terms of service, privacy policy, and other policies for Grove platform" />
 </svelte:head>
 
-<div class="min-h-screen bg-gradient-to-b from-purple-50 to-white">
+<div class="min-h-screen bg-page">
   <div class="max-w-6xl mx-auto px-4 py-12">
     <!-- Breadcrumb -->
-    <nav class="flex items-center space-x-2 text-sm text-gray-600 mb-8">
-      <a href="/knowledge" class="hover:text-purple-600">Knowledge Base</a>
+    <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
+      <a href="/knowledge" class="hover:text-purple-600 dark:hover:text-purple-400 transition-colors">Knowledge Base</a>
       <span>/</span>
-      <span class="text-gray-900">Legal & Policies</span>
+      <span class="text-foreground">Legal & Policies</span>
     </nav>
 
     <!-- Header -->
     <div class="mb-12">
-      <h1 class="text-4xl font-bold text-gray-900 mb-4">Legal & Policies</h1>
-      <p class="text-xl text-gray-600 max-w-3xl">
+      <h1 class="text-4xl font-bold text-foreground mb-4">Legal & Policies</h1>
+      <p class="text-xl text-foreground-muted max-w-3xl">
         Our terms of service, privacy policy, and other legal documents.
         We believe in transparency and keeping these documents readable and straightforward.
       </p>
@@ -29,37 +29,37 @@
     <!-- Legal Docs List -->
     <div class="grid gap-6">
       {#each legalDocs as doc}
-        <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+        <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
           <div class="flex items-start justify-between mb-4">
             <div class="flex-1">
-              <h2 class="text-xl font-semibold text-gray-900 mb-2">
-                <a href="/knowledge/legal/{doc.slug}" class="hover:text-purple-600">
+              <h2 class="text-xl font-semibold text-foreground mb-2">
+                <a href="/knowledge/legal/{doc.slug}" class="hover:text-purple-600 dark:hover:text-purple-400 transition-colors">
                   {doc.title}
                 </a>
               </h2>
               {#if doc.description}
-                <p class="text-gray-600 mb-3">{doc.description}</p>
+                <p class="text-foreground-muted mb-3">{doc.description}</p>
               {/if}
-              <p class="text-gray-500 text-sm">{doc.excerpt}</p>
+              <p class="text-foreground-subtle text-sm">{doc.excerpt}</p>
             </div>
             <div class="ml-6 text-right">
-              <div class="text-sm text-gray-500 mb-1">{doc.readingTime} min read</div>
+              <div class="text-sm text-foreground-subtle mb-1">{doc.readingTime} min read</div>
               {#if doc.lastUpdated}
-                <div class="text-xs text-gray-400">Updated {doc.lastUpdated}</div>
+                <div class="text-xs text-foreground-faint">Updated {doc.lastUpdated}</div>
               {/if}
             </div>
           </div>
           <div class="flex items-center justify-between">
             <a
               href="/knowledge/legal/{doc.slug}"
-              class="inline-flex items-center text-purple-600 hover:text-purple-700 font-medium"
+              class="inline-flex items-center text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 font-medium transition-colors"
             >
               Read document
               <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
               </svg>
             </a>
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300">
               Legal Document
             </span>
           </div>
@@ -68,12 +68,12 @@
     </div>
 
     <!-- Contact CTA -->
-    <div class="mt-12 bg-purple-50 rounded-lg p-8 text-center">
-      <h3 class="text-xl font-semibold text-gray-900 mb-2">Questions about our policies?</h3>
-      <p class="text-gray-600 mb-4">
+    <div class="mt-12 bg-purple-50 dark:bg-purple-900/20 rounded-lg p-8 text-center border border-purple-200 dark:border-purple-800">
+      <h3 class="text-xl font-semibold text-foreground mb-2">Questions about our policies?</h3>
+      <p class="text-foreground-muted mb-4">
         If you have questions about our terms or policies, or need clarification on anything, please reach out.
       </p>
-      <a href="mailto:autumn@grove.place" class="inline-flex items-center px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors">
+      <a href="mailto:autumn@grove.place" class="inline-flex items-center px-4 py-2 bg-purple-600 dark:bg-purple-500 text-white rounded-lg hover:bg-purple-700 dark:hover:bg-purple-600 transition-colors">
         Contact Us
         <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />

--- a/landing/src/routes/knowledge/specs/+page.svelte
+++ b/landing/src/routes/knowledge/specs/+page.svelte
@@ -10,19 +10,19 @@
   <meta name="description" content="Technical specifications and implementation details for Grove platform" />
 </svelte:head>
 
-<div class="min-h-screen bg-gradient-to-b from-green-50 to-white">
+<div class="min-h-screen bg-page">
   <div class="max-w-6xl mx-auto px-4 py-12">
     <!-- Breadcrumb -->
-    <nav class="flex items-center space-x-2 text-sm text-gray-600 mb-8">
-      <a href="/knowledge" class="hover:text-green-600">Knowledge Base</a>
+    <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
+      <a href="/knowledge" class="hover:text-accent hover:text-accent-muted transition-colors">Knowledge Base</a>
       <span>/</span>
-      <span class="text-gray-900">Technical Specifications</span>
+      <span class="text-foreground">Technical Specifications</span>
     </nav>
 
     <!-- Header -->
     <div class="mb-12">
-      <h1 class="text-4xl font-bold text-gray-900 mb-4">Technical Specifications</h1>
-      <p class="text-xl text-gray-600 max-w-3xl">
+      <h1 class="text-4xl font-bold text-foreground mb-4">Technical Specifications</h1>
+      <p class="text-xl text-foreground-muted max-w-3xl">
         Detailed technical documentation about Grove's architecture, features, and implementation details.
         These specifications provide transparency into how Grove works and our design decisions.
       </p>
@@ -31,37 +31,37 @@
     <!-- Specs List -->
     <div class="grid gap-6">
       {#each specsList as spec}
-        <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+        <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
           <div class="flex items-start justify-between mb-4">
             <div class="flex-1">
-              <h2 class="text-xl font-semibold text-gray-900 mb-2">
-                <a href="/knowledge/specs/{spec.slug}" class="hover:text-green-600">
+              <h2 class="text-xl font-semibold text-foreground mb-2">
+                <a href="/knowledge/specs/{spec.slug}" class="hover:text-accent hover:text-accent-muted transition-colors">
                   {spec.title}
                 </a>
               </h2>
               {#if spec.description}
-                <p class="text-gray-600 mb-3">{spec.description}</p>
+                <p class="text-foreground-muted mb-3">{spec.description}</p>
               {/if}
-              <p class="text-gray-500 text-sm">{spec.excerpt}</p>
+              <p class="text-foreground-subtle text-sm">{spec.excerpt}</p>
             </div>
             <div class="ml-6 text-right">
-              <div class="text-sm text-gray-500 mb-1">{spec.readingTime} min read</div>
+              <div class="text-sm text-foreground-subtle mb-1">{spec.readingTime} min read</div>
               {#if spec.lastUpdated}
-                <div class="text-xs text-gray-400">Updated {spec.lastUpdated}</div>
+                <div class="text-xs text-foreground-faint">Updated {spec.lastUpdated}</div>
               {/if}
             </div>
           </div>
           <div class="flex items-center justify-between">
-            <a 
-              href="/knowledge/specs/{spec.slug}" 
-              class="inline-flex items-center text-green-600 hover:text-green-700 font-medium"
+            <a
+              href="/knowledge/specs/{spec.slug}"
+              class="inline-flex items-center text-accent hover:text-accent-muted font-medium transition-colors"
             >
               Read specification
               <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
               </svg>
             </a>
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-accent/10 text-accent dark:bg-accent/20 dark:text-accent-text">
               Technical Spec
             </span>
           </div>
@@ -70,12 +70,12 @@
     </div>
 
     <!-- CTA -->
-    <div class="mt-12 bg-green-50 rounded-lg p-8 text-center">
-      <h3 class="text-xl font-semibold text-gray-900 mb-2">Have questions about our specs?</h3>
-      <p class="text-gray-600 mb-4">
+    <div class="mt-12 bg-accent/5 dark:bg-accent/10 rounded-lg p-8 text-center border border-accent/20">
+      <h3 class="text-xl font-semibold text-foreground mb-2">Have questions about our specs?</h3>
+      <p class="text-foreground-muted mb-4">
         If you need clarification on any technical specification or want to suggest improvements, we'd love to hear from you.
       </p>
-      <a href="mailto:autumn@grove.place" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
+      <a href="mailto:autumn@grove.place" class="inline-flex items-center px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent-muted transition-colors">
         Contact Us
         <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />


### PR DESCRIPTION
- Add ThemeToggle component to Header for site-wide theme switching
- Replace hardcoded Tailwind colors with CSS variable classes across all knowledge base pages
- Update article display page with proper dark mode text colors
- Fix knowledge base home page to use theme-aware colors
- Update help, legal, and specs category pages with dark mode support
- Ensure all text is readable in both light and dark modes
- Add proper hover states and transitions for interactive elements

This resolves the readability issues where text was nearly invisible due to hardcoded light colors being used regardless of dark mode setting.