### PR TITLE
feat(landing): add vineyard directory page

### DIFF
--- a/landing/src/lib/components/Footer.svelte
+++ b/landing/src/lib/components/Footer.svelte
@@ -11,7 +11,8 @@
 		Mail,
 		PenLine,
 		Hammer,
-		Scroll
+		Scroll,
+		Grape
 	} from 'lucide-svelte';
 	import { season } from '$lib/stores/season';
 
@@ -66,6 +67,12 @@
 						<a href="/roadmap/workshop" class="inline-flex items-center gap-1.5 text-foreground-subtle hover:text-accent-muted transition-colors">
 							<Hammer class="w-4 h-4" />
 							Workshop
+						</a>
+					</li>
+					<li>
+						<a href="/vineyard" class="inline-flex items-center gap-1.5 text-foreground-subtle hover:text-accent-muted transition-colors">
+							<Grape class="w-4 h-4" />
+							Vineyard
 						</a>
 					</li>
 					<li>

--- a/landing/src/routes/vineyard/+page.svelte
+++ b/landing/src/routes/vineyard/+page.svelte
@@ -34,6 +34,7 @@
 
 	// Tool definitions
 	type ToolStatus = 'ready' | 'preview' | 'development' | 'coming-soon';
+	type ToolColor = 'grove' | 'green' | 'amber' | 'violet' | 'pink' | 'emerald' | 'teal' | 'sky';
 
 	interface Tool {
 		name: string;
@@ -41,7 +42,7 @@
 		description: string;
 		status: ToolStatus;
 		icon: typeof Mail;
-		color: string;
+		color: ToolColor;
 		domain?: string;
 		integrated?: boolean;
 		philosophy?: string;
@@ -174,24 +175,25 @@
 		}
 	}
 
-	// Color mapping for tool accents
-	function getToolAccent(color: string) {
-		const accents: Record<string, string> = {
-			grove: 'bg-grove-500',
-			green: 'bg-green-500',
-			amber: 'bg-amber-500',
-			violet: 'bg-violet-500',
-			pink: 'bg-pink-500',
-			emerald: 'bg-emerald-500',
-			teal: 'bg-teal-500',
-			sky: 'bg-sky-500'
-		};
-		return accents[color] || 'bg-grove-500';
+	// Color mapping for tool accents (exhaustive - ToolColor enforces valid keys)
+	const toolAccents: Record<ToolColor, string> = {
+		grove: 'bg-grove-500',
+		green: 'bg-green-500',
+		amber: 'bg-amber-500',
+		violet: 'bg-violet-500',
+		pink: 'bg-pink-500',
+		emerald: 'bg-emerald-500',
+		teal: 'bg-teal-500',
+		sky: 'bg-sky-500'
+	};
+
+	function getToolAccent(color: ToolColor): string {
+		return toolAccents[color];
 	}
 
-	// Separate ready tools from upcoming
-	const readyTools = tools.filter(t => t.status === 'ready');
-	const upcomingTools = tools.filter(t => t.status !== 'ready');
+	// Separate ready tools from upcoming (using $derived to avoid recalculation)
+	const readyTools = $derived(tools.filter(t => t.status === 'ready'));
+	const upcomingTools = $derived(tools.filter(t => t.status !== 'ready'));
 </script>
 
 <SEO


### PR DESCRIPTION
Create grove.place/vineyard as a central hub showcasing all Grove tools:
- Lattice (engine) and Heartwood (auth) marked as Ready
- Ivy, Amber, Foliage, Meadow, Rings, Trails as Coming Soon
- Forage as In Development
- Glass effects, seasonal theming, nature decorations
- Status badges following the vineyard-spec pattern
- Links to individual tool vineyards on their subdomains