### PR TITLE
fix(ui): replace opaque slate glass with translucent grove glass

### DIFF
--- a/landing/src/routes/about/+page.svelte
+++ b/landing/src/routes/about/+page.svelte
@@ -55,21 +55,21 @@
 					</p>
 
 					<div class="grid gap-6">
-						<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-6 border border-white/30 dark:border-slate-700/30 shadow-sm">
+						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">The Login Problem</h3>
 							<p class="text-foreground-muted font-sans leading-relaxed">
 								When you log in to one Grove site, that login should work everywhere in Grove. Getting this handoff smooth and fast was really hard. The solution: a special system that coordinates all the login stuff in one place, like a really smart bouncer who remembers every face.
 							</p>
 						</div>
 
-						<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-6 border border-white/30 dark:border-slate-700/30 shadow-sm">
+						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">The Speed Problem</h3>
 							<p class="text-foreground-muted font-sans leading-relaxed">
 								Every time someone visits a page, Grove used to have to look up a bunch of information from a database. That's slow when thousands of people are visiting at once. The solution: keep the most-used information ready to go, and only check the database occasionally.
 							</p>
 						</div>
 
-						<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-6 border border-white/30 dark:border-slate-700/30 shadow-sm">
+						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">The Scale Problem</h3>
 							<p class="text-foreground-muted font-sans leading-relaxed">
 								What works for 10 users might break with 1,000 users, and definitely breaks with 100,000. We're building systems that automatically handle more load without anyone having to do anything manually.

--- a/landing/src/routes/forest/+page.svelte
+++ b/landing/src/routes/forest/+page.svelte
@@ -572,7 +572,7 @@
 		<div class="absolute bottom-6 right-6 z-40">
 			<button
 				onclick={toggleSeason}
-				class="p-2 rounded-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm shadow-lg border border-white/20 hover:scale-110 transition-transform"
+				class="p-2 rounded-full bg-white/70 dark:bg-emerald-950/35 backdrop-blur-md shadow-lg border border-white/30 dark:border-emerald-800/25 hover:scale-110 transition-transform"
 				aria-label={isSpring ? 'Switch to summer' : isAutumn ? 'Switch to winter' : isWinter ? 'Switch to spring' : 'Switch to autumn'}
 			>
 				{#if isSpring}

--- a/landing/src/routes/pricing/+page.svelte
+++ b/landing/src/routes/pricing/+page.svelte
@@ -33,7 +33,7 @@
 			</header>
 
 			<!-- Pricing Table -->
-			<div class="overflow-x-auto mb-8 bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-4 border border-white/30 dark:border-slate-700/30 shadow-sm">
+			<div class="overflow-x-auto mb-8 bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-4 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 				<table class="w-full text-left border-collapse">
 					<thead>
 						<tr class="border-b-2 border-default">
@@ -158,7 +158,7 @@
 			</p>
 
 			<!-- Details Box -->
-			<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-8 border border-white/30 dark:border-slate-700/30 shadow-sm">
+			<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-8 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 				<h2 class="text-xl font-serif text-foreground mb-6">The Fine Print</h2>
 
 				<div class="space-y-6 text-sm font-sans text-foreground-muted">

--- a/landing/src/routes/roadmap/+page.svelte
+++ b/landing/src/routes/roadmap/+page.svelte
@@ -413,7 +413,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['first-frost'].features as feature}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-800/70 backdrop-blur-sm shadow-sm">
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-900/25 backdrop-blur-sm shadow-sm">
 							<Check class="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
 							<div>
 								<span class="font-medium text-slate-800 dark:text-slate-100">{feature.name}</span>
@@ -484,7 +484,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases.thaw.features as feature}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-800/70 backdrop-blur-sm border-l-4 border-accent shadow-sm">
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-900/25 backdrop-blur-sm border-l-4 border-accent shadow-sm">
 							<CircleDot class="w-5 h-5 text-accent mt-0.5 flex-shrink-0" />
 							<div>
 								<span class="font-medium text-slate-800 dark:text-slate-100">{feature.name}</span>
