### PR TITLE
fix: Resolve GitHub Actions deployment failures

### DIFF
--- a/.github/workflows/deploy-router.yml
+++ b/.github/workflows/deploy-router.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+        working-directory: .
 
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3

--- a/packages/engine/src/routes/admin/blog/edit/[slug]/+page.svelte
+++ b/packages/engine/src/routes/admin/blog/edit/[slug]/+page.svelte
@@ -182,7 +182,7 @@
 
   <div class="editor-layout">
     <!-- Metadata Panel -->
-    <GlassCard variant="frosted" class="metadata-panel" class:collapsed={detailsCollapsed}>
+    <GlassCard variant="frosted" class="metadata-panel {detailsCollapsed ? 'collapsed' : ''}">
       <div class="panel-header">
         <h2 class="panel-title">{#if detailsCollapsed}Details{:else}Post Details{/if}</h2>
         <button

--- a/packages/engine/src/routes/admin/blog/new/+page.svelte
+++ b/packages/engine/src/routes/admin/blog/new/+page.svelte
@@ -142,7 +142,7 @@
 
   <div class="editor-layout">
     <!-- Metadata Panel -->
-    <GlassCard variant="frosted" class="metadata-panel" class:collapsed={detailsCollapsed}>
+    <GlassCard variant="frosted" class="metadata-panel {detailsCollapsed ? 'collapsed' : ''}">
       <div class="panel-header">
         <h2 class="panel-title">{#if detailsCollapsed}Details{:else}Post Details{/if}</h2>
         <button

--- a/packages/engine/src/routes/admin/images/+page.svelte
+++ b/packages/engine/src/routes/admin/images/+page.svelte
@@ -366,9 +366,7 @@
   <!-- Upload Section -->
   <section class="upload-section">
     <Glass variant="tint" intensity="light"
-      class="drop-zone"
-      class:dragging={isDragging}
-      class:uploading={uploading}
+      class="drop-zone {isDragging ? 'dragging' : ''} {uploading ? 'uploading' : ''}"
       role="button"
       tabindex="0"
       aria-label="Drop zone for image uploads"
@@ -505,7 +503,7 @@
 
       <div class="uploads-list">
         {#each uploads as upload (upload.id)}
-          <GlassCard variant="default" class="upload-card" class:success={upload.status === 'success'} class:duplicate={upload.status === 'duplicate'} class:error={upload.status === 'error'}>
+          <GlassCard variant="default" class="upload-card {upload.status === 'success' ? 'success' : ''} {upload.status === 'duplicate' ? 'duplicate' : ''} {upload.status === 'error' ? 'error' : ''}">
             <div class="upload-header">
               <span class="upload-name">{upload.name}</span>
               <span class="upload-badge" class:processing={upload.status === 'processing'} class:success={upload.status === 'success'} class:duplicate={upload.status === 'duplicate'} class:error={upload.status === 'error'}>


### PR DESCRIPTION
- Fix invalid Svelte class: directives on components (GlassCard, Glass)
  - class: directives are only valid on HTML elements, not components
  - Changed to template literal classes: class="foo {condition ? 'bar' : ''}"
- Fix router workflow to install dependencies from workspace root
  - Added working-directory: . to pnpm install step