### PR TITLE
fix(docs): update help center links and references

### DIFF
--- a/docs/help-center/articles/account-deletion.md
+++ b/docs/help-center/articles/account-deletion.md
@@ -4,7 +4,7 @@ slug: account-deletion
 category: data
 order: 3
 keywords: [delete, close, cancel, remove, account, data, gdpr, leave, goodbye]
-related: [exporting-your-content, understanding-your-privacy, cancellation-and-refunds]
+related: [exporting-your-content, understanding-your-privacy]
 ---
 
 # Deleting Your Account
@@ -17,7 +17,7 @@ If you decide to leave Grove, you can delete your account and all associated dat
 
 Go to **Settings → Data → Export Data** to download a complete copy of everything.
 
-See [Exporting Your Content](/help/exporting-your-content) for details on what's included.
+See [Exporting Your Content](/knowledge/help/exporting-your-content) for details on what's included.
 
 ## How to delete your account
 

--- a/docs/help-center/articles/adding-images-and-media.md
+++ b/docs/help-center/articles/adding-images-and-media.md
@@ -4,7 +4,7 @@ slug: adding-images-and-media
 category: writing
 order: 3
 keywords: [images, photos, upload, media, pictures, gif, png, jpeg, webp, featured image]
-related: [writing-your-first-post, formatting-your-posts, the-markdown-editor]
+related: [writing-your-first-post, formatting-your-posts]
 ---
 
 # Adding Images and Media

--- a/docs/help-center/articles/choosing-your-plan.md
+++ b/docs/help-center/articles/choosing-your-plan.md
@@ -4,7 +4,7 @@ slug: choosing-your-plan
 category: getting-started
 order: 2
 keywords: [plan, pricing, tier, seedling, sapling, oak, evergreen, free, upgrade, subscription]
-related: [what-is-grove, understanding-your-plan, upgrading-or-downgrading]
+related: [what-is-grove, upgrading-or-downgrading]
 ---
 
 # Choosing Your Plan

--- a/docs/help-center/articles/drafts-and-scheduling.md
+++ b/docs/help-center/articles/drafts-and-scheduling.md
@@ -4,7 +4,7 @@ slug: drafts-and-scheduling
 category: writing
 order: 6
 keywords: [draft, drafts, save, auto-save, schedule, scheduling, publish later, unpublish]
-related: [writing-your-first-post, the-markdown-editor]
+related: [writing-your-first-post]
 ---
 
 # Drafts and Scheduling

--- a/docs/help-center/articles/exporting-your-content.md
+++ b/docs/help-center/articles/exporting-your-content.md
@@ -4,7 +4,7 @@ slug: exporting-your-content
 category: data
 order: 1
 keywords: [export, download, backup, data, portability, markdown, json, leaving, migrate]
-related: [understanding-your-privacy, data-portability, account-deletion]
+related: [understanding-your-privacy, account-deletion]
 ---
 
 # Exporting Your Content

--- a/docs/help-center/articles/formatting-your-posts.md
+++ b/docs/help-center/articles/formatting-your-posts.md
@@ -4,7 +4,7 @@ slug: formatting-your-posts
 category: writing
 order: 2
 keywords: [markdown, formatting, bold, italic, links, lists, headers, code, blockquotes]
-related: [writing-your-first-post, adding-images-and-media, the-markdown-editor]
+related: [writing-your-first-post, adding-images-and-media]
 ---
 
 # Formatting Your Posts
@@ -182,7 +182,7 @@ Footnotes appear at the bottom of your post, linked from where you reference the
 
 ## Images
 