@@ -570,7 +570,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['first-buds'].features as feature}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-800/60 backdrop-blur-sm shadow-sm
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-900/25 backdrop-blur-sm shadow-sm
 							{feature.icon === 'ivy' ? 'border-l-4 border-green-500' : ''}
 							{feature.icon === 'amber' ? 'border-l-4 border-amber-500' : ''}"
 						>
@@ -666,7 +666,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['full-bloom'].features as feature}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-800/60 backdrop-blur-sm shadow-sm
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-900/25 backdrop-blur-sm shadow-sm
 							{feature.major ? 'border-2 border-green-300 dark:border-green-700' : ''}"
 						>
 							{#if feature.major}
@@ -766,7 +766,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['golden-hour'].features as feature}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm shadow-md border border-amber-200/50 dark:border-amber-800/30
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/70 dark:bg-slate-900/25 backdrop-blur-sm shadow-md border border-amber-200/50 dark:border-amber-800/30
 							{feature.major ? 'ring-2 ring-amber-400/50 dark:ring-amber-600/30' : ''}"
 						>
 							{#if feature.major}

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -227,7 +227,7 @@
 			</div>
 
 			<!-- More tools coming -->
-			<div class="text-center mt-12 p-8 rounded-xl bg-amber-100/50 dark:bg-slate-800/50 border border-dashed border-amber-300 dark:border-slate-600">
+			<div class="text-center mt-12 p-8 rounded-xl bg-amber-100/50 dark:bg-amber-950/25 backdrop-blur-md border border-dashed border-amber-300 dark:border-amber-800/30">
 				<p class="text-foreground-muted">
 					More tools are always being dreamed up in the workshop.
 				</p>

--- a/landing/src/routes/vision/+page.svelte
+++ b/landing/src/routes/vision/+page.svelte
@@ -60,7 +60,7 @@
 					<h2 class="text-2xl font-serif text-foreground mb-6">Core Values</h2>
 
 					<div class="grid gap-6">
-						<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-6 border border-white/30 dark:border-slate-700/30 shadow-sm">
+						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">Accessibility</h3>
 							<p class="text-foreground-muted font-sans leading-relaxed">
 								Everyone deserves a voice online. Pricing should never be the barrier that stops someone from sharing their story.
@@ -68,7 +68,7 @@
 							</p>
 						</div>
 
-						<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-6 border border-white/30 dark:border-slate-700/30 shadow-sm">
+						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">Ownership</h3>
 							<p class="text-foreground-muted font-sans leading-relaxed">
 								Your words are yours. Your data is yours. You can export everything, anytime.
@@ -76,7 +76,7 @@
 							</p>
 						</div>
 
-						<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-6 border border-white/30 dark:border-slate-700/30 shadow-sm">
+						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">Simplicity</h3>
 							<p class="text-foreground-muted font-sans leading-relaxed">
 								No feature bloat. No endless settings. Write in Markdown. Upload images. Publish. That's it.
@@ -84,7 +84,7 @@
 							</p>
 						</div>
 
-						<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-6 border border-white/30 dark:border-slate-700/30 shadow-sm">
+						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">Community With Care</h3>
 							<p class="text-foreground-muted font-sans leading-relaxed">
 								Intentionally queer-friendly. Welcoming to all. No engagement metrics breeding outrage.
@@ -92,7 +92,7 @@
 							</p>
 						</div>
 
-						<div class="bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm rounded-xl p-6 border border-white/30 dark:border-slate-700/30 shadow-sm">
+						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">AI Sanctuary</h3>
 							<p class="text-foreground-muted font-sans leading-relaxed">
 								Your words are not training data. Grove blocks every AI crawler, every scraper, every "search agent" that wants to harvest content for machine learning.

--- a/packages/engine/src/lib/ui/components/ui/Glass.svelte
+++ b/packages/engine/src/lib/ui/components/ui/Glass.svelte
@@ -76,43 +76,43 @@
 		...restProps
 	}: Props = $props();
 
