### PR TITLE
docs: update launch delay email with IRS closure details

### DIFF
--- a/docs/internal/grove-launch-email-v4-delay-notice.md
+++ b/docs/internal/grove-launch-email-v4-delay-notice.md
@@ -1,14 +1,15 @@
 # Grove Launch Email — Version 4 (Delay Notice)
 
 *Created: December 31, 2025*
+*Updated: January 1, 2026*
 
 ---
 
 ## Context
 
-Grove's launch is slightly delayed while Autumn finishes paperwork (DBA registration, tax documents). This email informs subscribers without going into specifics.
+Grove's launch is delayed because the IRS is closed until January 5th, preventing Autumn from getting an EIN to officially register the business. This email is honest about the reason without being overly technical.
 
-**The tone:** Grounded, concise, not over-apologetic. Respects their time.
+**The tone:** Grounded, honest, a little wry. Respects their time.
 
 ---
 
@@ -20,9 +21,9 @@ Grove's launch is slightly delayed while Autumn finishes paperwork (DBA registra
 
 Quick update:
 
-Grove's launch is slightly delayed while I finish up some paperwork. Should be ready early next week.
+The IRS is closed until January 5th, so I can't get an EIN to officially start the business yet. (Of course they'd be closed the week I'm ready to launch.)
 
-Thanks for waiting. It'll be worth it.
+Signups will open shortly after they're back. Almost there.
 
 — Autumn
 
@@ -32,16 +33,16 @@ Thanks for waiting. It'll be worth it.
 
 1. **A small delay** ← selected
 2. Quick update
-3. We're almost there
+3. Almost there
 
 ---
 
 ## Voice Notes
 
-- Grounded, not overly light (contrast with V2's "Classic.")
-- Keeps details vague (no mention of DBA/tax specifics)
-- Soft timing ("early next week" not a specific day)
-- Short closer that's confident without being boastful
+- Honest about the actual reason (IRS closure, EIN)
+- Wry parenthetical acknowledges the frustrating timing
+- Specific date (January 5th) so people know what to expect
+- "Almost there" — confident without overpromising
 - Respects their inbox
 
 ---


### PR DESCRIPTION
Be honest about the actual reason - IRS closed until Jan 5th,
can't get EIN yet. Matches the homepage notice.