### PR TITLE
fix(og): remove fallback OG tags that override dynamic images

### DIFF
--- a/landing/src/app.html
+++ b/landing/src/app.html
@@ -19,16 +19,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="description" content="Grove: a place to Be. Coming soon." />
 		<meta name="theme-color" content="#16a34a" />
-		<meta property="og:title" content="Grove" />
-		<meta property="og:description" content="A place to Be. Coming soon." />
-		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://grove.place" />
-		<meta property="og:image" content="https://grove.place/og-image.png" />
-		<meta property="og:image:type" content="image/png" />
-		<meta property="og:image:width" content="1200" />
-		<meta property="og:image:height" content="630" />
-		<meta property="og:image" content="https://grove.place/og-image.svg" />
-		<meta property="og:image:type" content="image/svg+xml" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/landing/src/routes/credits/+page.svelte
+++ b/landing/src/routes/credits/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Header from '$lib/components/Header.svelte';
 	import Footer from '$lib/components/Footer.svelte';
+	import SEO from '$lib/components/SEO.svelte';
 	import { TableOfContents, MobileTOC } from '@autumnsgrove/groveengine';
 
 	const headers = [
@@ -16,10 +17,11 @@
 	];
 </script>
 
-<svelte:head>
-	<title>Credits — Grove</title>
-	<meta name="description" content="The people, projects, and tools that make Grove possible." />
-</svelte:head>
+<SEO
+	title="Credits — Grove"
+	description="The people, projects, and tools that make Grove possible."
+	url="/credits"
+/>
 
 <main class="min-h-screen flex flex-col">
 	<Header />


### PR DESCRIPTION
The fallback OG meta tags in app.html were appearing before the
page-specific tags from the SEO component. Since crawlers use the
first matching meta tag, the static fallbacks were always used
instead of the dynamic OG images from /api/og.

- Remove og:title, og:description, og:image fallbacks from app.html
- Add SEO component to credits page for dynamic OG images