### PR TITLE
feat(ui): unify overlay menus with glass blur effect

### DIFF
--- a/landing/src/lib/components/Header.svelte
+++ b/landing/src/lib/components/Header.svelte
@@ -53,7 +53,7 @@
 	}
 </script>
 
-<header class="py-6 px-6 border-b border-default">
+<header class="relative z-30 py-6 px-6 border-b border-default">
 	<div class="{maxWidthClass[maxWidth]} mx-auto flex items-center justify-between">
 		<!-- Logo area -->
 		<div class="flex items-center gap-2">

--- a/packages/engine/src/lib/components/quota/UpgradePrompt.svelte
+++ b/packages/engine/src/lib/components/quota/UpgradePrompt.svelte
@@ -174,7 +174,7 @@
 {#if open}
   <!-- Backdrop -->
   <div
-    class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+    class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
     onclick={onClose}
     role="presentation"
   >

--- a/packages/engine/src/lib/ui/components/primitives/dialog/dialog-overlay.svelte
+++ b/packages/engine/src/lib/ui/components/primitives/dialog/dialog-overlay.svelte
@@ -12,7 +12,7 @@
 <DialogPrimitive.Overlay
 	bind:ref
 	class={cn(
-		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
+		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 backdrop-blur-sm",
 		className
 	)}
 	{...restProps}

--- a/packages/engine/src/lib/ui/components/primitives/sheet/sheet-overlay.svelte
+++ b/packages/engine/src/lib/ui/components/primitives/sheet/sheet-overlay.svelte
@@ -14,7 +14,7 @@
 <SheetPrimitive.Overlay
 	bind:ref
 	class={cn(
-		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
+		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 backdrop-blur-sm",
 		className
 	)}
 	{...restProps}

--- a/plant/src/routes/tour/+page.svelte
+++ b/plant/src/routes/tour/+page.svelte
@@ -224,7 +224,7 @@
 
 	<!-- Skip confirmation modal -->
 	{#if showSkipConfirm}
-		<div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+		<div class="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
 			<div class="card max-w-sm w-full animate-slide-up">
 				<div class="flex justify-between items-start mb-4">
 					<h2 class="text-lg font-medium text-foreground">Skip the tour?</h2>


### PR DESCRIPTION
- Add backdrop-blur-sm to sheet overlay for soft glass appearance
- Add backdrop-blur-sm to dialog overlay for consistency
- Add backdrop-blur-sm to UpgradePrompt modal
- Add backdrop-blur-sm to tour skip confirmation modal
- Change overlay opacity from 80% to 50% for softer feel
- Fix header z-index (z-30) so menu properly appears above season button

All overlays now have the beautiful glass blur aesthetic matching
the landing site's mobile menu.