### PR TITLE
feat(landing): add link from Manifesto to Vision page

### DIFF
--- a/landing/src/routes/manifesto/+page.svelte
+++ b/landing/src/routes/manifesto/+page.svelte
@@ -448,6 +448,17 @@
 						</div>
 					</section>
 
+					<!-- Bridge to Vision -->
+					<section class="pt-12">
+						<a
+							href="/vision"
+							class="group inline-flex items-center gap-2 text-purple-400 hover:text-purple-300 transition-colors font-serif text-lg"
+						>
+							<span class="italic">But loss isn't the whole story</span>
+							<span class="group-hover:translate-x-1 transition-transform">→</span>
+						</a>
+					</section>
+
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Connect the loss-focused Manifesto to the hope-focused Vision with a
gentle purple link at the bottom: "But loss isn't the whole story →"