### PR TITLE
docs: add 6 help center articles

### DIFF
--- a/docs/help-center/articles/custom-fonts.md
+++ b/docs/help-center/articles/custom-fonts.md
@@ -1,0 +1,107 @@
+---
+title: "Custom Fonts"
+slug: custom-fonts
+category: customization
+order: 4
+keywords: [fonts, typography, accessibility, dyslexia, readability, customize, appearance]
+related: [choosing-a-theme, the-markdown-editor]
+---
+
+# Custom Fonts
+
+Your blog's font shapes how readers experience your words. Grove includes a curated collection of fonts—all available on every paid plan—with no setup required.
+
+## Choosing a font
+
+1. Go to **Admin → Settings**
+2. Find the **Typography** section
+3. Select your preferred font
+4. Click **Save Font Setting**
+
+Changes apply immediately. Refresh any page to see your new font across your entire site.
+
+## Available fonts
+
+Grove includes 20 fonts, organized by purpose:
+
+### Accessibility fonts
+
+These fonts are designed for specific readability needs:
+
+- **Lexend** — Optimized for reading fluency, based on research into visual reading speed. Grove's default.
+- **Atkinson Hyperlegible** — Designed by the Braille Institute for low vision readers. Characters are distinct and unambiguous.
+- **OpenDyslexic** — Weighted bottoms help letters stay grounded for readers with dyslexia.
+- **Luciole** — Created for visually impaired readers, with enhanced letter differentiation.
+
+### Sans-serif fonts
+
+Clean, modern options:
+
+- **Nunito** — Rounded, friendly geometric shapes
+- **Quicksand** — Light and airy with smooth curves
+- **Manrope** — Contemporary with excellent legibility
+- **Instrument Sans** — Precise and modern
+- **Plus Jakarta Sans** — Professional with warmth
+
+### Serif fonts
+
+Classic typography with character:
+
+- **Cormorant** — Elegant display serif for a literary feel
+- **Bodoni Moda** — High-contrast, dramatic strokes
+- **Lora** — Balanced and readable for long-form content
+- **EB Garamond** — Historical elegance, refined for screens
+- **Merriweather** — Designed specifically for screen reading
+- **Fraunces** — Quirky old-style with personality
+
+### Monospace fonts
+
+For code-heavy or technical blogs:
+
+- **IBM Plex Mono** — Clean, highly readable code font
+- **Cozette** — Bitmap-style programming font
+
+### Display and decorative
+
+For personality:
+
+- **Alagard** — Medieval pixel font for fantasy vibes
+- **Calistoga** — Warm, retro display face
+- **Caveat** — Handwritten, casual feel
+
+## Font recommendations
+
+**For most blogs:** Lexend (the default) works well for general reading. It was designed specifically to improve reading fluency.
+
+**For accessibility:** Atkinson Hyperlegible is excellent for readers with low vision. OpenDyslexic helps readers with dyslexia.
+
+**For long-form writing:** Lora or Merriweather are designed for comfortable extended reading.
+
+**For technical blogs:** IBM Plex Mono gives a clean, code-friendly aesthetic.
+
+**For creative/artistic blogs:** Cormorant, Fraunces, or Caveat add personality.
+
+## Uploading custom fonts (Evergreen)
+
+Evergreen subscribers can upload their own fonts:
+
+1. Go to **Admin → Settings → Typography**
+2. Click **Upload Custom Font**
+3. Select your font file (WOFF2 recommended for best performance)
+4. Name your font and save
+
+Once uploaded, your custom font appears in the font selector alongside Grove's built-in options.
+
+**File formats supported:** WOFF2 (preferred), WOFF, TTF, OTF
+
+**Legal note:** Make sure you have the right to use any font you upload. Many fonts require licenses for web use.
+
+## How fonts are loaded
+
+All fonts are hosted on Grove's CDN and loaded efficiently. Your readers don't need to download anything—fonts load automatically with your pages.
+
+We use modern font loading techniques to avoid layout shifts. Text appears immediately in a fallback font, then smoothly transitions to your chosen font once it's loaded.
+
+---
+
+*Font credits and licenses are listed at [/credits](/credits).*

