### PR TITLE
docs: add help center articles and status page spec

### DIFF
--- a/docs/help-center/articles/account-deletion.md
+++ b/docs/help-center/articles/account-deletion.md
@@ -1,0 +1,96 @@
+---
+title: "Deleting Your Account"
+slug: account-deletion
+category: data
+order: 3
+keywords: [delete, close, cancel, remove, account, data, gdpr, leave, goodbye]
+related: [exporting-your-content, understanding-your-privacy, cancellation-and-refunds]
+---
+
+# Deleting Your Account
+
+If you decide to leave Grove, you can delete your account and all associated data. Here's how it works.
+
+## Before you delete
+
+**Export your content first.** Once your account is deleted, we can't recover it. If there's anything you want to keep—posts, images, comments—export it before proceeding.
+
+Go to **Settings → Data → Export Data** to download a complete copy of everything.
+
+See [Exporting Your Content](/help/exporting-your-content) for details on what's included.
+
+## How to delete your account
+
+1. Go to **Settings → Account** in your admin panel
+2. Scroll to the **Danger Zone** section
+3. Click **Delete Account**
+4. Read the confirmation message carefully
+5. Type your blog URL to confirm (e.g., `myblog.grove.place`)
+6. Click **Permanently Delete**
+
+This action is irreversible.
+
+## What gets deleted
+
+**Immediately:**
+- Your admin panel access
+- Your blog becomes inaccessible
+- Your posts are unpublished
+- Your subdomain is released
+
+**Within 24 hours:**
+- Your account data is removed from active systems
+- Your images are queued for deletion
+
+**Within 90 days:**
+- All data is permanently purged from backups
+- Nothing recoverable remains
+
+## What about my custom domain?
+
+If you're on Oak or Evergreen with a custom domain:
+
+**Domain you brought (BYOD):** The domain is yours. Remove the DNS records pointing to Grove, and the domain is free to use elsewhere.
+
+**Domain included with Evergreen:** The domain is registered in your name. Request a transfer authorization code before deleting your account. We'll provide it within 48 hours. Once transferred to another registrar, the domain is fully yours.
+
+## Data retention timeline
+
+| Data Type | When Deleted |
+|-----------|--------------|
+| Blog posts | Immediately unpublished, purged within 24 hours |
+| Images/media | Queued immediately, deleted within 7 days |
+| Account info | Removed within 24 hours |
+| Comments on your posts | Deleted with your posts |
+| Your comments on other blogs | Anonymized, not deleted |
+| Backup copies | Purged within 90 days |
+
+## Cancellation vs. deletion
+
+These are different things:
+
+**Cancellation:** Stops your subscription. Your account remains, data stays, you just can't access paid features. Good if you might come back.
+
+**Deletion:** Removes everything. Your account, data, and blog are gone permanently. Only do this if you're sure.
+
+If you just want to stop paying, cancel your subscription instead. Your blog stays live on whatever plan you qualify for (or becomes inaccessible if you have no free tier equivalent).
+
+## If you change your mind
+
+**Before deletion completes:** You have a brief window (about 24 hours) where you can contact support to attempt to halt the process. No guarantees, but we'll try.
+
+**After deletion completes:** We cannot recover your account. The data is gone. You'd need to create a new account and start fresh.
+
+## Legal requests
+
+Under GDPR and similar laws, you have the right to request deletion of your personal data. Deleting your account fulfills this right. If you have specific questions about data deletion for legal purposes, contact us directly.
+
+## A final note
+
+We're sorry to see you go, but we respect your choice. Your data has always been yours—deleting it is your right.
+
+If something about Grove drove you away, we'd genuinely appreciate knowing what. A quick note to support helps us improve. But no pressure—you can delete silently if you prefer.
+
+---
+
+*Need help with the deletion process? [Contact support](/support) and we'll walk you through it.*

