### PR TITLE
fix(ui): expand navbar max-width options for better tablet display

### DIFF
--- a/landing/src/lib/components/Header.svelte
+++ b/landing/src/lib/components/Header.svelte
@@ -16,9 +16,9 @@
 	let { maxWidth = 'default' }: Props = $props();
 
 	const maxWidthClass = {
-		narrow: 'max-w-2xl',
-		default: 'max-w-3xl',
-		wide: 'max-w-4xl'
+		narrow: 'max-w-3xl',
+		default: 'max-w-4xl',
+		wide: 'max-w-5xl'
 	};
 
 	// Mobile menu state


### PR DESCRIPTION
Bump each width class up one Tailwind level to give nav items more
breathing room, especially on tablets where 9 items were cramped.