### PR TITLE
fix(ui): make header sticky and fix mobile menu z-index on roadmap

### DIFF
--- a/landing/src/lib/components/Header.svelte
+++ b/landing/src/lib/components/Header.svelte
@@ -54,7 +54,7 @@
 	}
 </script>
 
-<header class="relative z-30 py-6 px-6 border-b border-default">
+<header class="sticky top-0 z-40 py-6 px-6 border-b border-default bg-surface/95 backdrop-blur-sm">
 	<div class="{maxWidthClass[maxWidth]} mx-auto flex items-center justify-between">
 		<!-- Logo area -->
 		<div class="flex items-center gap-2">

--- a/landing/src/lib/components/MobileMenu.svelte
+++ b/landing/src/lib/components/MobileMenu.svelte
@@ -104,7 +104,7 @@
 {#if open}
 	<button
 		type="button"
-		class="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm transition-opacity"
+		class="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm transition-opacity"
 		onclick={onClose}
 		aria-label="Close menu"
 	></button>
@@ -113,7 +113,7 @@
 <!-- Slide-out panel -->
 <div
 	bind:this={menuPanelRef}
-	class="fixed top-0 right-0 z-50 h-full w-64 transform bg-surface border-l border-default shadow-xl transition-transform duration-300 ease-out {open
+	class="fixed top-0 right-0 z-[70] h-full w-64 transform bg-surface border-l border-default shadow-xl transition-transform duration-300 ease-out {open
 		? 'translate-x-0'
 		: 'translate-x-full'}"
 	role="dialog"

--- a/landing/src/routes/roadmap/+page.svelte
+++ b/landing/src/routes/roadmap/+page.svelte
@@ -355,7 +355,7 @@
 
 	<!-- Navigation Pills -->
 	<nav
-		class="sticky top-0 z-50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm border-b border-divider py-3 px-4"
+		class="sticky top-[73px] z-30 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm border-b border-divider py-3 px-4"
 		aria-label="Development phases"
 	>
 		<div class="max-w-4xl mx-auto flex flex-wrap justify-center gap-2">


### PR DESCRIPTION
- Header is now sticky across all pages with backdrop blur
- Mobile menu z-index increased (60/70) to layer above roadmap nav (30)
- Roadmap sticky nav now positioned below header at top-[73px]