### PR TITLE
fix(engine): use $derived.by for complex derived value in GlassLogo

### DIFF
--- a/packages/engine/src/lib/ui/components/ui/GlassLogo.svelte
+++ b/packages/engine/src/lib/ui/components/ui/GlassLogo.svelte
@@ -135,7 +135,7 @@
 	const seasonColors = $derived(season ? seasonalPalettes[season] : null);
 
 	// Glass color schemes per variant, with seasonal override support
-	const variantColors = $derived(() => {
+	const variantColors = $derived.by(() => {
 		// If accentColor is provided, it takes precedence over season
 		if (accentColor) {
 			return {
@@ -215,7 +215,7 @@
 		};
 
 		return baseColors[variant];
-	})();
+	});
 
 	// Breathing animation
 	const breathValue = tweened(0, { easing: cubicInOut });


### PR DESCRIPTION
The $derived rune was incorrectly used with an immediately-invoked
function expression. Svelte 5 requires $derived.by() for complex
derived values that use function bodies with multiple statements.