### PR TITLE
fix: shorten Camille and Carmen credit entries

### DIFF
--- a/landing/src/routes/credits/+page.svelte
+++ b/landing/src/routes/credits/+page.svelte
@@ -128,7 +128,7 @@
 									<span class="supporter-context">order picker, wife & mom of 3</span>
 								</div>
 								<p class="supporter-note">
-									One of the best energies around. She has such an amazing personality, is so friendly, and very loving. She loves big, I can tell. She always gives me a hug and is absolutely thrilled to see me bloom.
+									One of the best energies around. Always gives me a hug and is thrilled to see me bloom.
 								</p>
 							</div>
 							<div class="supporter-card">
@@ -137,7 +137,7 @@
 									<span class="supporter-context">flooring/appliances</span>
 								</div>
 								<p class="supporter-note">
-									A grounding energy in that place. Every time I talk to her I feel more confident about my ambitions and purpose. She is so encouraging, and so very excited for everything in the Grove project. Love her lots. She also might one day get a grove of her own—she wants to have a blog talking about spiritual things!
+									A grounding energy—so encouraging about the Grove project. Might one day get a grove of her own to write about spiritual things.
 								</p>
 							</div>
 							<div class="supporter-item">


### PR DESCRIPTION
Condensed both extended entries to be consistent with the standard
length of other credit cards while preserving the warm, personal tone.