--- a/docs/help-center/articles/browser-compatibility.md
+++ b/docs/help-center/articles/browser-compatibility.md
@@ -1,0 +1,132 @@
+---
+title: "Browser Compatibility"
+slug: browser-compatibility
+category: troubleshooting
+order: 7
+keywords: [browser, chrome, firefox, safari, edge, mobile, compatibility, supported, not working]
+related: [my-site-isnt-loading, known-limitations]
+---
+
+# Browser Compatibility
+
+Grove works in all modern browsers. Here's what's supported and what to do if something isn't working right.
+
+## Supported browsers
+
+Grove is tested and works in:
+
+| Browser | Minimum Version | Notes |
+|---------|-----------------|-------|
+| **Chrome** | 90+ | Full support |
+| **Firefox** | 90+ | Full support |
+| **Safari** | 14+ | Full support |
+| **Edge** | 90+ | Full support (Chromium-based) |
+| **Mobile Safari** | iOS 14+ | Full support |
+| **Chrome Mobile** | Android 10+ | Full support |
+
+**In practice:** If your browser auto-updates (most do), you're fine. Grove uses standard web technologies that have been stable for years.
+
+## What "supported" means
+
+For readers visiting your blog:
+- Pages load correctly
+- Images display
+- Theme renders as intended
+- Navigation works
+- Comments and reactions function
+
+For you in the admin panel:
+- Editor works correctly
+- Image uploads succeed
+- Settings save properly
+- All admin features accessible
+
+## Browsers we don't support
+
+**Internet Explorer:** Not supported at all. IE was retired by Microsoft in 2022. If you're still using it, please switch to a modern browser.
+
+**Very old browser versions:** Browsers more than ~3 years out of date may have issues. CSS features or JavaScript APIs we rely on might not exist.
+
+**Text-only browsers:** Lynx, w3m, and similar text browsers will show content but without styling. This is fine for reading—the content is still accessible.
+
+## Known quirks
+
+### Safari private browsing
+
+Safari's private browsing mode blocks some storage features more aggressively than other browsers. The editor's autosave-to-local-storage feature may not work in private mode. Your work still saves to the server when you click Save—you just won't get the local backup.
+
+### Firefox strict tracking protection
+
+If you have Firefox's Enhanced Tracking Protection set to "Strict," it may occasionally interfere with authentication flows. If you can't log in, try setting tracking protection to "Standard" for Grove, or add an exception.
+
+### Mobile keyboards and the editor
+
+On some mobile devices, the formatting toolbar may compete with the keyboard for screen space. This is a limitation of mobile web editing in general. For long-form writing, we recommend a desktop or tablet.
+
+## If something isn't working
+
+### Step 1: Check your browser version
+
+- **Chrome:** Menu → Help → About Google Chrome
+- **Firefox:** Menu → Help → About Firefox
+- **Safari:** Safari menu → About Safari
+- **Edge:** Menu → Help and feedback → About Microsoft Edge
+
+If you're significantly out of date, update your browser first.
+
+### Step 2: Try a different browser
+
+If Grove works in Chrome but not Firefox (or vice versa), that helps us narrow down the issue. Cross-browser testing is useful diagnostic information.
+
+### Step 3: Clear your cache
+
+Old cached files can cause strange behavior:
+
+- **Chrome:** Settings → Privacy and security → Clear browsing data
+- **Firefox:** Settings → Privacy & Security → Clear Data
+- **Safari:** Safari menu → Clear History
+- **Edge:** Settings → Privacy, search, and services → Clear browsing data
+
+Select "Cached images and files" at minimum.
+
+### Step 4: Disable extensions
+
+Browser extensions—especially ad blockers, privacy tools, and script blockers—can interfere with Grove. Try disabling them temporarily to see if that's the cause.
+
+If an extension is the problem, you can usually whitelist Grove rather than disabling the extension entirely.
+
+### Step 5: Contact support
+
+If you've tried the above and things still aren't working, [contact us](/support) with:
+
+- Your browser and version
+- What you're trying to do
+- What's happening instead
+- Whether other browsers work
+
+We'll help figure it out.
+
+## For blog readers
+
+If someone tells you your blog isn't working for them:
+
+1. Ask what browser they're using
+2. Ask them to try clearing cache or a different browser
+3. If the issue persists, it might be on our end—check [status.grove.place](https://status.grove.place)
+
+Most "your site is broken" reports turn out to be temporary network issues or very outdated browsers.
+
+## Accessibility and assistive technology
+
+Grove aims to be accessible. We test with:
+
+- VoiceOver (macOS/iOS)
+- Screen readers (general compatibility)
+- Keyboard-only navigation
+- High contrast modes
+
+If you use assistive technology and encounter barriers, please let us know. Accessibility bugs are treated as high priority.
+
+---
+
+*Having browser issues we haven't covered? [Reach out](/support)—we want to know about edge cases.*

--- a/docs/help-center/articles/checking-grove-status.md
+++ b/docs/help-center/articles/checking-grove-status.md
@@ -1,0 +1,100 @@
+---
+title: "Checking Grove Status"
+slug: checking-grove-status
+category: troubleshooting
+order: 9
+keywords: [status, outage, down, maintenance, incident, issues, problems, not working]
+related: [my-site-isnt-loading, contact-support]
+---
+
+# Checking Grove Status
+
+If something seems off with Grove, here's how to find out what's happening.
+
+## The status page
+
+Grove's status page lives at **status.grove.place**.
+
+This is where we post updates whenever there's a known issue—outages, slowdowns, scheduled maintenance. If something's wrong on our end, it'll be listed here.
+
+## What you'll see
+
+### All systems operational
+
+When everything's working normally, you'll see a green banner and all components showing "Operational." This is the good state. Nothing to worry about.
+
+### Active incident
+
+If there's an ongoing issue, the page shows:
+
+- **What's affected** — Which parts of Grove are having problems (Blog Engine, CDN, Authentication, etc.)
+- **Current status** — Investigating, Identified, Monitoring, or Resolved
+- **Latest update** — What we know and what we're doing about it
+- **Timeline** — A history of updates since the incident started
+
+### Scheduled maintenance
+
+Sometimes we need to do planned work. When maintenance is scheduled, you'll see it listed on the status page in advance with:
+
+- When it's happening
+- What might be affected
+- Expected duration
+
+We try to schedule maintenance during low-traffic hours and keep it brief.
+
+## Subscribing to updates
+
+You can subscribe to status updates via RSS at `status.grove.place/feed`. Add this to your feed reader and you'll be notified when:
+
+- A new incident is reported
+- An incident status changes
+- An incident is resolved
+- Maintenance is scheduled
+
+You can also check your admin panel—active incidents appear in the **Messages** section.
+
+## What the components mean
+
+| Component | What it covers |
+|-----------|----------------|
+| Blog Engine | Publishing, editing, viewing blog posts |
+| CDN | Image and media loading |
+| Authentication | Signing in, session management |
+| Meadow | Community feed, reactions, voting |
+| Payments | Subscription billing, plan changes |
+| API | Backend services powering everything |
+
+## When to check vs. when to contact support
+
+**Check the status page first if:**
+- Your site isn't loading
+- Images aren't appearing
+- You can't sign in
+- Things feel slower than usual
+- Something that worked before suddenly doesn't
+
+If there's an active incident, we already know about it and are working on it. No need to contact support—we'll update the status page as things progress.
+
+**Contact support if:**
+- The status page shows all operational, but you're still having issues
+- Your problem seems specific to your account or blog
+- You've tried the troubleshooting steps and nothing helps
+
+## During an incident
+
+When there's an active incident:
+
+- **Don't panic.** We're on it.
+- **Check the status page** for updates rather than refreshing your broken blog repeatedly.
+- **Wait for the "Resolved" status** before expecting things to work normally.
+- **Cached pages might still work** even if the backend is having issues.
+
+We post updates as we learn more. If an incident is marked "Investigating," we're still figuring out what's wrong. "Identified" means we know the cause. "Monitoring" means we've deployed a fix and are watching to make sure it holds.
+
+## Historical incidents
+
+The status page shows the past 30 days of incidents. You can see what happened, how long it lasted, and how we handled it. This transparency is intentional—we want you to know our track record.
+
+---
+
+*If something's broken and the status page doesn't mention it, [let us know](/support). We want to know about issues we haven't caught yet.*

--- a/docs/help-center/articles/upgrading-or-downgrading.md
+++ b/docs/help-center/articles/upgrading-or-downgrading.md
@@ -1,0 +1,88 @@
+---
+title: "Upgrading or Downgrading Your Plan"
+slug: upgrading-or-downgrading
+category: billing
+order: 2
+keywords: [upgrade, downgrade, change plan, switch plan, subscription, billing, tier]
+related: [choosing-your-plan, understanding-your-plan, cancellation-and-refunds]
+---
+
+# Upgrading or Downgrading Your Plan
+
+You can change your Grove plan anytime. Here's how it works.
+
+## How to change your plan
+
+1. Go to **Settings → Plan** in your admin panel
+2. You'll see your current plan and available options
+3. Click **Change Plan**
+4. Select your new plan
+5. Confirm the change
+
+That's it. No hoops, no retention flows, no "are you sure?" five times.
+
+## When you upgrade
+
+**Immediate access.** The moment you upgrade, you get access to all features of your new plan. More posts, more storage, new themes—available right away.
+
+**Prorated billing.** You only pay the difference for the remainder of your billing cycle. If you're halfway through a month on Seedling ($8) and upgrade to Sapling ($12), you'll pay roughly $2 now for the rest of this month, then $12 starting next cycle.
+
+**What unlocks by plan:**
+
+| Upgrade to | You gain |
+|------------|----------|
+| Seedling → Sapling | 200 more posts, 4 GB storage, 7 themes, email forwarding |
+| Sapling → Oak | Unlimited posts, 15 GB storage, theme customizer, custom domain |
+| Oak → Evergreen | 80 GB more storage, custom fonts, included domain, support hours |
+
+## When you downgrade
+
+**Keep access until period ends.** When you downgrade, you keep your current plan's features until the end of your billing period. If you downgrade on day 10 of your month, you have 20 more days of your current plan.
+
+**Your content stays.** If you're over the new plan's limits, your existing content isn't deleted. You just can't publish new posts until you're under the limit.
+
+**Example:** You have 100 posts on Sapling (250 limit) and downgrade to Seedling (50 limit). All 100 posts remain published and visible. You just can't create post #101 until you delete or unpublish some.
+
+**Features revert.** When the billing period ends:
+- Theme customizer settings revert to defaults (if downgrading from Oak)
+- Custom domain stops working (if downgrading from Oak)
+- Some fonts become unavailable
+
+## What happens to my data?
+
+Nothing bad.
+
+- **Posts**: Stay published, stay accessible
+- **Images**: Remain in your media library
+- **Settings**: Preserved (though some options may become unavailable)
+- **Custom domain**: Stops resolving to your blog (but the domain is still yours)
+
+You never lose content because of a plan change.
+
+## Timing considerations
+
+**Upgrades:** Take effect immediately. Good for when you need a feature right now.
+
+**Downgrades:** Take effect at the end of your current billing period. You're already paid up—might as well use what you've got.
+
+**Tip:** If you're approaching your post limit on Seedling and not sure if you want to commit to Sapling, you can always upgrade for a month, see how it feels, and downgrade later. Your posts stay either way.
+
+## If you're on Free
+
+Free accounts can browse Meadow and comment on posts, but can't publish a blog. To start blogging, upgrade to Seedling or above.
+
+The upgrade path: **Free → Seedling → Sapling → Oak → Evergreen**
+
+You can jump to any paid tier directly—you don't have to go through them in order.
+
+## Payment method
+
+Plan changes use your existing payment method on file. If your card has expired or been replaced, you'll be prompted to update it before the change processes.
+
+## Refunds on downgrades
+
+Downgrades don't trigger refunds for the current period. You keep access to your current plan until the period ends, then move to the lower tier. If you need a refund for other reasons, see our [refund policy](/legal/refund-policy).
+
+---
+
+*Questions about which plan fits? [Ask us](/support)—we'll give you an honest recommendation.*

--- a/docs/specs/admin-panel-spec.md
+++ b/docs/specs/admin-panel-spec.md
@@ -1,0 +1,527 @@
+# Admin Panel Specification
+
+> The content management and site administration interface for Grove blogs
+
+**Internal Name**: Grove Admin
+**Access URL**: `{blog}.grove.place/admin`
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [Authentication](#authentication)
+4. [Navigation Structure](#navigation-structure)
+5. [Core Sections](#core-sections)
+6. [User Messages Panel](#user-messages-panel)
+7. [Mobile Experience](#mobile-experience)
+8. [Design System](#design-system)
+9. [API Integration](#api-integration)
+10. [Future Additions](#future-additions)
+
+---
+
+## Overview
+
+### Purpose
+
+The Grove Admin Panel is where bloggers manage their content, customize their site, and configure settings. It's designed to be simple, focused, and get out of the way—write, publish, done.
+
+### Design Philosophy
+
+- **Minimal by default**: Show what's needed, hide what isn't
+- **No anxiety-inducing metrics**: No real-time analytics dashboards
+- **Mobile-first**: Works on phones, tablets, and desktops
+- **Fast**: Quick navigation, instant saves, responsive UI
+- **Warm aesthetic**: Matches Grove's cozy, tea-shop vibe
+
+### Non-Goals
+
+- Complex analytics dashboards
+- SEO optimization tools
+- Plugin management
+- Multi-user collaboration (v1)
+
+---
+
+## Architecture
+
+### Tech Stack
+
+- **Framework**: SvelteKit 2.0+
+- **Styling**: Tailwind CSS + custom CSS variables
+- **UI Components**: Custom component library (`$lib/ui`)
+- **API**: RESTful endpoints via Cloudflare Workers
+- **State**: Svelte 5 runes ($state, $effect)
+
+### File Structure
+
+```
+packages/engine/src/routes/admin/
+├── +layout.svelte          # Admin layout with sidebar
+├── +layout.server.ts       # Auth check, user data
+├── +page.svelte            # Dashboard
+├── blog/
+│   ├── +page.svelte        # Post list
+│   ├── new/+page.svelte    # Create post
+│   └── edit/[slug]/        # Edit post
+├── pages/
+│   ├── +page.svelte        # Page list
+│   └── edit/[slug]/        # Edit page
+├── images/
+│   └── +page.svelte        # CDN uploader
+├── settings/
+│   └── +page.svelte        # Site settings
+└── messages/               # NEW: Platform messages
+    └── +page.svelte
+```
+
+### Shared Components
+
+```
+packages/engine/src/lib/components/admin/
+├── MarkdownEditor.svelte   # WYSIWYG-ish markdown editor
+├── FloatingToolbar.svelte  # Formatting toolbar
+├── GutterManager.svelte    # Line gutters for editor
+└── ImageUploader.svelte    # Drag-drop image upload
+```
+
+---
+
+## Authentication
+
+### Flow
+
+1. User visits `/admin`
+2. Server checks for valid session cookie
+3. If no session: redirect to Heartwood (GroveAuth)
+4. Heartwood authenticates (Google OAuth or Magic Code)
+5. Heartwood redirects back with auth token
+6. Admin creates session, sets cookie
+7. User lands on Dashboard
+
+### Session Management
+
+- Session cookie: `grove_session` (HttpOnly, Secure, SameSite=Lax)
+- Session duration: 30 days
+- Refresh: Extended on each authenticated request
+- Logout: Clears cookie, redirects to home
+
+### Authorization
+
+- Blog owners: Full access to their admin panel
+- No admin roles (single-owner blogs in v1)
+- Rate limiting on write operations
+
+---
+
+## Navigation Structure
+
+### Sidebar (Desktop)
+
+```
+┌────────────────────────────┐
+│ Admin Panel                │
+├────────────────────────────┤
+│ 🏠 Dashboard               │
+│ 📝 Blog Posts              │
+│ 📄 Pages                   │
+│ 📷 CDN Uploader            │
+│ 📢 Messages           NEW  │
+│ ⚙️ Settings                │
+├────────────────────────────┤
+│ user@email.com             │
+│ [Logout]                   │
+└────────────────────────────┘
+```
+
+### Mobile Navigation
+
+- Hamburger menu (top-left)
+- Slides in from left
+- Same sections as desktop
+- Overlay closes on tap outside
+
+### Section Descriptions
+
+| Section | Purpose |
+|---------|---------|
+| **Dashboard** | Quick overview, system health, quick actions |
+| **Blog Posts** | List, create, edit, delete blog posts |
+| **Pages** | Static pages (About, Contact, etc.) |
+| **CDN Uploader** | Upload images directly to media library |
+| **Messages** | Platform status, announcements (NEW) |
+| **Settings** | Site configuration, appearance, account |
+
+---
+
+## Core Sections
+
+### Dashboard
+
+The landing page after login. Intentionally simple.
+
+**Displays:**
+- Quick system health indicators (D1, KV, R2 status)
+- Quick action cards (New Post, Upload Image, View Site)
+- Recent activity summary (last 5 posts)
+- Active platform messages (if any)
+
+**Does NOT display:**
+- Visitor counts
+- Real-time analytics
+- Engagement metrics
+- Revenue numbers
+
+**Rationale**: Dashboards often create anxiety. Grove's dashboard answers "is everything working?" and provides quick shortcuts—nothing more.
+
+### Blog Posts
+
+List view of all blog posts with actions.
+
+**Features:**
+- Table view: Title, Date, Tags, Status, Actions
+- Filters: Published, Drafts, All
+- Sort: Date (newest first)
+- Actions: View, Edit, Delete
+- "New Post" button (prominent)
+
+**Post Editor:**
+- Markdown editor with toolbar
+- Live preview (toggle)
+- Autosave to local storage
+- Manual save to server
+- Fields: Title, Content, Slug, Excerpt, Featured Image, Tags
+- Publish/Draft toggle
+
+### Pages
+
+Same as Blog Posts, but for static pages.
+
+**Differences:**
+- No date display
+- No tags
+- Pages appear in navigation (configurable)
+- Slug determines URL path
+
+### CDN Uploader
+
+Direct upload to R2 storage.
+
+**Features:**
+- Drag-and-drop upload area
+- Paste from clipboard
+- Progress indicator
+- Copy URL button
+- Gallery view of recent uploads
+- File type restrictions (images only in v1)
+
+**Upload Flow:**
+1. User drops/selects file
+2. Client validates (type, size)
+3. Upload to `/api/upload` endpoint
+4. Worker stores in R2
+5. Returns CDN URL
+6. User can copy URL for use in posts
+
+### Settings
+
+Site configuration divided into sections.
+
+**Site Settings:**
+- Blog title
+- Blog description
+- Social links (Twitter, Mastodon, GitHub, etc.)
+
+**Appearance:**
+- Theme mode (Light / Dark / System)
+- Accent color picker
+- Font selection (plan-dependent)
+
+**Account:**
+- Email (display only, changed via Heartwood)
+- Current plan
+- Data export
+- Danger zone (delete account)
+
+**Cache Management:**
+- Clear all cache button
+- System health check
+
+---
+
+## User Messages Panel
+
+### Purpose
+
+Shows platform-wide status updates, maintenance notices, and system messages to users within their admin panel.
+
+### Location
+
+New sidebar item: **📢 Messages**
+
+Also displayed on Dashboard when there are active messages.
+
+### Data Source
+
+Pulls from the shared D1 database:
+- `status_incidents` (active incidents)
+- `status_scheduled` (upcoming maintenance)
+- `status_updates` (incident updates)
+
+### Display Types
+
+| Type | Icon | Display Duration |
+|------|------|------------------|
+| Active Incident | ⚠️ | Until resolved |
+| Scheduled Maintenance | 🔧 | Until completed |
+| Resolved Incident | ✓ | 24 hours after resolution |
+| Announcement | 📢 | As configured |
+
+### UI Design
+
+**On Dashboard (Summary):**
+```
+┌────────────────────────────────────────────────────────────────┐
+│ 📢 Messages                                                     │
+├────────────────────────────────────────────────────────────────┤
+│ ⚠️ CDN Degraded Performance                                    │
+│    Images may load slower than usual.                          │
+│    Status: Monitoring → View on status.grove.place             │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Messages Page (Full View):**
+```
+┌────────────────────────────────────────────────────────────────┐
+│ Messages                                                        │
+│ Platform status and announcements                               │
+├────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│ Active                                                          │
+│ ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│ ⚠️ CDN Degraded Performance                      Dec 20, 10:15 │
+│    Images may load slower than usual. We're on it.             │
+│    Affected: CDN                                                │
+│    Status: Monitoring                                           │
+│    Latest: "Fix deployed, watching for stability"               │
+│    [View on status.grove.place →]                              │
+│                                                                 │
+│ Upcoming                                                        │
+│ ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│ 🔧 Scheduled: Database Maintenance               Dec 22, 2:00  │
+│    Brief read-only period expected (~30 min).                  │
+│    Affected: Blog Engine, API                                   │
+│                                                                 │
+│ Recent (Past 24 Hours)                                          │
+│ ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│ ✓ Payment Processing Issue                       Dec 19, 15:00 │
+│    Resolved after 2 hours.                                      │
+│                                                                 │
+│ ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│ 📡 Subscribe to status updates: status.grove.place/feed        │
+│                                                                 │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### When Empty
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ Messages                                                        │
+│ Platform status and announcements                               │
+├────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│ ✓ All Systems Operational                                      │
+│                                                                 │
+│ No active incidents or scheduled maintenance.                  │
+│                                                                 │
+│ For real-time status updates, visit status.grove.place         │
+│                                                                 │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Badge Indicator
+
+When there are active incidents or upcoming maintenance:
+- Sidebar "Messages" item shows notification dot
+- Dashboard shows message summary card
+
+---
+
+## Mobile Experience
+
+### Responsive Breakpoints
+
+| Breakpoint | Behavior |
+|------------|----------|
+| < 768px | Mobile layout (hamburger nav) |
+| ≥ 768px | Desktop layout (sidebar visible) |
+
+### Mobile-Specific Adjustments
+
+- Sidebar slides in from left on hamburger tap
+- Table columns collapse (hide Tags, Date on mobile)
+- Editor toolbar stays fixed at bottom
+- Touch-friendly tap targets (44px minimum)
+- Swipe to close sidebar
+
+### Mobile Header
+
+```
+┌────────────────────────────────────────┐
+│ ☰    The Grove                         │
+└────────────────────────────────────────┘
+```
+
+---
+
+## Design System
+
+### Colors (CSS Variables)
+
+```css
+/* Light mode */
+--color-bg-primary: #fdfcfa;
+--color-bg-secondary: #f5f3ef;
+--color-text: #2d3436;
+--color-text-muted: #636e72;
+--color-primary: #2c5f2d;
+--color-border: #e0ddd8;
+
+/* Dark mode */
+--color-bg-primary-dark: #1a1d1e;
+--color-bg-secondary-dark: #232728;
+--color-text-dark: #e8e6e3;
+--color-text-muted-dark: #9ca3af;
+--color-primary-dark: #5cb85f;
+--color-border-dark: #3d4144;
+
+/* Status colors */
+--accent-success: #27ae60;
+--accent-warning: #f39c12;
+--accent-danger: #e74c3c;
+--accent-info: #3498db;
+```
+
+### Typography
+
+- **Font**: Lexend (default), configurable per-site
+- **Heading sizes**: 2rem (h1), 1.25rem (h2), 1rem (h3)
+- **Body**: 1rem (16px base)
+- **Small text**: 0.875rem
+
+### Spacing
+
+- Section padding: 1.5rem
+- Card padding: 1rem - 1.5rem
+- Gap between items: 0.75rem - 1rem
+- Border radius: var(--border-radius-standard) = 8px
+
+### Components
+
+| Component | Usage |
+|-----------|-------|
+| `Button` | Primary, secondary, danger variants |
+| `Card` | Content containers with optional title |
+| `Badge` | Tags, status indicators |
+| `Spinner` | Loading states |
+| `Toast` | Notifications (success, error) |
+
+---
+
+## API Integration
+
+### Endpoints Used
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/posts` | GET | List all posts |
+| `/api/posts` | POST | Create new post |
+| `/api/posts/:slug` | GET | Get single post |
+| `/api/posts/:slug` | PUT | Update post |
+| `/api/posts/:slug` | DELETE | Delete post |
+| `/api/pages` | GET/POST | Pages CRUD |
+| `/api/upload` | POST | Upload to R2 |
+| `/api/settings` | GET/PUT | Site settings |
+| `/api/admin/cache/clear` | POST | Clear KV cache |
+| `/api/status/messages` | GET | Platform messages (NEW) |
+
+### API Client
+
+```typescript
+// $lib/utils/api.ts
+export const api = {
+  async get(path: string) { ... },
+  async post(path: string, data: object) { ... },
+  async put(path: string, data: object) { ... },
+  async delete(path: string) { ... }
+};
+```
+
+### Error Handling
+
+- Toast notifications for user-facing errors
+- Console logging for debugging
+- Graceful degradation (show cached data if API fails)
+
+---
+
+## Future Additions
+
+### Planned Features
+
+| Feature | Priority | Description |
+|---------|----------|-------------|
+| **Comments moderation** | High | Approve/reject/delete comments |
+| **Analytics (basic)** | Medium | Aggregate page views, no tracking |
+| **Scheduled posts** | Medium | Publish at future date/time |
+| **Custom domain settings** | Medium | Configure custom domain (Oak+) |
+| **Theme customizer** | Low | Advanced appearance options (Oak+) |
+| **Sidebar links (Vines)** | Low | Manage sidebar link list |
+
+### Messages Panel Expansion
+
+Future versions may include:
+- Personal notifications (new comment, new reply)
+- Tips and onboarding messages
+- Feature announcements
+
+---
+
+## Implementation Notes
+
+### Current State
+
+The admin panel exists and is functional for:
+- ✅ Blog post management
+- ✅ Page management
+- ✅ CDN uploads
+- ✅ Settings (basic)
+- ✅ System health display
+
+### Needs Implementation
+
+- [ ] Messages panel (platform status)
+- [ ] Comments moderation section
+- [ ] Scheduled posts UI
+- [ ] Analytics section (basic)
+
+### Adding the Messages Panel
+
+1. Create `/admin/messages/+page.svelte`
+2. Add API endpoint `/api/status/messages`
+3. Add sidebar navigation item
+4. Add badge indicator for active incidents
+5. Add summary card to Dashboard
+
+---
+
+*Spec Version: 1.0*
+*Created: 2025-12-24*
+*Author: Claude (based on existing codebase exploration)*

--- a/docs/specs/status-page-spec.md
+++ b/docs/specs/status-page-spec.md
@@ -1,0 +1,747 @@
+# Status Page Specification
+
+> A public-facing status page for Grove platform health and incident communication
+
+**Public Domain**: `status.grove.place`
+**Internal Name**: Grove Status
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [Components & Services](#components--services)
+4. [Incident Types](#incident-types)
+5. [Database Schema](#database-schema)
+6. [Admin Interface](#admin-interface)
+7. [Public Interface](#public-interface)
+8. [User Notifications](#user-notifications)
+9. [API Specification](#api-specification)
+10. [Design & UX](#design--ux)
+
+---
+
+## Overview
+
+### Purpose
+
+The Grove Status page provides transparent, real-time communication about platform health. When something goes wrong—or when maintenance is planned—users can check status.grove.place to understand what's happening without needing to contact support.
+
+### Goals
+
+- **Transparency**: Honest, timely updates about platform issues
+- **Reduce support load**: Users can self-serve status information
+- **Build trust**: Proactive communication during incidents
+- **Simple administration**: Easy for Autumn to post updates from the admin panel
+
+### Non-Goals
+
+- Automated monitoring integration (v1 is manual updates)
+- Public incident reporting/submission
+- Complex SLA tracking or uptime percentages
+
+### Inspiration
+
+Modeled after Anthropic's Claude status page—clean, informative, focused on what matters.
+
+---
+
+## Architecture
+
+### High-Level Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        status.grove.place                            │
+│                     (Cloudflare Worker + Pages)                      │
+│                                                                      │
+│  ┌─────────────────────────────────────────────────────────────────┐│
+│  │                      Public Status Page                          ││
+│  │                                                                  ││
+│  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              ││
+│  │  │  Current    │  │  Component  │  │   Incident  │              ││
+│  │  │  Status     │  │  Status     │  │   History   │              ││
+│  │  └─────────────┘  └─────────────┘  └─────────────┘              ││
+│  │                                                                  ││
+│  │  ┌─────────────────────────────────────────────────────────────┐││
+│  │  │                    RSS Feed (/feed)                          │││
+│  │  └─────────────────────────────────────────────────────────────┘││
+│  └─────────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  │ reads from
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                           D1 Database                                │
+│                        (shared with Grove)                           │
+│                                                                      │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                  │
+│  │ components  │  │  incidents  │  │  updates    │                  │
+│  └─────────────┘  └─────────────┘  └─────────────┘                  │
+└─────────────────────────────────────────────────────────────────────┘
+                                  ▲
+                                  │ writes to
+                                  │
+┌─────────────────────────────────────────────────────────────────────┐
+│                    GroveAuth Admin Panel                             │
+│                   (Autumn's admin interface)                         │
+│                                                                      │
+│  ┌─────────────────────────────────────────────────────────────────┐│
+│  │                  Status Management Section                       ││
+│  │                                                                  ││
+│  │  - Create/update incidents                                       ││
+│  │  - Post incident updates                                         ││
+│  │  - Set component status                                          ││
+│  │  - Resolve incidents                                             ││
+│  └─────────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Tech Stack
+
+- **Frontend**: SvelteKit (static site generation for fast loading)
+- **Backend**: Cloudflare Worker (API endpoints)
+- **Database**: D1 (shared with main Grove database)
+- **Hosting**: Cloudflare Pages
+- **Styling**: Tailwind CSS (consistent with Grove aesthetic)
+
+---
+
+## Components & Services
+
+Grove's platform is divided into trackable components. Each component has its own status indicator.
+
+### Component List
+
+| Component | Description | Affects |
+|-----------|-------------|---------|
+| **Blog Engine** | Core blog functionality—publishing, reading, editing | All blog operations |
+| **CDN** | Image and media delivery via R2/Cloudflare | Media loading, image uploads |
+| **Authentication** | Heartwood login and session management | Sign-in, admin access |
+| **Meadow** | Community feed, reactions, voting | Social features |
+| **Payments** | Stripe integration for subscriptions | Plan upgrades, billing |
+| **API** | Backend API endpoints | All platform operations |
+
+### Component Statuses
+
+| Status | Color | Meaning |
+|--------|-------|---------|
+| **Operational** | Green | Everything working normally |
+| **Degraded Performance** | Yellow | Slower than usual, but functional |
+| **Partial Outage** | Orange | Some functionality unavailable |
+| **Major Outage** | Red | Component is down |
+| **Maintenance** | Blue | Planned maintenance in progress |
+
+---
+
+## Incident Types
+
+### Incident Classifications
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Outage** | Service unavailable | "Blog engine returning 500 errors" |
+| **Degraded Performance** | Service slow or unreliable | "Image uploads taking longer than usual" |
+| **Planned Maintenance** | Scheduled work | "Database migration scheduled for 2am UTC" |
+| **Security Incident** | Security-related issue | "Investigating unusual activity" |
+
+### Incident Lifecycle
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│ Investigating│────▶│  Identified  │────▶│  Monitoring  │────▶│   Resolved   │
+└──────────────┘     └──────────────┘     └──────────────┘     └──────────────┘
+       │                    │                    │                     │
+       ▼                    ▼                    ▼                     ▼
+  "We're aware       "Root cause         "Fix deployed,          "Incident
+   and looking        identified,          watching for           resolved"
+   into it"           working on fix"      stability"
+```
+
+### Incident States
+
+| State | Description |
+|-------|-------------|
+| **Investigating** | Aware of issue, determining cause |
+| **Identified** | Root cause found, working on fix |
+| **Monitoring** | Fix deployed, observing for stability |
+| **Resolved** | Issue fully resolved |
+
+---
+
+## Database Schema
+
+### Tables
+
+```sql
+-- Trackable platform components
+CREATE TABLE status_components (
+    id TEXT PRIMARY KEY,                    -- UUID
+    name TEXT NOT NULL,                     -- "Blog Engine", "CDN", etc.
+    slug TEXT UNIQUE NOT NULL,              -- "blog-engine", "cdn"
+    description TEXT,                       -- What this component does
+    display_order INTEGER DEFAULT 0,        -- Sort order on status page
+    current_status TEXT DEFAULT 'operational',  -- operational, degraded, partial_outage, major_outage, maintenance
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Incidents (outages, maintenance, etc.)
+CREATE TABLE status_incidents (
+    id TEXT PRIMARY KEY,                    -- UUID
+    title TEXT NOT NULL,                    -- "CDN Degraded Performance"
+    slug TEXT UNIQUE NOT NULL,              -- URL-friendly identifier
+    status TEXT NOT NULL,                   -- investigating, identified, monitoring, resolved
+    impact TEXT NOT NULL,                   -- none, minor, major, critical
+    type TEXT NOT NULL,                     -- outage, degraded, maintenance, security
+    started_at TEXT NOT NULL,               -- When incident began
+    resolved_at TEXT,                       -- When incident was resolved (null if ongoing)
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Updates posted to incidents (timeline)
+CREATE TABLE status_updates (
+    id TEXT PRIMARY KEY,                    -- UUID
+    incident_id TEXT NOT NULL,              -- Foreign key to incidents
+    status TEXT NOT NULL,                   -- Status at time of update
+    message TEXT NOT NULL,                  -- Update content (markdown supported)
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (incident_id) REFERENCES status_incidents(id)
+);
+
+-- Which components are affected by which incidents
+CREATE TABLE status_incident_components (
+    incident_id TEXT NOT NULL,
+    component_id TEXT NOT NULL,
+    PRIMARY KEY (incident_id, component_id),
+    FOREIGN KEY (incident_id) REFERENCES status_incidents(id),
+    FOREIGN KEY (component_id) REFERENCES status_components(id)
+);
+
+-- Scheduled maintenance announcements
+CREATE TABLE status_scheduled (
+    id TEXT PRIMARY KEY,                    -- UUID
+    title TEXT NOT NULL,                    -- "Database Migration"
+    description TEXT,                       -- Details about the maintenance
+    scheduled_start TEXT NOT NULL,          -- When maintenance begins
+    scheduled_end TEXT NOT NULL,            -- Expected end time
+    components TEXT NOT NULL,               -- JSON array of component IDs
+    status TEXT DEFAULT 'scheduled',        -- scheduled, in_progress, completed
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### Indexes
+
+```sql
+CREATE INDEX idx_incidents_started ON status_incidents(started_at DESC);
+CREATE INDEX idx_incidents_status ON status_incidents(status);
+CREATE INDEX idx_updates_incident ON status_updates(incident_id);
+CREATE INDEX idx_updates_created ON status_updates(created_at DESC);
+CREATE INDEX idx_scheduled_start ON status_scheduled(scheduled_start);
+```
+
+### Initial Component Data
+
+```sql
+INSERT INTO status_components (id, name, slug, description, display_order) VALUES
+('comp_blog', 'Blog Engine', 'blog-engine', 'Core blogging functionality', 1),
+('comp_cdn', 'CDN', 'cdn', 'Image and media delivery', 2),
+('comp_auth', 'Authentication', 'authentication', 'Login and session management', 3),
+('comp_meadow', 'Meadow', 'meadow', 'Community feed and social features', 4),
+('comp_payments', 'Payments', 'payments', 'Subscription and billing', 5),
+('comp_api', 'API', 'api', 'Backend API endpoints', 6);
+```
+
+---
+
+## Admin Interface
+
+### Location
+
+Status management lives in the GroveAuth admin panel under a new **Status** section in the sidebar.
+
+### Admin Sections
+
+#### Dashboard View
+
+Shows at a glance:
+- Current overall status
+- Any active incidents
+- Upcoming scheduled maintenance
+- Quick actions: "Report Incident", "Schedule Maintenance"
+
+#### Incident Management
+
+**Create Incident:**
+1. Title (required)
+2. Type: Outage / Degraded / Maintenance / Security
+3. Impact: Minor / Major / Critical
+4. Affected components (multi-select)
+5. Initial status: Investigating / Identified
+6. Initial update message (what you know so far)
+
+**Update Incident:**
+- Post new updates to the timeline
+- Change status (Investigating → Identified → Monitoring → Resolved)
+- Mark as resolved (sets resolved_at timestamp)
+
+**View History:**
+- List of past incidents
+- Filter by type, date range, component
+- Click to view full timeline
+
+#### Component Status
+
+- Override component status manually
+- Useful for quick "all clear" after incidents
+- Auto-updates when incidents are created/resolved
+
+#### Scheduled Maintenance
+
+- Schedule future maintenance windows
+- Set affected components
+- Auto-displays on status page when scheduled time approaches
+- Can convert to active incident when maintenance begins
+
+### Admin UI Wireframe
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ Status Management                                                    │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  Overall Status: [🟢 All Systems Operational]                       │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐ │
+│  │ Active Incidents (0)                                           │ │
+│  │                                                                 │ │
+│  │ No active incidents. All systems operational.                  │ │
+│  │                                                                 │ │
+│  │ [+ Report New Incident]                                        │ │
+│  └────────────────────────────────────────────────────────────────┘ │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐ │
+│  │ Scheduled Maintenance                                          │ │
+│  │                                                                 │ │
+│  │ No upcoming maintenance scheduled.                             │ │
+│  │                                                                 │ │
+│  │ [+ Schedule Maintenance]                                       │ │
+│  └────────────────────────────────────────────────────────────────┘ │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐ │
+│  │ Component Status                                               │ │
+│  │                                                                 │ │
+│  │ Blog Engine      [🟢 Operational  ▼]                           │ │
+│  │ CDN              [🟢 Operational  ▼]                           │ │
+│  │ Authentication   [🟢 Operational  ▼]                           │ │
+│  │ Meadow           [🟢 Operational  ▼]                           │ │
+│  │ Payments         [🟢 Operational  ▼]                           │ │
+│  │ API              [🟢 Operational  ▼]                           │ │
+│  └────────────────────────────────────────────────────────────────┘ │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Public Interface
+
+### Page Structure
+
+**Header:**
+- Grove Status logo
+- Current overall status indicator
+- Last updated timestamp
+
+**Current Status Section:**
+- Large status banner (All Operational / Active Incident)
+- Component status grid
+
+**Active Incidents:**
+- Displayed prominently if any
+- Shows latest update, timeline accessible
+
+**Scheduled Maintenance:**
+- Upcoming maintenance windows
+- When scheduled, how long expected
+
+**Incident History:**
+- 30-day rolling history
+- Expandable incident details
+- Full timeline for each incident
+
+**Footer:**
+- Link to subscribe (RSS)
+- Link to main Grove site
+- "Questions? Contact support"
+
+### Public Page Wireframe
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                                                                      │
+│  🌿 Grove Status                                    Last updated:    │
+│                                                     2 minutes ago    │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐ │
+│  │                                                                 │ │
+│  │           🟢 All Systems Operational                           │ │
+│  │                                                                 │ │
+│  └────────────────────────────────────────────────────────────────┘ │
+│                                                                      │
+│  Components                                                          │
+│  ─────────────────────────────────────────────────────────────────  │
+│  Blog Engine         🟢 Operational                                  │
+│  CDN                 🟢 Operational                                  │
+│  Authentication      🟢 Operational                                  │
+│  Meadow              🟢 Operational                                  │
+│  Payments            🟢 Operational                                  │
+│  API                 🟢 Operational                                  │
+│                                                                      │
+│  ─────────────────────────────────────────────────────────────────  │
+│                                                                      │
+│  Past Incidents (30 days)                                            │
+│                                                                      │
+│  ▼ December 20, 2025                                                │
+│    ✓ CDN Degraded Performance                        [Resolved]     │
+│      Resolved in 45 minutes                                         │
+│                                                                      │
+│  ▼ December 15, 2025                                                │
+│    ✓ Scheduled Maintenance - Database Migration      [Completed]    │
+│      Duration: 2 hours                                              │
+│                                                                      │
+│  No other incidents in the past 30 days.                            │
+│                                                                      │
+│  ─────────────────────────────────────────────────────────────────  │
+│                                                                      │
+│  📡 Subscribe via RSS    │    🌿 grove.place    │    📧 Support     │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Incident Detail View
+
+When clicking an incident:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  ← Back to Status                                                    │
+│                                                                      │
+│  CDN Degraded Performance                                            │
+│  ══════════════════════════════════════════════════════════════════ │
+│                                                                      │
+│  Status: ✓ Resolved                                                  │
+│  Duration: 45 minutes (Dec 20, 10:15 AM - 11:00 AM UTC)             │
+│  Affected: CDN                                                       │
+│                                                                      │
+│  Timeline                                                            │
+│  ─────────────────────────────────────────────────────────────────  │
+│                                                                      │
+│  11:00 AM  [Resolved]                                                │
+│            The issue has been resolved. Image delivery is back       │
+│            to normal speeds.                                         │
+│                                                                      │
+│  10:45 AM  [Monitoring]                                              │
+│            We've deployed a fix and are monitoring. Image            │
+│            loading times are improving.                              │
+│                                                                      │
+│  10:30 AM  [Identified]                                              │
+│            Root cause identified: cache invalidation issue           │
+│            following deployment. Working on a fix.                   │
+│                                                                      │
+│  10:15 AM  [Investigating]                                           │
+│            We're investigating reports of slow image loading.        │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## User Notifications
+
+### Messages Panel (User Admin Panels)
+
+Users see platform status in a **Messages** panel in their Grove admin dashboard.
+
+**What appears:**
+- Active incidents affecting the platform
+- Scheduled maintenance announcements
+- Resolved incidents (for 24 hours after resolution)
+
+**Display format:**
+```
+┌────────────────────────────────────────────────────────────────┐
+│ 📢 Messages                                                     │
+├────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│ ⚠️ CDN Degraded Performance                      Dec 20, 10:15 │
+│    Images may load slower than usual. We're on it.             │
+│    Status: Monitoring • View details →                         │
+│                                                                 │
+│ 🔧 Scheduled: Database Maintenance               Dec 22, 2:00  │
+│    Expect 30 minutes of read-only mode.                        │
+│    View details →                                              │
+│                                                                 │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**When empty:**
+```
+┌────────────────────────────────────────────────────────────────┐
+│ 📢 Messages                                                     │
+├────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│ ✓ No current issues. All systems operational.                  │
+│                                                                 │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### RSS Feed
+
+Available at `status.grove.place/feed`
+
+- Standard RSS 2.0 format
+- Includes all incidents and updates
+- Users can subscribe in their feed reader of choice
+- Updates posted when:
+  - New incident created
+  - Incident status changes
+  - Incident resolved
+  - Maintenance scheduled
+
+---
+
+## API Specification
+
+### Base URL
+
+```
+https://status.grove.place/api
+```
+
+### Public Endpoints (No Auth)
+
+#### `GET /status`
+
+Current overall status.
+
+**Response:**
+```json
+{
+  "status": "operational",
+  "components": [
+    {
+      "name": "Blog Engine",
+      "slug": "blog-engine",
+      "status": "operational"
+    },
+    {
+      "name": "CDN",
+      "slug": "cdn",
+      "status": "degraded"
+    }
+  ],
+  "activeIncidents": [
+    {
+      "id": "inc_xxx",
+      "title": "CDN Degraded Performance",
+      "status": "monitoring",
+      "impact": "minor",
+      "startedAt": "2025-12-20T10:15:00Z",
+      "latestUpdate": "We've deployed a fix and are monitoring."
+    }
+  ],
+  "scheduledMaintenance": [],
+  "updatedAt": "2025-12-20T10:45:00Z"
+}
+```
+
+#### `GET /incidents`
+
+List incidents (30-day history).
+
+**Query Parameters:**
+- `limit` (default: 20)
+- `offset` (default: 0)
+- `status` (filter: active, resolved, all)
+
+**Response:**
+```json
+{
+  "incidents": [
+    {
+      "id": "inc_xxx",
+      "title": "CDN Degraded Performance",
+      "slug": "cdn-degraded-performance-dec-20",
+      "status": "resolved",
+      "impact": "minor",
+      "type": "degraded",
+      "startedAt": "2025-12-20T10:15:00Z",
+      "resolvedAt": "2025-12-20T11:00:00Z",
+      "components": ["cdn"],
+      "updateCount": 4
+    }
+  ],
+  "total": 5,
+  "hasMore": false
+}
+```
+
+#### `GET /incidents/:slug`
+
+Single incident with full timeline.
+
+**Response:**
+```json
+{
+  "id": "inc_xxx",
+  "title": "CDN Degraded Performance",
+  "slug": "cdn-degraded-performance-dec-20",
+  "status": "resolved",
+  "impact": "minor",
+  "type": "degraded",
+  "startedAt": "2025-12-20T10:15:00Z",
+  "resolvedAt": "2025-12-20T11:00:00Z",
+  "components": [
+    {
+      "name": "CDN",
+      "slug": "cdn"
+    }
+  ],
+  "updates": [
+    {
+      "id": "upd_4",
+      "status": "resolved",
+      "message": "The issue has been resolved.",
+      "createdAt": "2025-12-20T11:00:00Z"
+    },
+    {
+      "id": "upd_3",
+      "status": "monitoring",
+      "message": "Fix deployed, monitoring.",
+      "createdAt": "2025-12-20T10:45:00Z"
+    }
+  ]
+}
+```
+
+#### `GET /feed`
+
+RSS feed of incidents.
+
+**Response:** RSS 2.0 XML
+
+### Admin Endpoints (Authenticated)
+
+These endpoints require authentication via GroveAuth.
+
+#### `POST /admin/incidents`
+
+Create new incident.
+
+#### `PATCH /admin/incidents/:id`
+
+Update incident status.
+
+#### `POST /admin/incidents/:id/updates`
+
+Post update to incident.
+
+#### `PATCH /admin/components/:slug`
+
+Update component status.
+
+#### `POST /admin/scheduled`
+
+Schedule maintenance.
+
+---
+
+## Design & UX
+
+### Visual Design
+
+- **Clean and minimal**: Focus on information, not decoration
+- **Consistent with Grove**: Same color palette, typography (Lexend)
+- **Status colors**: Green (good), Yellow (degraded), Orange (partial), Red (major), Blue (maintenance)
+- **Dark mode support**: Follows system preference
+
+### Mobile Considerations
+
+- Fully responsive
+- Component grid stacks on mobile
+- Incident timelines remain readable
+- Touch-friendly interactive elements
+
+### Accessibility
+
+- Proper color contrast ratios
+- Screen reader friendly status announcements
+- Keyboard navigable
+- Status not communicated by color alone (icons + text)
+
+### Performance
+
+- Static site generation where possible
+- API responses cached at edge
+- Minimal JavaScript
+- Fast initial load (status is time-sensitive)
+
+---
+
+## Implementation Notes
+
+### Phase 1 (MVP)
+
+- [ ] Database schema setup
+- [ ] Public status page (read-only)
+- [ ] Component status display
+- [ ] Incident history (30 days)
+- [ ] RSS feed
+
+### Phase 2
+
+- [ ] Admin interface in GroveAuth
+- [ ] Create/update incidents
+- [ ] Post incident updates
+- [ ] Manual component status override
+
+### Phase 3
+
+- [ ] Messages panel in user admin
+- [ ] Scheduled maintenance
+- [ ] Email notifications (optional)
+
+### Handoff Prompt for GroveAuth Agent
+
+When implementation is ready, use this prompt for the GroveAuth agent:
+
+```
+Implement the Status Management feature in the GroveAuth admin panel.
+
+Reference: /docs/specs/status-page-spec.md in the GroveEngine repository
+
+Key tasks:
+1. Add "Status" section to admin sidebar
+2. Create incident management UI (create, update, resolve)
+3. Add component status override controls
+4. Implement scheduled maintenance scheduling
+5. Connect to D1 database tables (status_components, status_incidents, status_updates)
+
+The admin panel already exists at packages/admin/. Follow existing patterns for:
+- Sidebar navigation (see +layout.svelte)
+- Form components and validation
+- API integration patterns
+
+Status data is written to the shared D1 database and read by status.grove.place.
+```
+
+---
+
+*Spec Version: 1.0*
+*Created: 2025-12-24*
+*Author: Claude (with guidance from Autumn)*

--- a/landing/src/lib/data/knowledge-base.ts
+++ b/landing/src/lib/data/knowledge-base.ts
@@ -87,6 +87,26 @@ export const specs: Doc[] = [
     lastUpdated: "2025-12-01",
     readingTime: 8,
   },
+  {
+    slug: "status-page-spec",
+    title: "Status Page Specification",
+    description: "Public-facing status page for platform health and incident communication",
+    excerpt:
+      "The Grove Status page provides transparent, real-time communication about platform health. When something goes wrong—or when maintenance is planned—users can check status.grove.place.",
+    category: "specs",
+    lastUpdated: "2025-12-24",
+    readingTime: 12,
+  },
+  {
+    slug: "admin-panel-spec",
+    title: "Admin Panel Specification",
+    description: "Content management and site administration interface",
+    excerpt:
+      "The Grove Admin Panel is where bloggers manage their content, customize their site, and configure settings. Designed to be simple, focused, and get out of the way.",
+    category: "specs",
+    lastUpdated: "2025-12-24",
+    readingTime: 10,
+  },
 ];
 
 // Help Center Articles
@@ -210,6 +230,126 @@ export const helpArticles: Doc[] = [
     category: "help",
     lastUpdated: "2025-12-01",
     readingTime: 2,
+  },
+  {
+    slug: "creating-your-account",
+    title: "Creating Your Account",
+    description: "How to sign up for Grove using Google authentication",
+    excerpt:
+      "Getting started with Grove takes about a minute. Grove uses Google for authentication—no new password to create or remember.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 3,
+  },
+  {
+    slug: "understanding-the-admin-panel",
+    title: "Understanding the Admin Panel",
+    description: "A tour of your Grove admin dashboard",
+    excerpt:
+      "Once you're signed in, the admin panel is your home base. Here's a quick tour of what you'll find and where to find it.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 4,
+  },
+  {
+    slug: "formatting-your-posts",
+    title: "Formatting Your Posts",
+    description: "Markdown syntax and formatting options for your writing",
+    excerpt:
+      "Grove uses Markdown for formatting—a simple way to style text that's been around since 2004. Here's everything you need.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 5,
+  },
+  {
+    slug: "adding-images-and-media",
+    title: "Adding Images and Media",
+    description: "How to upload and use images in your posts",
+    excerpt:
+      "Images make posts more engaging. Here's how to add them to your Grove blog, including supported formats and size limits.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 3,
+  },
+  {
+    slug: "choosing-a-theme",
+    title: "Choosing a Theme",
+    description: "Customize your blog's appearance with themes and colors",
+    excerpt:
+      "Your blog should feel like yours. Grove's theme system gives you meaningful customization without requiring design expertise.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 4,
+  },
+  {
+    slug: "what-is-meadow",
+    title: "What is Meadow?",
+    description: "Grove's community feed for discovering and sharing posts",
+    excerpt:
+      "Meadow is Grove's community feed—a shared space where bloggers can discover each other's work, react to posts, and have conversations.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 4,
+  },
+  {
+    slug: "known-limitations",
+    title: "Known Limitations",
+    description: "What Grove intentionally doesn't do",
+    excerpt:
+      "Grove is intentionally focused. Some things we don't do—not because we couldn't, but because they'd compromise what Grove is trying to be.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 5,
+  },
+  {
+    slug: "contact-support",
+    title: "Contacting Support",
+    description: "How to reach a real person when you need help",
+    excerpt:
+      "When you need help with something the documentation doesn't cover, here's how to reach a real person. No ticket system, no chatbot maze.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 3,
+  },
+  {
+    slug: "checking-grove-status",
+    title: "Checking Grove Status",
+    description: "How to check if Grove is experiencing issues",
+    excerpt:
+      "If something seems off with Grove, here's how to find out what's happening. Check status.grove.place for real-time updates.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 3,
+  },
+  {
+    slug: "upgrading-or-downgrading",
+    title: "Upgrading or Downgrading Your Plan",
+    description: "How to change your Grove subscription plan",
+    excerpt:
+      "You can change your Grove plan anytime. Upgrades take effect immediately; downgrades apply at the end of your billing period.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 4,
+  },
+  {
+    slug: "account-deletion",
+    title: "Deleting Your Account",
+    description: "How to close your Grove account and delete your data",
+    excerpt:
+      "If you decide to leave Grove, you can delete your account and all associated data. Export your content first—deletion is permanent.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 4,
+  },
+  {
+    slug: "browser-compatibility",
+    title: "Browser Compatibility",
+    description: "Supported browsers and troubleshooting tips",
+    excerpt:
+      "Grove works in all modern browsers. Here's what's supported and what to do if something isn't working right.",
+    category: "help",
+    lastUpdated: "2025-12-24",
+    readingTime: 4,
   },
 ];
 


### PR DESCRIPTION
New help articles:
- checking-grove-status: how to check status.grove.place
- upgrading-or-downgrading: plan change guide
- account-deletion: closing account process
- browser-compatibility: supported browsers

New specs:
- status-page-spec: technical spec for status.grove.place
- admin-panel-spec: documents current admin panel structure

Also registers existing articles in knowledge-base.ts that had
files but weren't indexed: creating-your-account, choosing-a-theme,
adding-images-and-media, formatting-your-posts, and others.