--- a/docs/help-center/articles/data-portability.md
+++ b/docs/help-center/articles/data-portability.md
@@ -1,0 +1,106 @@
+---
+title: "Data Portability"
+slug: data-portability
+category: data
+order: 2
+keywords: [export, migrate, move, transfer, wordpress, ghost, hugo, markdown, portable, leaving, import]
+related: [exporting-your-content, account-deletion, understanding-your-privacy]
+---
+
+# Data Portability
+
+Your content belongs to you. Not just philosophically—practically. Here's what you can do with your exported Grove data.
+
+## What you get when you export
+
+Grove exports your data in standard formats:
+
+- **Posts** — Markdown files with YAML frontmatter
+- **Images** — Original files (JPEG, PNG, WebP, etc.)
+- **Comments** — JSON with author, content, timestamps
+- **Settings** — JSON with your site configuration
+
+These aren't proprietary formats. They're the same formats used across the industry. Your writing doesn't need Grove to exist.
+
+## Moving to another platform
+
+### WordPress
+
+WordPress can import Markdown files, though you'll need a plugin:
+
+1. Install a Markdown import plugin (like "Jeykll Exporter" in reverse, or "WP All Import")
+2. Upload your exported post files
+3. Map the frontmatter fields to WordPress categories/tags
+
+Alternatively, copy-paste from your Markdown files into the WordPress editor. It's tedious for large archives but works for smaller blogs.
+
+### Ghost
+
+Ghost uses Markdown natively:
+
+1. In Ghost admin, go to **Settings → Import/Export**
+2. Ghost expects a specific JSON format, so you may need to convert
+3. Images can be uploaded to Ghost's media library
+
+Ghost's import format is JSON-based. You can write a simple script to convert Grove's format, or import posts manually.
+
+### Hugo, Jekyll, and other static site generators
+
+These are the easiest targets. Static generators typically expect Markdown with frontmatter—exactly what Grove exports.
+
+1. Copy your posts folder into the generator's content directory
+2. Adjust frontmatter field names if needed (e.g., `tags` vs `categories`)
+3. Copy images to your static/assets folder
+4. Build and deploy
+
+### Self-hosted solutions
+
+Markdown works anywhere. Open your exported files in any text editor, and your words are right there. No database required, no special software needed.
+
+## Your domain comes with you
+
+If you registered a domain through Grove (Evergreen tier), you own it. Not Grove.
+
+When you leave:
+- Request a transfer authorization code
+- We provide it within 48 hours
+- Transfer to any registrar you choose
+- No fees from our side
+
+Your domain was always yours. We just helped you find and register it.
+
+## What about comments?
+
+Exported comments include:
+- Author name and email
+- Comment content
+- Timestamp
+- Which post they belong to
+
+Most platforms don't have a standard comment import format, so you may need to handle these manually or through custom migration scripts. The data is there; how you use it depends on your destination.
+
+## The 90-day window
+
+After you cancel:
+- Your content stays accessible for 90 days
+- You can export anytime during this period
+- We'll also email you a download link
+- After 90 days, content is permanently deleted
+
+This isn't a threat—it's a promise. We don't keep data we don't need. But you have three months to make sure you have everything.
+
+## No lock-in, period
+
+Some platforms make leaving hard. Export fees. Proprietary formats. "Contact sales to discuss migration."
+
+Grove's approach:
+- Export is free, always
+- Formats are standard, always
+- No artificial delays
+- No "pay to keep your data" schemes
+
+If you want to leave, take your words and go. We'd rather you left happy than stayed trapped.
+
+---
+
+*For the technical details of Grove's export format, see [Exporting Your Content](/knowledge/help/exporting-your-content).*