-	// Background colors per variant
+	// Background colors per variant - warm grove tones, translucent for glass effect
 	const variantClasses: Record<Variant, string> = {
 		// High opacity for sticky headers/navbars (uses background color)
-		surface: "bg-background/95 dark:bg-background/95",
+		surface: "bg-background/90 dark:bg-background/90",
 
 		// Dark overlay for modals/sheets
 		overlay: "bg-black/50 dark:bg-black/60",
 
-		// Medium opacity for content cards
-		card: "bg-white/80 dark:bg-slate-800/70",
+		// Medium opacity for content cards - translucent with grove warmth
+		card: "bg-white/60 dark:bg-emerald-950/25",
 
 		// Light tint for text readability
-		tint: "bg-white/60 dark:bg-slate-900/50",
+		tint: "bg-white/50 dark:bg-emerald-950/20",
 
 		// Accent-colored glass for highlights/callouts
-		accent: "bg-accent/30 dark:bg-accent/20",
+		accent: "bg-accent/25 dark:bg-accent/15",
 
 		// Barely visible, very subtle
-		muted: "bg-white/40 dark:bg-slate-900/30"
+		muted: "bg-white/30 dark:bg-emerald-950/15"
 	};
 
-	// Blur intensity classes
+	// Blur intensity classes - default to medium blur for true glass effect
 	const intensityClasses: Record<Intensity, string> = {
 		none: "",
-		light: "backdrop-blur-sm",      // 4px
-		medium: "backdrop-blur",        // 8px
-		strong: "backdrop-blur-md"      // 12px
+		light: "backdrop-blur",         // 8px
+		medium: "backdrop-blur-md",     // 12px
+		strong: "backdrop-blur-lg"      // 16px
 	};
 
-	// Border classes per variant
+	// Border classes per variant - subtle borders that complement the glass
 	const borderClasses: Record<Variant, string> = {
 		surface: "border-border",
 		overlay: "border-white/10",
-		card: "border-border",
-		tint: "border-white/20 dark:border-slate-700/30",
+		card: "border-white/40 dark:border-emerald-800/25",
+		tint: "border-white/30 dark:border-emerald-800/20",
 		accent: "border-accent/30 dark:border-accent/20",
-		muted: "border-white/10 dark:border-slate-700/20"
+		muted: "border-white/20 dark:border-emerald-800/15"
 	};
 
 	// Shadow classes

--- a/packages/engine/src/lib/ui/components/ui/GlassButton.svelte
+++ b/packages/engine/src/lib/ui/components/ui/GlassButton.svelte
@@ -58,44 +58,44 @@
 		...restProps
 	}: Props = $props();
 
-	// Base styles shared by all variants
+	// Base styles shared by all variants - medium blur for glass effect
 	const baseClasses = `
 		inline-flex items-center justify-center gap-2
 		font-medium rounded-lg
 		transition-all duration-200
-		backdrop-blur-sm
+		backdrop-blur-md
 		outline-none
 		focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-2
 		disabled:opacity-50 disabled:pointer-events-none
 		[&_svg]:w-4 [&_svg]:h-4 [&_svg]:shrink-0
 	`.trim().replace(/\s+/g, ' ');
 
