### PR TITLE
feat(landing): add Header/Footer chrome to knowledge base pages

### DIFF
--- a/landing/src/routes/knowledge/+page.svelte
+++ b/landing/src/routes/knowledge/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  
+  import Header from '$lib/components/Header.svelte';
+  import Footer from '$lib/components/Footer.svelte';
+
   export let data;
   const { specs, helpArticles, legalDocs } = data;
-  
+
   let searchQuery = '';
-  
+
   function handleSearch() {
     if (searchQuery.trim()) {
       goto(`/knowledge/search?q=${encodeURIComponent(searchQuery)}`);
@@ -19,8 +21,11 @@
   <meta name="description" content="Learn about Grove's features, specifications, and how to use our platform" />
 </svelte:head>
 
-<div class="min-h-screen bg-page">
-  <div class="max-w-6xl mx-auto px-4 py-12">
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-6xl mx-auto">
     <!-- Header -->
     <div class="text-center mb-12">
       <h1 class="text-4xl font-bold text-foreground mb-4">Knowledge Base</h1>
@@ -173,4 +178,7 @@
       </div>
     </div>
   </div>
-</div>
+  </article>
+
+  <Footer />
+</main>

--- a/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
+++ b/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
+  import Header from '$lib/components/Header.svelte';
+  import Footer from '$lib/components/Footer.svelte';
 
   export let data;
 
@@ -15,8 +17,11 @@
   <meta name="description" content={doc?.description || doc?.excerpt || ''} />
 </svelte:head>
 
-<div class="min-h-screen bg-page">
-  <div class="max-w-4xl mx-auto px-4 py-12">
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-4xl mx-auto">
     {#if doc}
       <!-- Breadcrumb -->
       <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8" aria-label="Breadcrumb">
@@ -110,5 +115,8 @@
         </div>
       </div>
     {/if}
-  </div>
-</div>
+    </div>
+  </article>
+
+  <Footer />
+</main>

--- a/landing/src/routes/knowledge/help/+page.svelte
+++ b/landing/src/routes/knowledge/help/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { helpArticles } from '$lib/data/knowledge-base';
-  
+  import Header from '$lib/components/Header.svelte';
+  import Footer from '$lib/components/Footer.svelte';
+
   export let data;
   const { helpArticles: articles } = data;
 </script>
@@ -10,8 +12,11 @@
   <meta name="description" content="Help articles and guides for using Grove platform" />
 </svelte:head>
 
-<div class="min-h-screen bg-page">
-  <div class="max-w-6xl mx-auto px-4 py-12">
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-6xl mx-auto">
     <!-- Breadcrumb -->
     <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
       <a href="/knowledge" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Knowledge Base</a>
@@ -168,5 +173,7 @@
         </svg>
       </a>
     </div>
-  </div>
-</div>
+  </article>
+
+  <Footer />
+</main>

--- a/landing/src/routes/knowledge/legal/+page.svelte
+++ b/landing/src/routes/knowledge/legal/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import Header from '$lib/components/Header.svelte';
+  import Footer from '$lib/components/Footer.svelte';
+
   export let data;
   const { legalDocs } = data;
 </script>
@@ -8,8 +11,11 @@
   <meta name="description" content="Legal documents, terms of service, privacy policy, and other policies for Grove platform" />
 </svelte:head>
 
-<div class="min-h-screen bg-page">
-  <div class="max-w-6xl mx-auto px-4 py-12">
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-6xl mx-auto">
     <!-- Breadcrumb -->
     <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
       <a href="/knowledge" class="hover:text-purple-600 dark:hover:text-purple-400 transition-colors">Knowledge Base</a>
@@ -80,5 +86,7 @@
         </svg>
       </a>
     </div>
-  </div>
-</div>
+  </article>
+
+  <Footer />
+</main>

--- a/landing/src/routes/knowledge/search/+page.svelte
+++ b/landing/src/routes/knowledge/search/+page.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import { allDocs } from '$lib/data/knowledge-base';
-  
+  import Header from '$lib/components/Header.svelte';
+  import Footer from '$lib/components/Footer.svelte';
+
   export let data;
-  
+
   $: query = $page.url.searchParams.get('q') || '';
-  $: results = query ? allDocs.filter(doc => 
+  $: results = query ? allDocs.filter(doc =>
     doc.title.toLowerCase().includes(query.toLowerCase()) ||
     doc.excerpt.toLowerCase().includes(query.toLowerCase()) ||
     (doc.description && doc.description.toLowerCase().includes(query.toLowerCase()))
   ) : [];
-  
+
   $: categoryCounts = {
     specs: results.filter(d => d.category === 'specs').length,
     help: results.filter(d => d.category === 'help').length,
@@ -23,18 +25,21 @@
   <meta name="description" content="Search Grove's knowledge base for documentation and help articles" />
 </svelte:head>
 
-<div class="min-h-screen bg-gray-50">
-  <div class="max-w-6xl mx-auto px-4 py-12">
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-6xl mx-auto">
     <!-- Breadcrumb -->
-    <nav class="flex items-center space-x-2 text-sm text-gray-600 mb-8">
-      <a href="/knowledge" class="hover:text-gray-900">Knowledge Base</a>
+    <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
+      <a href="/knowledge" class="hover:text-foreground transition-colors">Knowledge Base</a>
       <span>/</span>
-      <span class="text-gray-900">Search</span>
+      <span class="text-foreground">Search</span>
     </nav>
 
     <!-- Search Header -->
     <div class="mb-8">
-      <h1 class="text-3xl font-bold text-gray-900 mb-4">Search Knowledge Base</h1>
+      <h1 class="text-3xl font-bold text-foreground mb-4">Search Knowledge Base</h1>
       <form method="GET" action="/knowledge/search" class="max-w-2xl">
         <div class="relative">
           <input
@@ -42,16 +47,16 @@
             name="q"
             value={query}
             placeholder="Search documentation..."
-            class="w-full px-4 py-3 pl-12 pr-20 text-gray-900 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            class="w-full px-4 py-3 pl-12 pr-20 text-foreground bg-surface-elevated border border-default rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent"
           />
           <div class="absolute inset-y-0 left-0 flex items-center pl-4">
-            <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-5 h-5 text-foreground-subtle" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
           </div>
           <button
             type="submit"
-            class="absolute inset-y-0 right-0 flex items-center pr-4 text-blue-600 hover:text-blue-700 font-medium"
+            class="absolute inset-y-0 right-0 flex items-center pr-4 text-accent hover:text-accent-muted font-medium"
           >
             Search
           </button>
@@ -62,11 +67,11 @@
     {#if query}
       <!-- Results Summary -->
       <div class="mb-6">
-        <p class="text-gray-600">
+        <p class="text-foreground-muted">
           Found {results.length} result{results.length !== 1 ? 's' : ''} for "<span class="font-medium">{query}</span>"
         </p>
         {#if results.length > 0}
-          <div class="flex gap-4 mt-2 text-sm text-gray-500">
+          <div class="flex gap-4 mt-2 text-sm text-foreground-subtle">
             {#if categoryCounts.specs > 0}
               <span>{categoryCounts.specs} specs</span>
             {/if}
@@ -84,31 +89,31 @@
       {#if results.length > 0}
         <div class="space-y-4">
           {#each results as doc}
-            <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+            <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
               <div class="flex items-start justify-between mb-2">
                 <div class="flex-1">
-                  <h2 class="text-lg font-semibold text-gray-900 mb-1">
-                    <a href="/knowledge/{doc.category}/{doc.slug}" class="hover:text-blue-600">
+                  <h2 class="text-lg font-semibold text-foreground mb-1">
+                    <a href="/knowledge/{doc.category}/{doc.slug}" class="hover:text-accent transition-colors">
                       {doc.title}
                     </a>
                   </h2>
                   {#if doc.description}
-                    <p class="text-gray-600 text-sm mb-2">{doc.description}</p>
+                    <p class="text-foreground-muted text-sm mb-2">{doc.description}</p>
                   {/if}
-                  <p class="text-gray-500 text-sm">{doc.excerpt}</p>
+                  <p class="text-foreground-subtle text-sm">{doc.excerpt}</p>
                 </div>
-                <span class="ml-4 inline-flex items-center px-2 py-1 rounded-full text-xs font-medium {doc.category === 'specs' ? 'bg-green-100 text-green-800' : doc.category === 'help' ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800'}">
+                <span class="ml-4 inline-flex items-center px-2 py-1 rounded-full text-xs font-medium {doc.category === 'specs' ? 'bg-accent/10 text-accent dark:bg-accent/20 dark:text-accent-text' : doc.category === 'help' ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300' : 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300'}">
                   {doc.category === 'specs' ? 'Spec' : doc.category === 'help' ? 'Help' : 'Legal'}
                 </span>
               </div>
               <div class="flex items-center justify-between mt-4">
-                <a href="/knowledge/{doc.category}/{doc.slug}" class="text-blue-600 hover:text-blue-700 font-medium text-sm">
+                <a href="/knowledge/{doc.category}/{doc.slug}" class="text-accent hover:text-accent-muted font-medium text-sm transition-colors">
                   Read more
                   <svg class="w-4 h-4 ml-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                   </svg>
                 </a>
-                <span class="text-sm text-gray-500">{doc.readingTime} min read</span>
+                <span class="text-sm text-foreground-subtle">{doc.readingTime} min read</span>
               </div>
             </article>
           {/each}
@@ -116,18 +121,18 @@
       {:else}
         <!-- No Results -->
         <div class="text-center py-12">
-          <svg class="w-16 h-16 text-gray-300 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-16 h-16 text-foreground-faint mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
-          <h3 class="text-lg font-medium text-gray-900 mb-2">No results found</h3>
-          <p class="text-gray-600 mb-4">
+          <h3 class="text-lg font-medium text-foreground mb-2">No results found</h3>
+          <p class="text-foreground-muted mb-4">
             We couldn't find any documentation matching your search. Try different keywords or browse our categories.
           </p>
           <div class="flex gap-4 justify-center">
-            <a href="/knowledge/specs" class="px-4 py-2 bg-green-100 text-green-700 rounded-lg hover:bg-green-200 transition-colors">
+            <a href="/knowledge/specs" class="px-4 py-2 bg-accent/10 text-accent rounded-lg hover:bg-accent/20 transition-colors">
               Browse Specs
             </a>
-            <a href="/knowledge/help" class="px-4 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors">
+            <a href="/knowledge/help" class="px-4 py-2 bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-lg hover:bg-blue-200 dark:hover:bg-blue-900/40 transition-colors">
               Browse Help Articles
             </a>
           </div>
@@ -136,14 +141,17 @@
     {:else}
       <!-- Empty State -->
       <div class="text-center py-12">
-        <svg class="w-16 h-16 text-gray-300 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-16 h-16 text-foreground-faint mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
-        <h3 class="text-lg font-medium text-gray-900 mb-2">Search our knowledge base</h3>
-        <p class="text-gray-600">
+        <h3 class="text-lg font-medium text-foreground mb-2">Search our knowledge base</h3>
+        <p class="text-foreground-muted">
           Enter a search term above to find documentation, help articles, and specifications.
         </p>
       </div>
     {/if}
-  </div>
-</div>
+    </div>
+  </article>
+
+  <Footer />
+</main>

--- a/landing/src/routes/knowledge/specs/+page.svelte
+++ b/landing/src/routes/knowledge/specs/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { specs } from '$lib/data/knowledge-base';
-  
+  import Header from '$lib/components/Header.svelte';
+  import Footer from '$lib/components/Footer.svelte';
+
   export let data;
   const { specs: specsList } = data;
 </script>
@@ -10,8 +12,11 @@
   <meta name="description" content="Technical specifications and implementation details for Grove platform" />
 </svelte:head>
 
-<div class="min-h-screen bg-page">
-  <div class="max-w-6xl mx-auto px-4 py-12">
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-6xl mx-auto">
     <!-- Breadcrumb -->
     <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
       <a href="/knowledge" class="hover:text-accent hover:text-accent-muted transition-colors">Knowledge Base</a>
@@ -82,5 +87,7 @@
         </svg>
       </a>
     </div>
-  </div>
-</div>
+  </article>
+
+  <Footer />
+</main>


### PR DESCRIPTION
Update all knowledge base pages to include the shared site chrome
(Header, Footer, mobile navigation) matching other pages like /vision.

Changes:
- Import Header and Footer components into all knowledge pages
- Wrap content in main/article structure with flex layout
- Update search page colors from hardcoded grays to design tokens
- Apply consistent max-width and spacing patterns