--- a/docs/help-center/articles/gdpr-and-privacy-rights.md
+++ b/docs/help-center/articles/gdpr-and-privacy-rights.md
@@ -1,0 +1,152 @@
+---
+title: "GDPR and Privacy Rights"
+slug: gdpr-and-privacy-rights
+category: data
+order: 3
+keywords: [gdpr, privacy, rights, data protection, ccpa, personal data, deletion, access, europe, california]
+related: [understanding-your-privacy, exporting-your-content, account-deletion, data-portability]
+---
+
+# GDPR and Privacy Rights
+
+Whether you're in Europe, California, or anywhere else, you have rights over your personal data. Here's what Grove collects, why, and what you can do about it.
+
+## Your rights
+
+Under GDPR (Europe), CCPA (California), and similar laws, you have the right to:
+
+### Access your data
+
+You can see everything Grove stores about you:
+
+1. Go to **Admin → Settings → Data**
+2. Click **Export Data**
+3. Download a complete copy
+
+Your export includes posts, comments, images, and account settings. Everything we have.
+
+### Correct your data
+
+If something's wrong, you can fix it:
+
+- **Email address** — Update via Settings
+- **Blog content** — Edit directly in your admin panel
+- **Account details** — Most settings are self-service
+
+For anything you can't change yourself, email us and we'll help.
+
+### Delete your data
+
+You can close your account at any time:
+
+1. Go to **Admin → Settings → Account**
+2. Click **Delete Account**
+3. Confirm the deletion
+
+We'll email you an export link before deletion completes. After 90 days, your data is permanently removed from our servers.
+
+### Data portability
+
+You can take your data elsewhere. Grove exports in standard formats (Markdown, JSON) that work with other platforms. No proprietary lock-in.
+
+### Object to processing
+
+If you believe we're processing your data inappropriately, let us know. We'll review and respond within 30 days.
+
+## What Grove collects
+
+### Account data
+
+When you sign up:
+- **Email address** — For login and notifications
+- **Authentication tokens** — For secure sign-in via Google OAuth
+
+We don't collect your name unless you choose to display one. We don't require phone numbers, addresses, or government ID.
+
+### Blog content
+
+What you create:
+- Posts (text and images)
+- Pages
+- Comments on your blog
+- Site settings and preferences
+
+This is your content. You control it. You can delete it.
+
+### Technical data
+
+To run the service:
+- **IP addresses** — Kept for 60 seconds for rate limiting, then discarded
+- **Error logs** — Kept for 7 days to fix bugs
+- **Session data** — For keeping you logged in
+
+We don't build profiles. We don't track behavior across sessions.
+
+### What we don't collect
+
+- Browsing history
+- Location data (beyond what IP briefly reveals)
+- Device fingerprints
+- Third-party tracking data
+- Analytics on your readers (unless you opt into Grove's privacy-respecting analytics)
+
+## Data retention
+
+| Data type | How long we keep it |
+|-----------|-------------------|
+| IP addresses | 60 seconds |
+| Error logs | 7 days |
+| Your blog content | Until you delete it |
+| Account data | Until you close your account |
+| Backups | 30 days after deletion |
+| Payment records | 7 years (legal requirement) |
+
+## Third parties
+
+Grove uses a small number of third-party services:
+
+- **Cloudflare** — CDN and security (no persistent tracking)
+- **Stripe** — Payment processing (required for subscriptions)
+- **Google** — OAuth authentication only
+- **AI providers** — Content moderation with zero data retention
+
+We don't sell data to anyone. We don't use advertising networks. We don't share your information except as required to provide the service.
+
+## Content moderation and AI
+
+Grove uses AI for content moderation (checking for harmful content). This is done with:
+
+- **Zero data retention** — Your content is processed and immediately forgotten
+- **No training** — Your words aren't used to train AI models
+- **Minimal processing** — Only what's necessary for safety
+
+For details, see [Understanding Your Privacy](/knowledge/help/understanding-your-privacy).
+
+## International transfers
+
+Grove is built on Cloudflare's global network. Your data may be processed in different countries as part of normal CDN operation. Cloudflare maintains appropriate safeguards for international data transfers.
+
+## How to exercise your rights
+
+**Self-service** (fastest):
+- Export: **Settings → Data → Export**
+- Delete: **Settings → Account → Delete Account**
+- Correct: Edit your content directly in the admin panel
+
+**Email** (for anything else):
+- Contact: [support](/support)
+- Response time: Within 30 days (usually much faster)
+
+## For blog readers
+
+If you've commented on a Grove blog and want your comment removed, contact the blog author directly. Blog authors control their own comment sections.
+
+If you can't reach the author, contact Grove support and we'll help facilitate.
+
+## Questions
+
+If you have questions about your privacy rights or how Grove handles data, reach out. We'll give you a straight answer.
+
+---
+
+*Privacy law is complex. Our approach is simple: collect what we need, delete what we don't, and give you control over what's yours.*

--- a/docs/help-center/articles/groves-vision.md
+++ b/docs/help-center/articles/groves-vision.md
@@ -1,0 +1,78 @@
+---
+title: "Grove's Vision"
+slug: groves-vision
+category: legal
+order: 1
+keywords: [vision, philosophy, values, why, mission, purpose, about, story]
+related: [what-is-grove, understanding-your-privacy, how-grove-protects-your-content]
+---
+
+# Grove's Vision
+
+The internet used to be a place of personal expression. Geocities. Angelfire. Blogs with personality. Somewhere along the way, we traded that for algorithms, engagement metrics, and platforms that own our words.
+
+Grove is a return to something simpler.
+
+## What we believe
+
+### Your words are yours
+
+Not a platform's. Not a dataset. Not training material for AI models. When you write on Grove, you own what you create. You can export it anytime. You can leave anytime. Your content comes with you.
+
+### Readers matter
+
+Every Grove blog is publicly accessible by default. No login walls. No "sign up to read more." Just visit and read. The open web, as it should be.
+
+### Privacy isn't a premium feature
+
+We don't track your readers. No analytics scripts following people around the web. No selling data to advertisers. When someone reads your blog and leaves, that's it. They're gone.
+
+### Simplicity is a feature
+
+Write in Markdown. Upload images. Publish. That's it. No plugin ecosystems, no endless settings, no feature bloat competing for your attention. The technology should disappear into the background.
+
+### Community can exist without competition
+
+Meadow (our optional community feed) doesn't display follower counts. Reactions are private—encouragement for the author, not performance for an audience. No algorithms deciding who gets amplified. Just chronological posts from people you follow.
+
+## What we're building against
+
+The major platforms have trained us to measure ourselves by engagement. Likes, shares, follower counts. Algorithms that reward outrage because outrage gets clicks.
+
+Grove doesn't have public metrics. We don't have an algorithm boosting "engaging" content. We don't notify you when someone unfollows you. These aren't missing features—they're intentional absences.
+
+## AI and your writing
+
+Your words are not training data.
+
+Every major AI company sends crawlers across the web to feed their models. Grove blocks them all. GPTBot, CCBot, Google-Extended, anthropic-ai—they hit a wall. Your writing stays between you and your readers.
+
+We do use AI internally, but carefully: for content moderation with zero data retention, through providers who don't train on your content. There's a difference between using a tool responsibly and feeding a machine indiscriminately.
+
+## Who this is for
+
+Grove works for people who want:
+
+- A personal space online, without wrestling with complex software
+- Ownership of their words, not just permission to post
+- Privacy for their readers, not surveillance
+- Community without competition
+- Something calmer than social media
+
+Grove probably isn't for people who need e-commerce, complex membership tiers, or infinite customization. We're intentionally focused.
+
+## The metaphor
+
+A grove is a small group of trees. Each tree is independent—complete on its own. But beneath the surface, roots intermingle. Trees share nutrients through mycorrhizal networks. The oldest trees nurture the saplings.
+
+That's what we're building. A forest of voices. A place where people can plant their thoughts and watch them grow.
+
+## Why this matters
+
+The web is being scraped into datasets. Authentic human spaces are getting rarer. Platforms optimize for engagement, not wellbeing. Algorithms decide what you see.
+
+Grove is one small corner where things work differently. A refuge from the noise. A place to write for the sake of writing, and to read for the sake of reading.
+
+---
+
+*A forest of voices. A place to be.*

--- a/docs/help-center/articles/the-markdown-editor.md
+++ b/docs/help-center/articles/the-markdown-editor.md
@@ -1,0 +1,93 @@
+---
+title: "The Markdown Editor"
+slug: the-markdown-editor
+category: writing-and-publishing
+order: 2
+keywords: [editor, markdown, writing, interface, toolbar, preview, zen mode, ambient sounds, keyboard shortcuts]
+related: [writing-your-first-post, formatting-your-posts, drafts-and-scheduling]
+---
+
+# The Markdown Editor
+
+Grove's editor is where you'll spend most of your time. It's designed to get out of the way—write, format, publish.
+
+## The basics
+
+The editor uses Markdown, but you don't need to memorize syntax. Select any text and a floating toolbar appears with formatting options: bold, italic, headings, links, quotes, code, and lists.
+
+If you prefer keyboard shortcuts:
+- **⌘/Ctrl + B** — Bold
+- **⌘/Ctrl + I** — Italic
+- **⌘/Ctrl + S** — Save
+- **Tab** — Indent
+
+## Preview modes
+
+**Side-by-side preview**: Click `[show preview]` in the toolbar to see your rendered Markdown alongside your writing. The preview scrolls in sync with your editor.
+
+**Full preview**: Click `[full]` to see exactly how your post will look on your published blog—with your theme, fonts, and styling applied. Press Escape to close.
+
+## The status bar
+
+At the bottom of the editor, you'll find:
+- Current line and column position
+- Total lines, words, and estimated reading time
+- Draft save status
+- Ambient sounds control
+
+## Autosave and drafts
+
+Grove saves your work to your browser automatically as you type. If you close the tab or your browser crashes, you'll see a prompt to restore your draft when you return.
+
+This local draft is separate from saving to the server—think of it as a safety net. Click **Save** (or ⌘/Ctrl + S) to publish your changes to Grove's servers.
+
+## Adding images
+
+Three ways to add images:
+
+1. **Drag and drop** — Drag an image file directly onto the editor
+2. **Paste** — Copy an image and paste it (⌘/Ctrl + V)
+3. **Manual** — Type the Markdown syntax: `![alt text](image-url)`
+
+When you drag or paste, Grove uploads the image automatically and inserts the Markdown for you. You'll see a brief upload indicator, then the image appears in your preview.
+
+## Zen mode
+
+For distraction-free writing, press **⌘/Ctrl + Shift + Enter** to enter Zen mode. The editor goes fullscreen, the toolbar fades until you hover, and it's just you and your words.
+
+Press **Escape** to exit.
+
+Zen mode automatically enables typewriter mode, which keeps your current line vertically centered as you write—no more typing at the bottom of the screen.
+
+## Ambient sounds
+
+Writing is easier with the right atmosphere. Click the sound button in the bottom-right corner of the status bar (it shows the current sound name, like `[forest]`).
+
+Five ambient soundscapes are available:
+- **Forest** — birds and wind through trees
+- **Rain** — gentle rainfall
+- **Fire** — crackling campfire
+- **Night** — crickets and evening breeze
+- **Cafe** — soft background murmurs
+
+Adjust the volume with the slider. Your sound preference is remembered between sessions.
+
+## Snippets
+
+If you frequently type the same text—a signature, a standard disclaimer, a formatting template—save it as a snippet.
+
+Snippets can have optional triggers. If you set a trigger like `sig`, typing `/sig` in the editor will insert your saved snippet.
+
+## Campfire sessions
+
+Campfire is a timed writing mode. Start a session, and Grove tracks how long you've been writing and how many words you've added. A warm ember glows in the corner as a gentle reminder to keep going.
+
+Use it for writing sprints, daily practice, or when you need a little accountability.
+
+## Line numbers
+
+Line numbers appear on the left side of the editor. The current line is highlighted. They help you navigate longer posts and make it easier to reference specific sections when editing.
+
+---
+
+*The editor should feel natural after a few posts. If something's confusing or not working as expected, [let us know](/support).*

--- a/docs/help-center/articles/understanding-your-plan.md
+++ b/docs/help-center/articles/understanding-your-plan.md
@@ -1,0 +1,133 @@
+---
+title: "Understanding Your Plan"
+slug: understanding-your-plan
+category: billing
+order: 1
+keywords: [plan, limits, features, storage, posts, what's included, subscription, tier]
+related: [choosing-your-plan, upgrading-or-downgrading]
+---
+
+# Understanding Your Plan
+
+Here's what each Grove plan includes—and what happens when you approach your limits.
+
+## Plan limits at a glance
+
+| | Seedling | Sapling | Oak | Evergreen |
+|---|:---:|:---:|:---:|:---:|
+| **Price** | $8/mo | $12/mo | $25/mo | $35/mo |
+| **Posts** | 50 | 250 | Unlimited | Unlimited |
+| **Storage** | 1 GB | 5 GB | 20 GB | 100 GB |
+| **Themes** | 3 | 10 | All + customizer | All + custom fonts |
+| **Custom domain** | — | — | BYOD | Included |
+| **Email** | — | Forwarding | Full mailbox | Full mailbox |
+
+## What counts toward limits
+
+### Post limits (Seedling and Sapling)
+
+Every published post counts toward your limit. Drafts don't count until you publish them.
+
+If you reach your limit:
+- You can still edit existing posts
+- You can still save drafts
+- You can't publish new posts until you upgrade or delete old ones
+
+### Storage limits
+
+Storage is measured in bytes—the actual file sizes of your uploads.
+
+**What counts:**
+- Images you upload to posts
+- Featured images
+- Any media files
+
+**What doesn't count:**
+- Your post text (Markdown is tiny)
+- Comments and replies
+- Settings and configuration
+
+If you reach your storage limit, you can't upload new images until you free up space or upgrade. Existing images aren't affected.
+
+## Checking your usage
+
+1. Go to **Admin → Settings → Account**
+2. Look for the **Usage** section
+
+You'll see:
+- How many posts you've published vs. your limit
+- How much storage you've used vs. your limit
+- Your current plan and billing date
+
+## What's included on every paid plan
+
+Regardless of which plan you choose:
+
+- **Markdown editor** with live preview and drag-drop images
+- **Autosave** so you never lose drafts
+- **RSS feed** for your blog
+- **Meadow access** (opt-in community features)
+- **Unlimited comments** on your posts
+- **SSL/HTTPS** (secure connection)
+- **Cloudflare CDN** (fast loading worldwide)
+- **Daily backups** (your content is protected)
+- **No ads** on your blog
+- **No tracking** of your readers
+- **Data export** anytime
+
+## Features by tier
+
+### Seedling ($8/month)
+
+The essentials for starting a blog:
+- 50 posts, 1 GB storage
+- 3 themes (Grove, Minimal, Night Garden) plus accent color customization
+- Community support via help documentation
+
+Good for: Trying blogging out, personal journals, occasional posting.
+
+### Sapling ($12/month)
+
+Room to grow:
+- 250 posts, 5 GB storage
+- All 10 themes plus accent color
+- Email forwarding to `you@grove.place`
+- Email support
+
+Good for: Regular bloggers, building an archive, hobbyist writers.
+
+### Oak ($25/month)
+
+Full control:
+- Unlimited posts, 20 GB storage
+- Theme customizer (full color and layout control)
+- Community themes (install themes others have created)
+- Bring your own domain
+- Full @grove.place email (send and receive)
+- Priority support
+
+Good for: Serious bloggers, professionals, anyone who wants a custom domain.
+
+### Evergreen ($35/month)
+
+Everything:
+- Unlimited posts, 100 GB storage
+- Custom font uploads
+- Domain registration included (we find and register it for you)
+- 8 hours of included support time
+- Privacy controls (option to require login)
+- Priority support with faster response
+
+Good for: Professional presence, high-volume media, businesses.
+
+## What happens if you exceed limits
+
+**You won't lose content.** If you downgrade from Sapling to Seedling while having 100 posts, all 100 stay published. You just can't add new ones until you're under the limit.
+
+**Same with storage.** Over the limit? Existing files stay. You just can't upload more.
+
+Grove doesn't delete your content because you downgraded. We want you to stay because you want to, not because you're trapped.
+
+---
+
+*Not sure what plan is right? Start with Seedling. It's a real plan, not a trial. Upgrade when you need more.*

--- a/landing/src/lib/data/knowledge-base.ts
+++ b/landing/src/lib/data/knowledge-base.ts
@@ -535,6 +535,66 @@ export const helpArticles: Doc[] = [
     lastUpdated: "2025-12-24",
     readingTime: 4,
   },
+  {
+    slug: "the-markdown-editor",
+    title: "The Markdown Editor",
+    description: "A guide to Grove's writing environment with preview, ambient sounds, and zen mode",
+    excerpt:
+      "Grove's editor is where you'll spend most of your time. Markdown with floating toolbar, live preview, drag-drop images, ambient sounds, zen mode, and autosave.",
+    category: "help",
+    lastUpdated: "2026-01-03",
+    readingTime: 5,
+  },
+  {
+    slug: "custom-fonts",
+    title: "Custom Fonts",
+    description: "20 curated fonts including accessibility options, with custom upload for Evergreen",
+    excerpt:
+      "Grove includes 20 fonts—accessibility fonts like Lexend and OpenDyslexic, serifs, sans-serifs, and display faces. Evergreen subscribers can upload their own.",
+    category: "help",
+    lastUpdated: "2026-01-03",
+    readingTime: 4,
+  },
+  {
+    slug: "understanding-your-plan",
+    title: "Understanding Your Plan",
+    description: "What's included in each Grove plan and how limits work",
+    excerpt:
+      "Here's what each Grove plan includes—post limits, storage, themes, and features—and what happens when you approach your limits.",
+    category: "help",
+    lastUpdated: "2026-01-03",
+    readingTime: 5,
+  },
+  {
+    slug: "data-portability",
+    title: "Data Portability",
+    description: "Taking your Grove content to WordPress, Ghost, Hugo, or anywhere else",
+    excerpt:
+      "Your content belongs to you. Grove exports in standard formats—Markdown and JSON—that work with WordPress, Ghost, Hugo, and other platforms.",
+    category: "help",
+    lastUpdated: "2026-01-03",
+    readingTime: 4,
+  },
+  {
+    slug: "groves-vision",
+    title: "Grove's Vision",
+    description: "The philosophy and values behind Grove",
+    excerpt:
+      "The internet used to be a place of personal expression. Grove is a return to something simpler—a forest of voices, a place where your words are yours.",
+    category: "help",
+    lastUpdated: "2026-01-03",
+    readingTime: 5,
+  },
+  {
+    slug: "gdpr-and-privacy-rights",
+    title: "GDPR and Privacy Rights",
+    description: "Your data rights under GDPR, CCPA, and similar laws",
+    excerpt:
+      "Whether you're in Europe, California, or anywhere else, you have rights over your personal data. Here's what Grove collects and what you can do about it.",
+    category: "help",
+    lastUpdated: "2026-01-03",
+    readingTime: 5,
+  },
 ];
 
 // Legal Documents


### PR DESCRIPTION
Add comprehensive help documentation covering:
- the-markdown-editor: Editor features, preview, ambient sounds, zen mode
- custom-fonts: 20 curated fonts with accessibility options
- understanding-your-plan: Plan limits and features explained
- data-portability: Moving content to other platforms
- groves-vision: Philosophy and values behind Grove
- gdpr-and-privacy-rights: Data rights under privacy laws

Register all articles in knowledge-base.ts for the landing site.