### PR TITLE
docs: add Data Portability & Account Separation Policy to knowledge base

### DIFF
--- a/landing/src/lib/data/knowledge-base.ts
+++ b/landing/src/lib/data/knowledge-base.ts
@@ -496,6 +496,16 @@ export const legalDocs: Doc[] = [
     lastUpdated: "2025-12-01",
     readingTime: 3,
   },
+  {
+    slug: "data-portability-separation",
+    title: "Data Portability & Account Separation Policy",
+    description: "Your data export rights, domain ownership, and account cancellation terms",
+    excerpt:
+      "Your content is yours. Your domain is yours. Grove will never hold your data or domain hostage. This document outlines what happens when you cancel your subscription.",
+    category: "legal",
+    lastUpdated: "2025-12-01",
+    readingTime: 7,
+  },
 ];
 
 // Combined export for convenience


### PR DESCRIPTION
The 6th legal document about data portability and account separation was
already created but missing from the knowledge base listing. Adding it now
so it appears alongside the other legal documents.