### PR TITLE
Make manifesto page more personal and detailed and added Centennial to specs

### DIFF
--- a/docs/grove-pricing.md
+++ b/docs/grove-pricing.md
@@ -29,6 +29,7 @@ Your content is yours. Your domain is yours. No lock-in, no hostage situations.
 | Public Comments | 20/week | Unlimited | Unlimited | Unlimited | Unlimited |
 | Custom Domain | — | — | — | BYOD | ✓ |
 | @grove.place Email | — | — | Forward | Full | Full |
+| Centennial Status | — | — | ✓ | ✓ | ✓ |
 | Privacy Controls | — | — | — | — | Login-required option |
 | Support | Community | Community | Email | Priority | 8hrs + Priority |
 | **Best For** | *Readers* | *Curious* | *Hobbyists* | *Serious Bloggers* | *Professionals* |
@@ -95,6 +96,7 @@ Free is for readers and community members. When you're ready to write, upgrade t
 - Your blog at `username.grove.place`
 - **10 themes** + custom accent color
 - **Email forwarding:** Receive emails at `you@grove.place`
+- **Centennial eligible:** After 12 months, your site stays online for 100 years
 - Email support
 
 ### Oak: $25/month
@@ -195,6 +197,39 @@ When we register a domain for you, **you own it**. If you ever leave Grove:
 - No transfer fees, no hostage situations
 
 See our [Data Portability & Separation Policy](https://grove.place/legal/data-portability) for full details.
+
+---
+
+## Centennial Status
+
+*Some trees outlive the people who planted them.*
+
+Centennial is Grove's promise that your words can have the same longevity. After 12 cumulative months on Sapling tier or above, your grove earns **Centennial status** — your site stays online for 100 years from the day you planted it.
+
+### How It Works
+
+| Path to Centennial | Timeline |
+|-------------------|----------|
+| Yearly subscription (Sapling+) | Instant upon first renewal |
+| Monthly subscription (Sapling+) | After 12 monthly payments |
+| Mixed (upgrade/downgrade) | Cumulative months counted |
+
+### What Centennial Means
+
+- **100-year domain reservation** — Your `name.grove.place` is yours for a century
+- **Content preservation** — Published posts remain publicly accessible
+- **Read-only archive** — If you stop paying, your site becomes a static archive (no new posts, but everything stays online)
+- **Reactivate anytime** — Resume your subscription to regain full access
+
+### Opting Out
+
+Not everyone wants their words to outlive them. Centennial is automatic once earned, but you can:
+
+- **Disable preservation** in account settings
+- **Delete your account** for full removal
+- **Transfer to a successor** (future feature)
+
+For full technical details, see the [Centennial Specification](/knowledge/specs/centennial-spec).
 
 ---
 

--- a/docs/help-center/articles/choosing-your-plan.md
+++ b/docs/help-center/articles/choosing-your-plan.md
@@ -48,6 +48,7 @@ More room to grow. If you're posting frequently or building up an archive, Sapli
 - 5 GB storage
 - 10 themes + accent color
 - Email forwarding (`you@grove.place`)
+- **Centennial eligible** — after 12 months, your site stays online for 100 years
 - Everything in Seedling
 
 ### Oak
@@ -98,6 +99,14 @@ You can upgrade or downgrade anytime from **Settings → Plan**.
 When you upgrade, you get immediate access to new features. When you downgrade, you keep access through the end of your current billing period.
 
 If you're over the limits of your new plan (say, you have 100 posts and downgrade to Seedling's 50), your existing content stays. You just can't publish new posts until you're under the limit.
+
+## Centennial: Your grove can outlive you
+
+On Sapling and above, after 12 cumulative months of membership, your grove earns **Centennial status**. Your site stays online for 100 years from the day you planted it—even if you stop paying someday.
+
+A hundred years is roughly how long an oak tree lives. Some trees outlive the people who planted them. Yours can too.
+
+You can opt out anytime if you'd rather your site not persist. But we think your words are worth keeping.
 
 ## No hidden fees
 

--- a/docs/help-center/articles/understanding-your-plan.md
+++ b/docs/help-center/articles/understanding-your-plan.md
@@ -21,6 +21,7 @@ Here's what each Grove plan includes—and what happens when you approach your l
 | **Themes** | 3 | 10 | All + customizer | All + custom fonts |
 | **Custom domain** | — | — | BYOD | Included |
 | **Email** | — | Forwarding | Full mailbox | Full mailbox |
