### PR TITLE
feat(knowledge): add table of contents to knowledge book pages

### DIFF
--- a/landing/src/lib/types/docs.ts
+++ b/landing/src/lib/types/docs.ts
@@ -20,10 +20,19 @@ export interface Doc {
   readingTime: number;
 }
 
+/** Header extracted from markdown for table of contents */
+export interface DocHeader {
+  level: number;
+  text: string;
+  id: string;
+}
+
 /** Document with full content loaded (used for individual article pages) */
 export interface DocWithContent extends Doc {
   /** Raw markdown content */
   content: string;
   /** Rendered HTML content (safe to use with {@html} - see note above) */
   html: string;
+  /** Headers for table of contents */
+  headers: DocHeader[];
 }


### PR DESCRIPTION
- Add DocHeader type and headers field to DocWithContent interface
- Extract headers from markdown content for TOC generation
- Add desktop sidebar TOC and mobile floating button
- Import reusable TOC components from groveengine package
- Dynamic container width based on TOC presence