### PR TITLE
fix: add missing color palette imports to forest page

### DIFF
--- a/landing/src/routes/forest/+page.svelte
+++ b/landing/src/routes/forest/+page.svelte
@@ -18,6 +18,8 @@
 		Cardinal, Chickadee, Robin, Bluebird,
 		// Sky
 		Cloud,
+		// Color palettes
+		spring, autumn, winter, greens, springBlossoms, autumnReds, bark,
 		// Type
 		type Season
 	} from '@autumnsgrove/groveengine/ui/nature';


### PR DESCRIPTION
The forest page was referencing color palette objects (spring, autumn,
winter, greens, springBlossoms, autumnReds, bark) in functions like
getDepthColors() and getDepthPinks() but these were not imported,
causing the page to fail to render.

These imports are necessary for the forest visualization to function,
even though the palette showcase was moved to /vineyard.

Fixes page hydration and rendering.