+| **Centennial** | — | ✓ | ✓ | ✓ |
 
 ## What counts toward limits
 
@@ -127,6 +128,16 @@ Good for: Professional presence, high-volume media, businesses.
 **Same with storage.** Over the limit? Existing files stay. You just can't upload more.
 
 Grove doesn't delete your content because you downgraded. We want you to stay because you want to, not because you're trapped.
+
+## Centennial status (Sapling+)
+
+After 12 cumulative months on Sapling, Oak, or Evergreen, your grove earns **Centennial status**. This means your site stays online for 100 years from the day you planted it.
+
+- **Automatic:** No application needed. After 12 months, you're in.
+- **Preserved even if you leave:** If you stop paying after earning Centennial, your site becomes a read-only archive. Your words stay online.
+- **Opt-out available:** If you'd rather your site disappear when you leave, you can disable preservation in Settings.
+
+A hundred years is roughly how long an oak tree lives. Some trees outlive the people who planted them.
 
 ---
 

--- a/docs/specs/centennial-spec.md
+++ b/docs/specs/centennial-spec.md
@@ -1,0 +1,308 @@
+# Centennial — Domain Preservation
+
+> *Some trees outlive the people who planted them.*
+
+**Public Name:** Centennial
+**Internal Name:** GroveCentennial
+**Last Updated:** January 2026
+
+A century is the lifetime of an oak. It's the span between a sapling taking root and becoming something people gather beneath for shade. Centennial is Grove's promise that your words can have that same longevity.
+
+When you've been part of Grove long enough to put down real roots, your site earns Centennial status. Your `name.grove.place` domain stays online for 100 years from the day you planted it — even if you stop paying, even after you're gone.
+
+---
+
+## Goals
+
+1. **Permanence as a feature** — Your grove outlives you if you want it to
+2. **Automatic unlock** — No application, no ceremony, just time invested
+3. **Opt-out available** — Not everyone wants digital immortality
+4. **Simple math** — 12 months of membership, 100 years of preservation
+
+---
+
+## How It Works
+
+### Earning Centennial Status
+
+Centennial status unlocks automatically when a user reaches **12 cumulative months** of paid membership on **Sapling tier or above**.
+
+| Path to Centennial | Timeline |
+|-------------------|----------|
+| Yearly subscription (Sapling+) | Instant upon first renewal |
+| Monthly subscription (Sapling+) | After 12 monthly payments |
+| Mixed (upgrade/downgrade) | Cumulative months counted |
+
+**Tier requirements:**
+- **Free:** Not eligible
+- **Seedling ($8):** Not eligible
+- **Sapling ($12):** Eligible
+- **Oak ($25):** Eligible
+- **Evergreen ($35):** Eligible
+
+The logic: Sapling is where people start investing seriously. If you've committed to a year at Sapling or above, you've proven this matters to you.
+
+### What Centennial Means
+
+Once earned, Centennial status grants:
+
+1. **100-year domain reservation** — Your `name.grove.place` subdomain is reserved for 100 years from your `planted_at` date
+2. **Content preservation** — Your published posts remain publicly accessible
+3. **RSS feed maintained** — Subscribers can still receive your content
+4. **Static archive** — If you stop paying, your site becomes a read-only archive (no new posts, no admin access)
+
+### The 100-Year Clock
+
+The preservation period is calculated from when the user first created their Grove account (`planted_at`), not when they earned Centennial status.
+
+```
+preservation_until = planted_at + 100 years
+```
+
+This means:
+- Plant your grove in 2026 → preserved until 2126
+- The clock starts when you plant, not when you qualify
+- Earning Centennial retroactively protects from day one
+
+### Active vs. Archived State
+
+| State | Description |
+|-------|-------------|
+| **Active** | Paid subscription, full access, can publish |
+| **Archived** | Centennial earned, subscription lapsed, read-only |
+| **Deleted** | User requested deletion, content removed |
+
+**Archived groves:**
+- All published posts remain publicly accessible
+- RSS feed continues working
+- No admin access (can't edit, delete, or publish)
+- Site displays subtle "archived" indicator
+- Reactivate anytime by resuming subscription
+
+---
+
+## Opting Out
+
+Not everyone wants their words to outlive them. Centennial is **automatic but reversible**.
+
+### Opt-Out Options
+
+1. **Disable Centennial** — In account settings, toggle off "Preserve my grove"
+   - Domain returns to pool after subscription ends
+   - Can re-enable anytime while subscribed
+
+2. **Delete Account** — Full account deletion removes everything
+   - Content permanently deleted
+   - Domain released immediately
+   - Irreversible (with confirmation flow)
+
+3. **Designate Successor** — Future feature (Phase 3+)
+   - Transfer grove ownership to another Grove user
+   - Successor can choose to maintain, archive, or delete
+
+### Default State
+
+Centennial is **enabled by default** once earned. The logic:
+- Most people want their work preserved
+- Opting out is easy if you don't
+- Surprise deletion is worse than surprise preservation
+
+---
+
+## Implementation
+
+### Database Schema
+
+```sql
+-- Add to users table
+ALTER TABLE users ADD COLUMN centennial_status TEXT DEFAULT 'ineligible';
+-- Values: 'ineligible', 'eligible', 'earned', 'opted_out'
+
+ALTER TABLE users ADD COLUMN centennial_earned_at INTEGER;
+-- Unix timestamp when status changed to 'earned'
+
+ALTER TABLE users ADD COLUMN centennial_preserve BOOLEAN DEFAULT TRUE;
+-- User preference for preservation
+
+ALTER TABLE users ADD COLUMN cumulative_months INTEGER DEFAULT 0;
+-- Running count of qualifying months
+```
+
+### Status Calculation
+
+```typescript
+function updateCentennialStatus(user: User): CentennialStatus {
+  // Check tier eligibility
+  const eligibleTiers = ['sapling', 'oak', 'evergreen'];
+  if (!eligibleTiers.includes(user.tier)) {
+    return 'ineligible';
+  }
+
+  // Check cumulative months
+  if (user.cumulative_months >= 12) {
+    if (user.centennial_status !== 'earned') {
+      user.centennial_earned_at = Date.now();
+    }
+    return user.centennial_preserve ? 'earned' : 'opted_out';
+  }
+
+  return 'eligible';
+}
+
+function getPreservationDate(user: User): Date | null {
+  if (user.centennial_status !== 'earned') return null;
+
+  const plantedAt = new Date(user.planted_at);
+  return new Date(plantedAt.setFullYear(plantedAt.getFullYear() + 100));
+}
+```
+
+### Monthly Increment Logic
+
+Cumulative months increment when:
+- A monthly payment succeeds (Sapling+)
+- A yearly payment succeeds (adds 12 months)
+- An upgrade from Seedling to Sapling+ occurs mid-cycle (prorated)
+
+Cumulative months do **not** decrement:
+- On downgrade to Seedling
+- On subscription pause
+- On payment failure (but no new months added)
+
+### Archive Transition
+
+When a Centennial-earned user's subscription lapses:
+
+1. **Grace period:** 7 days before any change
+2. **Archive transition:**
+   - Set `status = 'archived'`
+   - Disable admin routes
+   - Add archive banner to public pages
+   - Preserve all content as-is
+3. **Reactivation:** Resume subscription → full access restored
+
+---
+
+## User Communication
+
+### Earning Centennial
+
+When a user earns Centennial status, send:
+
+**Subject:** Your grove will stand for a century
+
+**Body:**
+> You've been growing with us for a year now. That means something.
+>
+> Your grove has earned Centennial status. Even if you stop paying someday, even after you're gone, your words will remain at `name.grove.place` for the next hundred years.
+>
+> Some trees outlive the people who planted them. Yours will too — if you want it to.
+>
+> You can disable this anytime in Settings → Privacy → Preservation. But we thought you'd want to know: your roots run deep now.
+
+### Archive Transition
+
+When a Centennial grove becomes archived:
+
+**Subject:** Your grove is now an archive
+
+**Body:**
+> Your subscription has ended, but your grove remains.
+>
+> Because you earned Centennial status, `name.grove.place` will stay online as a read-only archive until [preservation_date]. Your words are still there. People can still read them.
+>
+> If you ever want to write again, just resubscribe and pick up where you left off.
+
+---
+
+## Display Elements
+
+### Account Settings
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Centennial Status                                  │
+│  ────────────────────────────────────────────────── │
+│                                                     │
+│  ✓ Earned (January 2027)                           │
+│                                                     │
+│  Your grove will be preserved until January 2126.   │
+│  Even if you stop paying, your words remain.        │
+│                                                     │
+│  [ ] Preserve my grove after I'm gone               │
+│      Uncheck to release your domain when your       │
+│      subscription ends.                             │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### Progress Indicator (Pre-Earned)
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Path to Centennial                                 │
+│  ────────────────────────────────────────────────── │
+│                                                     │
+│  ████████████░░░░░░░░  7 of 12 months               │
+│                                                     │
+│  5 months until your grove earns permanent status.  │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### Archived Grove Banner
+
+Subtle banner on archived groves (visible to visitors):
+
+```
+┌─────────────────────────────────────────────────────┐
+│  🌳 This grove is preserved as an archive.         │
+│     Last updated: March 2045                        │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Edge Cases
+
+### What if Grove shuts down?
+
+If Grove ever ceases operation:
+1. All Centennial groves are exported to static HTML
+2. Archives hosted on commodity infrastructure (pre-funded)
+3. Domain redirects to archive location
+4. See: [Shutdown Plan] (future doc)
+
+### What about abandoned domains people want?
+
+Centennial domains are **never reclaimed** during the 100-year period:
+- Even if the content seems abandoned
+- Even if someone else wants the username
+- The promise is the promise
+
+After 100 years, domain returns to the pool.
+
+### What if someone dies and family wants content removed?
+
+Family can contact support with:
+- Proof of relationship
+- Death certificate
+- Request for deletion or transfer
+
+We'll work with them. Preservation is the default; respect for the family's wishes is the exception.
+
+---
+
+## Philosophy
+
+Most platforms treat your content as theirs. When you stop paying, it vanishes. When they shut down, everything disappears. The default state of the internet is impermanence.
+
+Centennial is a different bet: that some things are worth keeping. That your words, accumulated over years, might matter to someone you'll never meet. That a century from now, someone might stumble onto your little corner of the internet and feel less alone.
+
+A hundred years is a long time. It's also roughly how long an oak tree lives.
+
+Plant something worth keeping.
+
+---
+
+*Last updated: January 2026*

--- a/landing/src/lib/data/knowledge-base.ts
+++ b/landing/src/lib/data/knowledge-base.ts
@@ -6,6 +6,17 @@ export type { Doc } from "$lib/types/docs";
 // Technical Specifications
 export const specs: Doc[] = [
   {
+    slug: "centennial-spec",
+    title: "Centennial — Domain Preservation",
+    description:
+      "100-year domain preservation for long-term Grove members",
+    excerpt:
+      "Some trees outlive the people who planted them. Centennial is Grove's promise that your words can have that same longevity. After 12 months on Sapling tier or above, your grove earns Centennial status—your site stays online for 100 years from the day you planted it.",
+    category: "specs",
+    lastUpdated: "2026-01-04",
+    readingTime: 8,
+  },
+  {
     slug: "thorn-spec",
     title: "Thorn — Content Moderation",
     description:

--- a/landing/src/routes/manifesto/+page.svelte
+++ b/landing/src/routes/manifesto/+page.svelte
@@ -9,7 +9,11 @@
 		Moon,
 		StarCluster,
 		Lantern,
-		Firefly
+		Firefly,
+		Bridge,
+		Acorn,
+		Leaf,
+		TreePine
 	} from '@autumnsgrove/groveengine/ui/nature';
 </script>
 
@@ -73,6 +77,9 @@
 		<div class="absolute top-[60%] left-[30%] opacity-60 pointer-events-none" aria-hidden="true">
 			<Firefly class="w-2 h-2" />
 		</div>
+		<div class="absolute top-[75%] right-[15%] opacity-40 pointer-events-none" aria-hidden="true">
+			<Firefly class="w-2 h-2" />
+		</div>
 
 		<!-- Content -->
 		<div class="relative z-10 px-6 py-20 md:py-28">
@@ -91,15 +98,28 @@
 				</header>
 
 				<!-- The Declarations -->
-				<div class="space-y-16 md:space-y-24 text-center">
+				<div class="space-y-16 md:space-y-20 text-center">
 
-					<!-- Opening -->
-					<section class="space-y-4">
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- THE GARDEN THAT WAS -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
+					<section class="space-y-6">
+						<div class="flex items-center justify-center gap-3 text-purple-400/60 mb-4">
+							<Acorn class="w-4 h-4" />
+							<span class="text-xs uppercase tracking-widest">The Garden That Was</span>
+						</div>
 						<p class="text-xl md:text-2xl text-purple-100 font-serif leading-relaxed">
-							We believe the internet was a garden once.
+							The internet used to be a garden.
 						</p>
-						<p class="text-xl md:text-2xl text-purple-100 font-serif leading-relaxed">
-							We believe it can be again.
+						<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+							Not a manicured one—a wild one. Full of weird little corners and handmade pages.
+							You could stumble onto someone's space and feel like you'd discovered something.
+							A stranger's thoughts, laid out with care, just for you to find.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/80 font-serif leading-relaxed">
+							I remember that feeling. Finding someone's cozy corner and thinking:
+							<span class="text-amber-300/90 italic">I want something like this.</span>
 						</p>
 					</section>
 
@@ -108,13 +128,192 @@
 						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
 					</div>
 
-					<!-- Ownership - Glass Callout -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- THE WALLS -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
+					<section class="space-y-6">
+						<div class="flex items-center justify-center gap-3 text-purple-400/60 mb-4">
+							<span class="text-xs uppercase tracking-widest">The Walls</span>
+						</div>
+						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
+							Then the walls went up.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+							Garden walls, at first. Then higher. Then so high you couldn't see
+							another garden on the horizon. The gardens disappeared into isolated biospheres—
+							entirely self-consuming voids where the only way out was through a gate
+							someone else controlled.
+						</p>
+					</section>
+
+					<!-- Glass Callout - The Loss -->
 					<section class="relative">
 						<div class="bg-purple-900/30 backdrop-blur-md rounded-2xl p-8 md:p-10 border border-purple-700/30 shadow-xl">
 							<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed mb-6">
-								We believe your words belong to you—not to platforms that lock them in,
+								Friends scattered to different platforms and became unreachable
+								unless you followed them there. Some I can only talk to on one app—
+								that's the only place they'll respond. Others I've lost entirely.
+								People I met in games, in communities, in spaces that don't exist anymore.
+							</p>
+							<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed mb-6">
+								I had music saved from artists I loved. One song I can still hum
+								but will never hear again—the artist deleted it, lost the file themselves.
+								<span class="text-amber-300/80">Gone.</span> Screenshots from games I played as a kid.
+								Blog posts I'd bookmarked. Proof I existed somewhere, vanished.
+							</p>
+							<p class="text-base md:text-lg text-purple-300/80 font-serif leading-relaxed italic">
+								That's what the walls took. Not just content. Connection. Memory. Proof.
+							</p>
+						</div>
+					</section>
+
+					<!-- Divider -->
+					<div class="flex justify-center">
+						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
+					</div>
+
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- THE MACHINES -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
+					<section class="space-y-6">
+						<div class="flex items-center justify-center gap-3 text-purple-400/60 mb-4">
+							<span class="text-xs uppercase tracking-widest">The Machines</span>
+						</div>
+						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
+							I'm tired of watching my friends get trapped in dopamine slot machines
+							designed to exploit how our minds work.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+							I signed up for a platform to see my friends. Instead I got 40,000 strangers
+							the algorithm decided I should see instead. Reels, shorts, infinite scroll—
+							engineered to hijack attention, especially neurodivergent attention.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/80 font-serif leading-relaxed">
+							Platforms that built their empires on our words, then loosened protections
+							for people like us the moment it became profitable.
+						</p>
+						<p class="text-xl md:text-2xl font-serif leading-relaxed mt-8">
+							<span class="text-purple-200">I think that's </span>
+							<span class="text-amber-300">disgusting.</span>
+						</p>
+					</section>
+
+					<!-- Divider -->
+					<div class="flex justify-center">
+						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
+					</div>
+
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- THE BRIDGE -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
+					<section class="space-y-6">
+						<div class="flex items-center justify-center gap-3 text-purple-400/60 mb-4">
+							<Bridge class="w-5 h-4" />
+							<span class="text-xs uppercase tracking-widest">The Bridge</span>
+						</div>
+						<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed">
+							Grove is everything that isn't.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+							I want to build a bridge—between people and other people,
+							between you and your own data. I want you and your words to hold hands,
+							not be separated by a company's database.
+						</p>
+					</section>
+
+					<!-- Glass Callout - What Grove Is -->
+					<section class="relative">
+						<div class="bg-purple-900/20 backdrop-blur-sm rounded-xl p-8 border border-purple-800/20">
+							<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed mb-4">
+								There's a search engine called Kagi. You pay for it. It doesn't show you ads.
+								It doesn't track you. When you search, you just... search.
+							</p>
+							<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed mb-4">
+								That's how Grove works.
+							</p>
+							<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+								You pay for a place to write. We don't sell your attention to anyone.
+								Your words are just words. There's the membership, and that's it.
+							</p>
+						</div>
+					</section>
+
+					<!-- Divider -->
+					<div class="flex justify-center">
+						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
+					</div>
+
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- THE CHOICES -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
+					<section class="space-y-6">
+						<div class="flex items-center justify-center gap-3 text-purple-400/60 mb-4">
+							<Leaf class="w-4 h-4" />
+							<span class="text-xs uppercase tracking-widest">The Choices</span>
+						</div>
+						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
+							Grove is text and photos only. That's not a limitation—it's a choice.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+							I want people to be intentional about what they post. Short-form video
+							is ruining our attention spans—mine included. So I'm not building another
+							place for content to disappear into an infinite scroll.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/80 font-serif leading-relaxed">
+							No algorithms deciding who sees your words. No engagement metrics
+							breeding outrage. No viral mechanics rewarding the loudest voice.
+						</p>
+						<p class="text-xl md:text-2xl text-purple-100 font-serif leading-relaxed mt-6">
+							Just people, sharing what matters to them.
+						</p>
+					</section>
+
+					<!-- Divider -->
+					<div class="flex justify-center">
+						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
+					</div>
+
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- QUEER-FRIENDLY -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
+					<section class="space-y-4">
+						<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed">
+							I believe in <span class="text-amber-300">queer-friendly infrastructure.</span>
+						</p>
+						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
+							In safe digital spaces, especially when physical ones feel hostile.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+							I'm building this because I want somewhere that's intentionally welcoming.
+							Somewhere that won't suddenly decide we're not worth protecting.
+						</p>
+					</section>
+
+					<!-- Divider -->
+					<div class="flex justify-center">
+						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
+					</div>
+
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- OWNERSHIP -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
+					<section class="relative">
+						<div class="bg-purple-900/30 backdrop-blur-md rounded-2xl p-8 md:p-10 border border-purple-700/30 shadow-xl">
+							<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed mb-6">
+								Your words belong to you—not to platforms that lock them in,
 								not to algorithms that decide who sees them,
-								not to AI companies that harvest them for machine learning.
+								not to AI companies that harvest them without asking.
+							</p>
+							<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed mb-6">
+								At any point, you can download everything. Not just when you leave—
+								<span class="text-amber-300/90">always.</span> Your content lives in standard formats
+								that work anywhere. Markdown files you can take to any platform.
 							</p>
 							<p class="text-xl md:text-2xl font-serif leading-relaxed">
 								<span class="text-amber-300">Your voice remains yours.</span>
@@ -129,78 +328,29 @@
 						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
 					</div>
 
-					<!-- Privacy & Portability -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- THE CENTURY -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
 					<section class="space-y-6">
-						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
-							We believe privacy isn't a premium feature.
-						</p>
-						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
-							We believe <span class="text-amber-300/90">"free"</span> doesn't mean <span class="text-amber-300/90">"you're the product."</span>
-						</p>
-						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
-							We believe you should be able to leave and take your roots with you.
-						</p>
-					</section>
-
-					<!-- Divider -->
-					<div class="flex justify-center">
-						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
-					</div>
-
-					<!-- Community - Glass Callout -->
-					<section class="relative">
-						<div class="bg-purple-900/20 backdrop-blur-sm rounded-xl p-8 border border-purple-800/20">
-							<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed mb-4">
-								We believe in community without competition.
-							</p>
-							<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed mb-4">
-								In feeds without algorithms.
-								<br />
-								In encouragement without performance.
-							</p>
-							<p class="text-base md:text-lg text-purple-200/90 font-serif leading-relaxed mt-6">
-								No metrics breeding outrage.
-								<br />
-								No viral mechanics rewarding the loudest voice.
-								<br />
-								Just people, sharing what matters to them.
-							</p>
+						<div class="flex items-center justify-center gap-3 text-purple-400/60 mb-4">
+							<TreePine class="w-4 h-5" />
+							<span class="text-xs uppercase tracking-widest">The Century</span>
 						</div>
-					</section>
-
-					<!-- Divider -->
-					<div class="flex justify-center">
-						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
-					</div>
-
-					<!-- Queer-Friendly -->
-					<section class="space-y-4">
+						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
+							Your words could outlive you.
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+							On most platforms, they'd vanish the moment you stopped paying—or the moment
+							the company decided to pivot, or shut down, or get acquired.
+						</p>
 						<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed">
-							We believe in <span class="text-amber-300">queer-friendly infrastructure.</span>
+							Here, if you grow with us long enough, your grove earns
+							<span class="text-amber-300/90">Centennial status</span>—your site stays online
+							for a hundred years. Even after you're gone, if you want it to.
 						</p>
-						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
-							In safe digital spaces, especially when physical ones feel hostile.
-						</p>
-						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
-							In building something intentionally welcoming.
-						</p>
-					</section>
-
-					<!-- Divider -->
-					<div class="flex justify-center">
-						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
-					</div>
-
-					<!-- Simplicity -->
-					<section class="space-y-4">
-						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
-							We believe the technology should disappear.
-						</p>
-						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
-							That you shouldn't need to fight your tools to create.
-						</p>
-						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
-							That simplicity is not the same as simplistic.
+						<p class="text-base md:text-lg text-purple-300/70 font-serif leading-relaxed italic mt-4">
+							A hundred years is roughly how long an oak tree lives.
 						</p>
 					</section>
 
@@ -209,26 +359,10 @@
 						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
 					</div>
 
-					<!-- Open Web -->
-					<section class="space-y-4">
-						<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed">
-							We believe in the <span class="text-amber-300">open web.</span>
-						</p>
-						<p class="text-base md:text-lg text-purple-200/90 font-serif leading-relaxed">
-							In RSS feeds.
-							<br />
-							In markdown files you can take anywhere.
-							<br />
-							In standards that outlast any single platform.
-						</p>
-					</section>
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- BUILDING SLOWLY -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
 
-					<!-- Divider -->
-					<div class="flex justify-center">
-						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
-					</div>
-
-					<!-- Building Slowly - Glass Callout -->
 					<section class="relative">
 						<div class="bg-slate-900/40 backdrop-blur-sm rounded-xl p-8 border border-slate-700/30">
 							<p class="text-lg md:text-xl text-purple-100 font-serif leading-relaxed mb-4">
@@ -247,9 +381,21 @@
 						<div class="w-24 h-px bg-gradient-to-r from-transparent via-purple-700/50 to-transparent"></div>
 					</div>
 
-					<!-- The Heart -->
-					<section class="space-y-6 py-8">
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- THE FEELING -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
+					<section class="space-y-6 py-4">
 						<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed">
+							When someone signs up for Grove, I want them to feel
+							<span class="text-amber-300/90">empowered.</span>
+						</p>
+						<p class="text-lg md:text-xl text-purple-200/90 font-serif leading-relaxed">
+							Like they've found a launching point for something good.
+							Like they're planting something that could grow for years.
+							Like their words are safe here.
+						</p>
+						<p class="text-xl md:text-2xl text-purple-100 font-serif leading-relaxed mt-6">
 							Grove is not trying to be everything.
 						</p>
 						<p class="text-xl md:text-2xl text-purple-100 font-serif leading-relaxed">
@@ -270,19 +416,23 @@
 						<Lantern class="w-12 h-20" variant="hanging" lit animate />
 					</div>
 
-					<!-- Closing - Major Glass Callout -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+					<!-- CLOSING -->
+					<!-- ═══════════════════════════════════════════════════════════════ -->
+
 					<section class="relative">
 						<div class="bg-gradient-to-b from-purple-900/40 to-slate-900/40 backdrop-blur-md rounded-2xl p-10 md:p-12 border border-purple-600/30 shadow-2xl">
 							<p class="text-base md:text-lg text-purple-200/90 font-serif leading-relaxed mb-6">
-								This is our manifesto.
+								This is my manifesto.
 								<br />
 								Not a pitch. Not a promise of features.
 								<br />
-								A statement of what we believe.
+								A statement of what I believe.
+							</p>
+							<p class="text-lg md:text-xl text-purple-200 font-serif leading-relaxed mb-6">
+								And if you believe it too—
 							</p>
 							<p class="text-xl md:text-2xl text-white font-serif leading-relaxed">
-								If this sounds like home,
-								<br />
 								<span class="text-amber-300">welcome to the Grove.</span>
 							</p>
 						</div>

--- a/landing/src/routes/pricing/+page.svelte
+++ b/landing/src/routes/pricing/+page.svelte
@@ -15,6 +15,7 @@
 		Mail,
 		LifeBuoy,
 		CalendarDays,
+		Clock,
 		// Tier header icons
 		Sprout,
 		TreeDeciduous,
@@ -198,6 +199,19 @@
 						<tr class="border-b border-subtle">
 							<td class="py-3 px-3 text-foreground-muted">
 								<span class="inline-flex items-center gap-2">
+									<Clock class="w-4 h-4 text-accent-subtle flex-shrink-0" />
+									Centennial
+								</span>
+							</td>
+							<td class="py-3 px-3 text-center text-foreground-faint">—</td>
+							<td class="py-3 px-3 text-center text-foreground-faint">—</td>
+							<td class="py-3 px-3 text-center text-accent-muted"><Check class="w-5 h-5 mx-auto" /></td>
+							<td class="py-3 px-3 text-center text-accent-muted"><Check class="w-5 h-5 mx-auto" /></td>
+							<td class="py-3 px-3 text-center text-accent-muted"><Check class="w-5 h-5 mx-auto" /></td>
+						</tr>
+						<tr class="border-b border-subtle bg-surface">
+							<td class="py-3 px-3 text-foreground-muted">
+								<span class="inline-flex items-center gap-2">
 									<LifeBuoy class="w-4 h-4 text-accent-subtle flex-shrink-0" />
 									Support
 								</span>
@@ -297,6 +311,16 @@
 						<p>
 							Evergreen includes 8 hours of hands-on support in your first month — setup help, customization, whatever you need.
 							After that, priority email support with faster response times.
+						</p>
+					</div>
+
+					<div>
+						<h3 class="font-medium text-foreground mb-2">Centennial (Sapling+)</h3>
+						<p>
+							<strong>Your grove can outlive you.</strong> After 12 cumulative months on Sapling or above, your site earns Centennial status — it stays online for 100 years from the day you planted it. Even if you stop paying, your words remain as a read-only archive.
+						</p>
+						<p class="mt-2 text-xs text-foreground-faint">
+							A hundred years is roughly how long an oak tree lives. Some trees outlive the people who planted them.
 						</p>
 					</div>
 

--- a/plant/src/routes/plans/+page.svelte
+++ b/plant/src/routes/plans/+page.svelte
@@ -40,7 +40,7 @@
 				'5 GB storage',
 				'10 themes',
 				'Email forwarding',
-				'Priority email support',
+				'Centennial eligible',
 				'Everything in Seedling'
 			],
 			highlight: 'popular',
@@ -57,7 +57,7 @@
 				'20 GB storage',
 				'Theme customizer',
 				'Bring your own domain',
-				'Full email suite',
+				'Centennial eligible',
 				'Priority support'
 			],
 			highlight: 'value',
@@ -74,7 +74,7 @@
 				'100 GB storage',
 				'Custom fonts',
 				'Domain included',
-				'Domain search & registration',
+				'Centennial eligible',
 				'8 hrs/mo dedicated support'
 			],
 			highlight: null,


### PR DESCRIPTION
Manifesto:
- Rewrote manifesto with deeply personal voice drawn from conversation
- Added sections: The Garden That Was, The Walls, The Machines, The Bridge, The Choices, The Century, The Feeling
- Included personal themes: lost songs, platform lock-in, dopamine slot machines, platforms loosening queer protections, the Kagi comparison
- Added inline icons (Acorn, Bridge, Leaf, TreePine) as section markers
- Maintained midnight/stars ambient decorations

Centennial (new feature):
- Created centennial-spec.md: 100-year domain preservation system
- After 12 months on Sapling+, sites stay online for a century
- Automatic unlock, opt-out available, read-only archive if subscription lapses
- "Some trees outlive the people who planted them"

Pricing updates:
- Added Centennial to grove-pricing.md main table and tier descriptions
- Added Centennial row and Fine Print section to pricing page
- Updated help center articles (choosing-your-plan, understanding-your-plan)
- Added Centennial feature to plant/plans onboarding page
- Added Centennial spec to knowledge-base.ts