### PR TITLE
docs: clarify that reading Grove blogs is free

### DIFF
--- a/docs/help-center/articles/choosing-your-plan.md
+++ b/docs/help-center/articles/choosing-your-plan.md
@@ -9,6 +9,8 @@ related: [what-is-grove, upgrading-or-downgrading]
 
 # Choosing Your Plan
 
+**First, the important bit:** Reading Grove blogs is free. Always. Every blog is publicly accessible — just visit and read, no account needed. You only need a plan if you want to *write* your own blog.
+
 Grove has a few plans, each designed for different needs. Here's what you get at each level.
 
 ## The plans

--- a/docs/help-center/articles/what-is-grove.md
+++ b/docs/help-center/articles/what-is-grove.md
@@ -15,6 +15,8 @@ Grove is a blogging platform for people who want their own space on the internet
 
 You get a blog. It's yours. You write, we host it, your readers can find you via your own URL. No ads, no algorithms deciding who sees your posts, no tracking your visitors.
 
+**Reading is free. Always.** Every Grove blog is publicly accessible — just visit and read, no account needed. You only pay if you want to write your own blog.
+
 ## What makes Grove different
 
 **You own your content.** Everything you write belongs to you. You can export it anytime, in standard formats that work anywhere. If you ever leave, your words come with you.
@@ -44,7 +46,7 @@ If you need e-commerce, complex membership tiers, or a design tool with infinite
 
 ## Pricing
 
-Grove has a few plans, starting with **Seedling** (free, with limits) up through paid tiers that unlock more posts, storage, and features. We're transparent about what each plan includes—no hidden fees, no bait-and-switch.
+Grove has a **Free** tier for readers and community members, and paid plans starting at **$8/month (Seedling)** for bloggers. Higher tiers unlock more posts, storage, and features. We're transparent about what each plan includes—no hidden fees, no bait-and-switch.
 
 See current pricing at [grove.place/pricing](/pricing).
 

--- a/docs/marketing/grove-at-a-glance.md
+++ b/docs/marketing/grove-at-a-glance.md
@@ -19,8 +19,11 @@ You get `yourname.grove.place` — a website that's yours. Write posts, share th
 **Who is it for?**
 Writers who want a home on the internet without the surveillance, manipulation, and noise of social media. People who remember when the web felt personal.
 
-**How much does it cost?**
-Plans start at $8/month. No free tier with hidden catches — just straightforward pricing for a service that respects you.
+**Is it free to read?**
+Yes. Reading is free. Always. Every Grove blog is publicly accessible — just visit and read, no account needed. You only pay if you want to *write* your own blog.
+
+**How much does it cost to write?**
+Plans start at $8/month. No hidden catches — just straightforward pricing for a service that respects you.
 
 **Where do I start?**
 Visit [grove.place](https://grove.place) and join the waitlist. We're launching soon.

--- a/landing/src/routes/+page.svelte
+++ b/landing/src/routes/+page.svelte
@@ -279,8 +279,11 @@
 
 	<!-- Pricing teaser -->
 	<section class="w-full max-w-md mb-12 text-center">
+		<p class="text-foreground font-sans font-medium mb-2">
+			Reading is free. Always.
+		</p>
 		<p class="text-foreground-muted font-sans mb-4">
-			Plans start at <span class="text-foreground font-medium">$8/month</span>. No free tier with hidden catches — just straightforward pricing for a service that respects you.
+			Every Grove blog is publicly accessible — just visit and read, no account needed. When you're ready to write your own, plans start at <span class="text-foreground font-medium">$8/month</span>.
 		</p>
 		<a
 			href="/pricing"

--- a/landing/src/routes/about/+page.svelte
+++ b/landing/src/routes/about/+page.svelte
@@ -42,8 +42,11 @@
 					<p class="text-foreground-muted font-sans leading-relaxed mb-4">
 						Imagine you're building a neighborhood of tiny houses. Each person gets their own house (their website at <code>yourname.grove.place</code>), but they all share some common infrastructure — the roads, the power grid, the community center.
 					</p>
-					<p class="text-foreground-muted font-sans leading-relaxed">
+					<p class="text-foreground-muted font-sans leading-relaxed mb-4">
 						Grove is all of that infrastructure: the roads (how you get to any site), the power grid (keeping everything fast and reliable), the locks on the doors (making sure only you can access your stuff), and eventually the community center (where people can interact with each other).
+					</p>
+					<p class="text-foreground-muted font-sans leading-relaxed">
+						<strong class="text-foreground">And reading is free.</strong> Every Grove blog is publicly accessible — no account, no paywall, no hoops to jump through. Just visit and read. The paid plans are for people who want to <em>write</em>, not for people who want to read.
 					</p>
 				</section>
 

--- a/landing/src/routes/vision/+page.svelte
+++ b/landing/src/routes/vision/+page.svelte
@@ -62,9 +62,12 @@
 					<div class="grid gap-6">
 						<div class="bg-white/60 dark:bg-emerald-950/25 backdrop-blur-md rounded-xl p-6 border border-white/40 dark:border-emerald-800/25 shadow-sm">
 							<h3 class="text-lg font-serif text-accent-muted mb-2">Accessibility</h3>
-							<p class="text-foreground-muted font-sans leading-relaxed">
+							<p class="text-foreground-muted font-sans leading-relaxed mb-3">
 								Everyone deserves a voice online. Pricing should never be the barrier that stops someone from sharing their story.
 								The basic tier exists so that anyone who wants to write can afford to write.
+							</p>
+							<p class="text-foreground-muted font-sans leading-relaxed">
+								<strong class="text-foreground">Reading is always free.</strong> Every Grove blog is publicly accessible — no login, no paywall. You pay to write, not to read.
 							</p>
 						</div>
 


### PR DESCRIPTION
Add prominent "Reading is free. Always." messaging across the site to
make it crystal clear that Grove blogs are publicly accessible without
any account or payment. Updates:

- Landing page: Add free reading callout in pricing section
- About page: Note that reading requires no account or paywall
- Vision page: Expand accessibility value to include free reading
- grove-at-a-glance.md: Add "Is it free to read?" FAQ
- what-is-grove.md: Fix pricing error (Seedling is $8, not free)
- choosing-your-plan.md: Lead with free reading note