### PR TITLE
feat(landing): add plant.grove.place CTA to homepage

### DIFF
--- a/landing/src/routes/+page.svelte
+++ b/landing/src/routes/+page.svelte
@@ -18,7 +18,8 @@
 		Users,
 		Download,
 		ArrowRight,
-		MapPin
+		MapPin,
+		Sprout
 	} from 'lucide-svelte';
 
 	// Get error from URL if present
@@ -99,7 +100,7 @@
 			class="btn-primary inline-flex items-center gap-2 text-base mb-4"
 		>
 			Plant Your Blog
-			<Sparkles class="w-4 h-4" />
+			<Sprout class="w-4 h-4" />
 		</a>
 		<p class="text-foreground-subtle text-sm font-sans mb-6">
 			Signups aren't open yet, but feel free to look around.


### PR DESCRIPTION
Add prominent "Plant Your Blog" button linking to the signup portal,
with a note that signups aren't open yet but visitors can explore.