### PR TITLE
docs: add Grove launch email v1

### DIFF
--- a/docs/internal/grove-launch-email-v1.md
+++ b/docs/internal/grove-launch-email-v1.md
@@ -1,0 +1,95 @@
+# Grove Launch Email — Version 1
+
+*Created: December 22, 2025*
+
+---
+
+## Context
+
+This is the first email to the 60 people who signed up for Grove updates. They've been waiting. This is Autumn finally reaching out.
+
+**The moment:** Grove is 90% complete, launching early January 2025. Two strangers at Barnes & Noble talked with Autumn for 2 hours about the project — genuine excitement, not polite interest. That energy is what this email captures.
+
+**The goal:** Make subscribers feel like they're witnessing the next big thing. Give them a reason to explore the site. Encourage word-of-mouth.
+
+---
+
+## Final Email Draft
+
+**Subject:** I'm finally ready to show you what I've been building
+
+---
+
+You signed up to hear about Grove. I've been quiet. That changes now.
+
+Grove is a new social platform that goes against all the rules.
+
+You own your content. Your privacy is respected. There's no advertising. No data harvesting. No training AI on your posts. Everything is privacy-centric, from the ground up.
+
+Other platforms say that. We actually mean it.
+
+I'm launching in early January. The site is live. You can explore it right now.
+
+**[INSERT AUTUMN FOREST SCREENSHOT]**
+
+**→ grove.place**
+
+Look around. Poke at things. Check out the pricing. And if you like what you see — tell someone. Word of mouth is the only marketing Grove has.
+
+More soon.
+
+— Autumn
+
+---
+
+## Subject Line Options
+
+1. **I'm finally ready to show you what I've been building** ← selected
+2. Grove is almost here
+3. The next big thing (no, really)
+
+---
+
+## Visual Placement
+
+- **Image:** Screenshot of the forest page (`/forest`) in autumn mode
+- **Placement:** After "You can explore it right now."
+- **Link:** Make the image clickable, pointing to `grove.place/forest`
+- **Sizing:** Keep it reasonably sized for fast loading and mobile compatibility
+
+The forest page has three seasonal modes (summer, autumn, winter) with procedural tree generation, falling leaves, snowfall, and winter birds. The "You built this??" reaction is real — use it.
+
+---
+
+## Voice Notes
+
+Key phrases that landed:
+- "A new social site that goes against all the rules"
+- "We respect your privacy and you own your content. But, for real."
+- "No advertising. No data collection. Everything is privacy-centric, from the ground up."
+
+The "but for real" / "we actually mean it" framing acknowledges that other platforms make empty promises. Grove doesn't.
+
+---
+
+## Sending Options
+
+For 60 subscribers:
+- **Buttondown** — free tier, markdown-friendly, indie-focused
+- **Mailchimp** — free up to 500 contacts
+- **Loops** — newer, clean UI, founder-friendly
+- **BCC from personal email** — it's 60 people, it's personal, it works
+
+---
+
+## What's Next
+
+This is email #1. Future emails can cover:
+- The "why" behind Grove (the journey, the vision)
+- Feature deep-dives
+- Launch day announcement
+- Community building
+
+---
+
+*This email is Autumn stepping into the identity of someone who builds things and shares them with the world.*


### PR DESCRIPTION
First email draft for the 60 subscribers. Captures the "next big thing"
energy, includes the autumn forest visual hook, and keeps it personal.