-	// Variant-specific styles
+	// Variant-specific styles - warm grove tones with true glass transparency
 	const variantClasses: Record<GlassVariant, string> = {
 		default: `
-			bg-white/70 dark:bg-slate-800/60
-			border border-white/30 dark:border-slate-600/30
+			bg-white/60 dark:bg-emerald-950/25
+			border border-white/40 dark:border-emerald-800/25
 			text-foreground
-			hover:bg-white/90 dark:hover:bg-slate-800/80
-			hover:border-white/50 dark:hover:border-slate-500/40
+			hover:bg-white/75 dark:hover:bg-emerald-950/35
+			hover:border-white/50 dark:hover:border-emerald-700/30
 			shadow-sm hover:shadow-md
 		`.trim().replace(/\s+/g, ' '),
 
 		accent: `
-			bg-accent/80 dark:bg-accent/70
+			bg-accent/70 dark:bg-accent/60
 			border border-accent/40 dark:border-accent/30
 			text-white
-			hover:bg-accent/95 dark:hover:bg-accent/85
+			hover:bg-accent/85 dark:hover:bg-accent/75
 			hover:border-accent/60 dark:hover:border-accent/50
 			shadow-sm hover:shadow-md shadow-accent/20
 		`.trim().replace(/\s+/g, ' '),
 
 		dark: `
-			bg-slate-900/70 dark:bg-slate-950/80
+			bg-slate-900/50 dark:bg-slate-950/50
 			border border-slate-700/30 dark:border-slate-600/30
 			text-white
-			hover:bg-slate-900/90 dark:hover:bg-slate-950/95
-			hover:border-slate-600/50 dark:hover:border-slate-500/40
+			hover:bg-slate-900/65 dark:hover:bg-slate-950/65
+			hover:border-slate-600/40 dark:hover:border-slate-500/35
 			shadow-md hover:shadow-lg
 		`.trim().replace(/\s+/g, ' '),
 
@@ -103,16 +103,16 @@
 			bg-transparent
 			border border-transparent
 			text-foreground
-			hover:bg-white/50 dark:hover:bg-slate-800/50
-			hover:border-white/20 dark:hover:border-slate-600/20
+			hover:bg-white/40 dark:hover:bg-emerald-950/25
+			hover:border-white/25 dark:hover:border-emerald-800/20
 		`.trim().replace(/\s+/g, ' '),
 
 		outline: `
 			bg-transparent
-			border border-white/40 dark:border-slate-600/40
+			border border-white/40 dark:border-emerald-800/30
 			text-foreground
-			hover:bg-white/30 dark:hover:bg-slate-800/30
-			hover:border-white/60 dark:hover:border-slate-500/50
+			hover:bg-white/25 dark:hover:bg-emerald-950/20
+			hover:border-white/55 dark:hover:border-emerald-700/40
 		`.trim().replace(/\s+/g, ' ')
 	};
 

--- a/packages/engine/src/lib/ui/components/ui/GlassCard.svelte
+++ b/packages/engine/src/lib/ui/components/ui/GlassCard.svelte
@@ -58,51 +58,51 @@
 		...restProps
 	}: Props = $props();
 
-	// Variant-specific styles
+	// Variant-specific styles - warm grove tones with true glass transparency
 	const variantClasses: Record<GlassVariant, string> = {
 		default: `
-			bg-white/70 dark:bg-slate-800/60
-			backdrop-blur-sm
+			bg-white/60 dark:bg-emerald-950/25
+			backdrop-blur-md
 		`.trim().replace(/\s+/g, ' '),
 
 		accent: `
 			bg-accent/20 dark:bg-accent/15
-			backdrop-blur-sm
+			backdrop-blur-md
 		`.trim().replace(/\s+/g, ' '),
 
 		dark: `
-			bg-slate-900/60 dark:bg-slate-950/70
-			backdrop-blur-sm
+			bg-slate-900/40 dark:bg-slate-950/40
+			backdrop-blur-md
 			text-white
 		`.trim().replace(/\s+/g, ' '),
 
 		muted: `
-			bg-white/40 dark:bg-slate-900/30
-			backdrop-blur-sm
+			bg-white/30 dark:bg-emerald-950/15
+			backdrop-blur
 		`.trim().replace(/\s+/g, ' '),
 
 		frosted: `
-			bg-white/85 dark:bg-slate-800/80
-			backdrop-blur-md
+			bg-white/70 dark:bg-emerald-950/35
+			backdrop-blur-lg
 		`.trim().replace(/\s+/g, ' ')
 	};
 
-	// Border colors per variant
+	// Border colors per variant - subtle, warm borders
 	const borderClasses: Record<GlassVariant, string> = {
-		default: "border-white/30 dark:border-slate-600/30",
+		default: "border-white/40 dark:border-emerald-800/25",
 		accent: "border-accent/30 dark:border-accent/20",
 		dark: "border-slate-700/30 dark:border-slate-600/30",
-		muted: "border-white/20 dark:border-slate-700/20",
-		frosted: "border-white/40 dark:border-slate-600/40"
+		muted: "border-white/20 dark:border-emerald-800/15",
+		frosted: "border-white/50 dark:border-emerald-800/30"
 	};
 
-	// Hover styles
+	// Hover styles - slightly more visible on hover
 	const hoverClasses: Record<GlassVariant, string> = {
-		default: "hover:bg-white/85 dark:hover:bg-slate-800/75 hover:shadow-lg hover:border-white/50 dark:hover:border-slate-500/40",
+		default: "hover:bg-white/70 dark:hover:bg-emerald-950/35 hover:shadow-lg hover:border-white/50 dark:hover:border-emerald-700/30",
 		accent: "hover:bg-accent/30 dark:hover:bg-accent/25 hover:shadow-lg hover:shadow-accent/10 hover:border-accent/40",
-		dark: "hover:bg-slate-900/75 dark:hover:bg-slate-950/85 hover:shadow-xl hover:border-slate-600/50",
-		muted: "hover:bg-white/55 dark:hover:bg-slate-900/45 hover:shadow-md hover:border-white/30",
-		frosted: "hover:bg-white/95 dark:hover:bg-slate-800/90 hover:shadow-lg hover:border-white/60"
+		dark: "hover:bg-slate-900/50 dark:hover:bg-slate-950/50 hover:shadow-xl hover:border-slate-600/40",
+		muted: "hover:bg-white/40 dark:hover:bg-emerald-950/25 hover:shadow-md hover:border-white/30",
+		frosted: "hover:bg-white/80 dark:hover:bg-emerald-950/45 hover:shadow-lg hover:border-white/60"
 	};
 
 	const computedClass = $derived(

--- a/plant/src/routes/+page.svelte
+++ b/plant/src/routes/+page.svelte
@@ -32,7 +32,7 @@
 	</div>
 
 	<!-- Auth options -->
-	<div class="card max-w-md mx-auto bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm border border-white/30 dark:border-slate-700/30">
+	<div class="card max-w-md mx-auto bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md border border-white/40 dark:border-emerald-800/25">
 		<h2 class="text-lg font-medium text-foreground mb-6 text-center">
 			Choose how to sign in
 		</h2>

--- a/plant/src/routes/plans/+page.svelte
+++ b/plant/src/routes/plans/+page.svelte
@@ -104,7 +104,7 @@
 
 	<!-- Billing toggle -->
 	<div class="flex justify-center mb-8">
-		<div class="inline-flex items-center gap-3 p-1 rounded-lg bg-white/70 dark:bg-slate-800/50 backdrop-blur-sm border border-white/30 dark:border-slate-700/30">
+		<div class="inline-flex items-center gap-3 p-1 rounded-lg bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md border border-white/40 dark:border-emerald-800/25">
 			<button
 				onclick={() => (billingCycle = 'monthly')}
 				class="px-4 py-2 rounded-md text-sm font-medium transition-all"


### PR DESCRIPTION
The glassmorphism overhaul used dark:bg-slate-800/50 which created
opaque blue cards that blocked the grove gradient backgrounds.

Changes:
- Replace slate-800 backgrounds with emerald-950 at 25% opacity
- Increase backdrop-blur from sm (4px) to md (12px) for true glass effect
- Update borders to use warm emerald-800 tones
- Fix Glass, GlassCard, and GlassButton component defaults
- Apply fixes across pricing, vision, about, roadmap, forest pages
- Apply fixes to plant auth and plans pages

The result is translucent cards that let the grove styling show through,
creating the warm glassmorphism effect originally intended.