-See [Adding Images and Media](/help/adding-images-and-media) for the full guide. The short version:
+See [Adding Images and Media](/knowledge/help/adding-images-and-media) for the full guide. The short version:
 
 ```markdown
 ![Alt text description](image-url.jpg)

--- a/docs/help-center/articles/known-limitations.md
+++ b/docs/help-center/articles/known-limitations.md
@@ -97,7 +97,7 @@ Some features are restricted by subscription tier:
 
 **Why:** Running a platform costs money. Tiered pricing lets Grove exist without ads, data mining, or venture capital pressure.
 
-See [Choosing Your Plan](/help/choosing-your-plan) for details on what each tier includes.
+See [Choosing Your Plan](/knowledge/help/choosing-your-plan) for details on what each tier includes.
 
 ## What if I need something that's limited?
 
@@ -113,7 +113,7 @@ No hard feelings. Use the tool that fits.
 
 ## Limitations vs. bugs
 
-If something isn't working as expected, that might be a bug rather than a limitation. [Contact support](/help/contact-support) and we'll figure out which it is.
+If something isn't working as expected, that might be a bug rather than a limitation. [Contact support](/knowledge/help/contact-support) and we'll figure out which it is.
 
 ---
 

--- a/docs/help-center/articles/my-site-isnt-loading.md
+++ b/docs/help-center/articles/my-site-isnt-loading.md
@@ -4,7 +4,7 @@ slug: my-site-isnt-loading
 category: troubleshooting
 order: 1
 keywords: [not loading, down, broken, error, 404, 500, can't access, offline, site down]
-related: [checking-grove-status, custom-domain-issues, contacting-support]
+related: [checking-grove-status, contact-support]
 ---
 
 # My Site Isn't Loading

--- a/docs/help-center/articles/reactions-and-voting.md
+++ b/docs/help-center/articles/reactions-and-voting.md
@@ -4,7 +4,7 @@ slug: reactions-and-voting
 category: meadow
 order: 3
 keywords: [meadow, reactions, voting, upvote, downvote, emoji, engagement, community]
-related: [what-is-meadow, opting-into-the-feed, your-meadow-profile]
+related: [what-is-meadow, opting-into-the-feed]
 ---
 
 # Reactions and Voting in Meadow

--- a/docs/help-center/articles/understanding-replies-vs-comments.md
+++ b/docs/help-center/articles/understanding-replies-vs-comments.md
@@ -4,7 +4,7 @@ slug: understanding-replies-vs-comments
 category: comments
 order: 1
 keywords: [comments, replies, private, public, moderation, feedback, readers]
-related: [moderating-your-comments, comment-settings, blocking-users]
+related: []
 ---
 
 # Understanding Replies vs. Comments

--- a/docs/help-center/articles/understanding-the-admin-panel.md
+++ b/docs/help-center/articles/understanding-the-admin-panel.md
@@ -4,7 +4,7 @@ slug: understanding-the-admin-panel
 category: getting-started
 order: 3
 keywords: [admin, dashboard, panel, navigation, settings, posts, pages, uploader]
-related: [creating-your-account, writing-your-first-post, site-title-and-description]
+related: [creating-your-account, writing-your-first-post]
 ---
 
 # Understanding the Admin Panel
@@ -51,7 +51,7 @@ Uploaded files are:
 - Available to use in any post or page
 - Organized by upload date
 
-See [Adding Images and Media](/help/adding-images-and-media) for format and size details.
+See [Adding Images and Media](/knowledge/help/adding-images-and-media) for format and size details.
 
 ### Settings
 

--- a/docs/help-center/articles/understanding-your-privacy.md
+++ b/docs/help-center/articles/understanding-your-privacy.md
@@ -4,7 +4,7 @@ slug: understanding-your-privacy
 category: data-and-privacy
 order: 1
 keywords: [privacy, data, tracking, analytics, gdpr, security, personal information]
-related: [exporting-your-data, deleting-your-account, what-is-grove]
+related: [exporting-your-content, account-deletion, what-is-grove]
 ---
 
 # Understanding Your Privacy

--- a/docs/help-center/articles/upgrading-or-downgrading.md
+++ b/docs/help-center/articles/upgrading-or-downgrading.md
@@ -4,7 +4,7 @@ slug: upgrading-or-downgrading
 category: billing
 order: 2
 keywords: [upgrade, downgrade, change plan, switch plan, subscription, billing, tier]
-related: [choosing-your-plan, understanding-your-plan, cancellation-and-refunds]
+related: [choosing-your-plan]
 ---
 
 # Upgrading or Downgrading Your Plan

--- a/docs/help-center/articles/writing-your-first-post.md
+++ b/docs/help-center/articles/writing-your-first-post.md
@@ -4,7 +4,7 @@ slug: writing-your-first-post
 category: writing-and-publishing
 order: 1
 keywords: [first post, writing, publish, getting started, new post, create]
-related: [what-is-grove, formatting-your-posts, saving-drafts]
+related: [what-is-grove, formatting-your-posts, drafts-and-scheduling]
 ---
 
 # Writing Your First Post


### PR DESCRIPTION
- Update all /help/ links to /knowledge/help/ for new route structure
- Remove broken frontmatter references in related: arrays
- Fix cross-references to use correct article slugs

This resolves prerender build failures caused by broken internal links.