### PR TITLE
fix(ui): remove opaque backgrounds to let leaf-pattern show through

### DIFF
--- a/landing/src/routes/about/+page.svelte
+++ b/landing/src/routes/about/+page.svelte
@@ -11,7 +11,7 @@
 	url="/about"
 />
 
-<main class="min-h-screen flex flex-col bg-gradient-to-b from-sky-50 via-white to-emerald-50 dark:from-slate-900 dark:via-slate-800 dark:to-emerald-950">
+<main class="min-h-screen flex flex-col">
 	<Header />
 
 	<!-- Content -->

--- a/landing/src/routes/journey/+page.svelte
+++ b/landing/src/routes/journey/+page.svelte
@@ -94,7 +94,7 @@
 	url="/journey"
 />
 
-<main class="min-h-screen flex flex-col bg-gradient-to-b from-sky-50 via-white to-emerald-50 dark:from-slate-900 dark:via-slate-800 dark:to-emerald-950">
+<main class="min-h-screen flex flex-col">
 	<Header />
 
 	<article class="flex-1 px-6 py-12">

--- a/landing/src/routes/pricing/+page.svelte
+++ b/landing/src/routes/pricing/+page.svelte
@@ -11,7 +11,7 @@
 	url="/pricing"
 />
 
-<main class="min-h-screen flex flex-col bg-gradient-to-b from-sky-50 via-white to-emerald-50 dark:from-slate-900 dark:via-slate-800 dark:to-emerald-950">
+<main class="min-h-screen flex flex-col">
 	<Header maxWidth="wide" />
 
 	<!-- Content -->

--- a/landing/src/routes/vision/+page.svelte
+++ b/landing/src/routes/vision/+page.svelte
@@ -11,7 +11,7 @@
 	url="/vision"
 />
 
-<main class="min-h-screen flex flex-col bg-gradient-to-b from-sky-50 via-white to-emerald-50 dark:from-slate-900 dark:via-slate-800 dark:to-emerald-950">
+<main class="min-h-screen flex flex-col">
 	<Header />
 
 	<!-- Content -->


### PR DESCRIPTION
Content pages were using full-page gradients that completely covered
the leaf-pattern decorations from the layout. These pages should be
transparent so the vine decorations remain visible.

Affected pages:
- /vision
- /about
- /pricing
- /journey

The glass cards within these pages still have their translucent
backgrounds for readability - only the full-page opaque gradients
were removed.

Note: Roadmap/workshop pages intentionally keep their themed backgrounds
as they have custom seasonal visual designs.