### PR TITLE
fix(landing): restore markdown formatting in knowledge base articles

### DIFF
--- a/landing/package.json
+++ b/landing/package.json
@@ -20,6 +20,7 @@
     "@sveltejs/adapter-cloudflare": "^4.7.4",
     "@sveltejs/kit": "^2.8.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.4",
+    "@tailwindcss/typography": "^0.5.19",
     "@testing-library/svelte": "^5.2.9",
     "autoprefixer": "^10.4.20",
     "jsdom": "^27.2.0",

--- a/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
+++ b/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
@@ -56,7 +56,7 @@
 
       <!-- Article Content -->
       <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-8 mb-8">
-        <div class="prose prose-lg max-w-none prose-headings:text-foreground prose-p:text-foreground-muted prose-a:text-accent-muted hover:prose-a:text-accent prose-strong:text-foreground prose-ul:text-foreground-muted prose-ol:text-foreground-muted prose-li:text-foreground-muted">
+        <div class="prose prose-lg max-w-none">
           {#if doc.html}
             {@html doc.html}
           {:else}

--- a/landing/tailwind.config.js
+++ b/landing/tailwind.config.js
@@ -24,8 +24,84 @@ export default {
 			fontFamily: {
 				serif: ['Lexend', 'Georgia', 'Cambria', 'Times New Roman', 'serif'],
 				sans: ['Lexend', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif']
-			}
+			},
+			typography: ({ theme }) => ({
+				DEFAULT: {
+					css: {
+						'--tw-prose-body': 'var(--color-foreground-muted)',
+						'--tw-prose-headings': 'var(--color-foreground)',
+						'--tw-prose-lead': 'var(--color-foreground-muted)',
+						'--tw-prose-links': 'var(--color-accent-text-muted)',
+						'--tw-prose-bold': 'var(--color-foreground)',
+						'--tw-prose-counters': 'var(--color-foreground-subtle)',
+						'--tw-prose-bullets': 'var(--color-foreground-subtle)',
+						'--tw-prose-hr': 'var(--color-border)',
+						'--tw-prose-quotes': 'var(--color-foreground)',
+						'--tw-prose-quote-borders': 'var(--color-accent-border)',
+						'--tw-prose-captions': 'var(--color-foreground-subtle)',
+						'--tw-prose-code': 'var(--color-foreground)',
+						'--tw-prose-pre-code': 'var(--color-foreground)',
+						'--tw-prose-pre-bg': 'var(--color-surface)',
+						'--tw-prose-th-borders': 'var(--color-border)',
+						'--tw-prose-td-borders': 'var(--color-border-subtle)',
+						// Links
+						a: {
+							color: 'var(--color-accent-text-muted)',
+							textDecoration: 'underline',
+							'&:hover': {
+								color: 'var(--color-primary)',
+							},
+						},
+						// Headings
+						h1: {
+							color: 'var(--color-foreground)',
+						},
+						h2: {
+							color: 'var(--color-foreground)',
+						},
+						h3: {
+							color: 'var(--color-foreground)',
+						},
+						h4: {
+							color: 'var(--color-foreground)',
+						},
+						// Strong/bold
+						strong: {
+							color: 'var(--color-foreground)',
+						},
+						// Code blocks
+						code: {
+							color: 'var(--color-foreground)',
+							backgroundColor: 'var(--color-surface)',
+							borderRadius: '0.25rem',
+							padding: '0.125rem 0.25rem',
+						},
+						'code::before': {
+							content: '""',
+						},
+						'code::after': {
+							content: '""',
+						},
+						// Pre blocks
+						pre: {
+							backgroundColor: 'var(--color-surface)',
+							color: 'var(--color-foreground)',
+						},
+						// Blockquotes
+						blockquote: {
+							borderLeftColor: 'var(--color-accent-border)',
+							color: 'var(--color-foreground-muted)',
+						},
+						// Horizontal rules
+						hr: {
+							borderColor: 'var(--color-border)',
+						},
+					},
+				},
+			}),
 		}
 	},
-	plugins: []
+	plugins: [
+		require('@tailwindcss/typography'),
+	]
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.4
         version: 4.0.4(svelte@5.45.3)(vite@5.4.21(@types/node@20.19.25))
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@3.4.18)
       '@testing-library/svelte':
         specifier: ^5.2.9
         version: 5.2.9(svelte@5.45.3)(vite@5.4.21(@types/node@20.19.25))(vitest@4.0.14)


### PR DESCRIPTION
The knowledge base articles were rendering as plain text because
@tailwindcss/typography plugin was not installed. This adds the plugin
and configures it to use the existing CSS variable theme system, ensuring
proper rendering of headers, bold, italics, lists, blockquotes, and code
blocks in both light and dark modes.