### PR TITLE
docs: comprehensive grove-naming update with full ecosystem

### DIFF
--- a/docs/grove-naming.md
+++ b/docs/grove-naming.md
@@ -8,9 +8,162 @@
 
 The internet used to be a place of personal expression. Somewhere along the way, we traded that for algorithms and engagement metrics. Grove is a return to something simpler: a place where people can plant their thoughts and watch them grow.
 
-These names aren't just branding. They're the language of an ecosystem. Each one draws from the same soil: forests, growth, shelter, connection. Beneath the surface, roots intermingle. Trees share nutrients through mycorrhizal networks. The oldest trees nurture the saplings. 
+These names aren't just branding. They're the language of an ecosystem. Each one draws from the same soil: forests, growth, shelter, connection. Beneath the surface, roots intermingle. Trees share nutrients through mycorrhizal networks. The oldest trees nurture the saplings.
 
 This is how we build.
+
+---
+
+# Core Infrastructure
+
+*The foundation everything grows from*
+
+---
+
+## Lattice
+**Core Platform** · `npm: @autumnsgrove/lattice`
+**Repository:** [AutumnsGrove/GroveEngine](https://github.com/AutumnsGrove/GroveEngine)
+
+A lattice is the framework that supports growth. Vines climb it. Gardens are built around it. It's not the thing you see, it's the thing that holds everything else up.
+
+Lattice is the npm package powering every Grove site. UI components, authentication utilities, markdown rendering, database patterns: all the infrastructure that makes building on Grove feel effortless. You don't admire a lattice. You build on it, and watch what grows.
+
+**Vines** are a feature of Lattice: the widgets and content that fill your blog's gutters (the sidebar margins alongside your main content). Like vines climbing a trellis, they grow alongside your posts: related links, callouts, annotations, metadata. Gutter content that adds context without interrupting the flow.
+
+---
+
+# Platform Services
+
+*Essential services that power every Grove blog*
+
+---
+
+## Heartwood
+**Authentication** · `heartwood.grove.place`
+**Repository:** [AutumnsGrove/GroveAuth](https://github.com/AutumnsGrove/GroveAuth)
+
+Cut a tree open and you'll find the heartwood at the center, the densest, most durable part. It's what remains when everything else falls away. It's the authentic core.
+
+Heartwood is centralized authentication for the Grove ecosystem. One identity, verified and protected, that works across every Grove property. Your heartwood is yours. It proves you are who you say you are.
+
+---
+
+## Arbor
+**Admin Panel** · `{blog}.grove.place/admin`
+
+An arbor is a garden structure that supports climbing plants: structured, nurturing, and essential for healthy growth. It's where you manage and cultivate your corner of the grove.
+
+Arbor is Grove's blogger admin panel where users manage content, customize their site, and configure settings. Designed to be minimal and anxiety-free with quick navigation, instant saves, and a warm aesthetic matching Grove's cozy tea-shop vibe. No real-time analytics dashboards breeding anxiety. Just write, publish, done.
+
+---
+
+## Plant
+**Onboarding** · `plant.grove.place`
+
+A seedbed is where seeds are planted and nurtured until they're ready to grow on their own. It's the starting place: carefully prepared soil, the right conditions, gentle care until roots take hold.
+
+Plant is Grove's onboarding system: the complete flow for new users from initial signup through payment, interactive tour, and handoff to their own blog. A frictionless, welcoming experience that gets you publishing within minutes. You arrive as a visitor. You leave with a home.
+
+---
+
+## Amber
+**Storage Management** · `amber.grove.place`
+**Repository:** [AutumnsGrove/Amber](https://github.com/AutumnsGrove/Amber)
+
+Amber is fossilized tree resin, preserving moments in time, capturing life in suspended animation. It holds what matters, protecting it for centuries.
+
+Amber is Grove's unified storage management system. Every file you upload (blog images, email attachments, profile pictures) is preserved in Amber, organized and accessible from one place. See what's using your space. Download and export your data. Clean up what you don't need. Buy more when you need it. Amber isn't trying to be Dropbox or Google Drive. It's the storage layer that already exists in Grove, made visible and manageable. Every paid user already has storage; Amber is how they understand and control it.
+
+---
+
+## Foliage
+**Theming System** · `foliage.grove.place`
+**Repository:** [AutumnsGrove/Foliage](https://github.com/AutumnsGrove/Foliage)
+
+Foliage is what you see when you look at a tree. The leaves, the color, the personality that changes with the seasons. No two canopies are quite the same.
+
+Foliage is visual customization for your blog, from accent colors to full theme control. Pick a curated theme or build your own. Make it warm, make it bold, make it *yours*. Your foliage is how the world sees your corner of the grove.
+
+---
+
+## Rings
+**Analytics** · *Integrated into admin dashboard*
+
+Count the rings of a tree and you learn its story. Each ring records a season: growth in plenty, resilience through hardship, the quiet accumulation of years. Rings are internal. Private. You only see them when you look closely at your own tree.
+
+Rings is analytics for writers, not marketers. No public view counts breeding anxiety. No leaderboards. No real-time dopamine hits. Just private insights about your own growth: who's reading, what resonates, how your garden is growing over time. Delayed by design, reflective by nature. Your rings are yours alone.
+
+---
+
+## Clearing
+**Status Page** · `status.grove.place`
+
+A clearing is an open space in the forest where the trees part and visibility opens up. You can see what's around you, assess the situation, and understand what's happening.
+
+Clearing is Grove's public status page: transparent, real-time communication about platform health. When something goes wrong or maintenance is planned, users can check the clearing to understand what's happening without needing to contact support.
+
+---
+
+## Waystone
+**Help Center** · *(integrated)*
+
+Waystones are the markers travelers leave along forest paths, guiding those who follow, showing the way forward.
+
+Waystone is Grove's built-in help center: searchable documentation, contextual help buttons throughout the interface, and a lantern to light your path when you're lost. Not an external docs site, not a separate login. Help is where you need it, not hidden away. Clear about what Grove can and can't do. Text-first for easy updates as the platform evolves.
+
+*Trail markers that guide you through the forest.*
+
+---
+
+## Centennial
+**Domain Preservation** · *(feature)*
+
+A century is the lifetime of an oak. It's the span between a sapling taking root and becoming something people gather beneath for shade.
+
+Centennial is Grove's promise that your words can have that same longevity. When you've been part of Grove long enough to put down real roots (12 cumulative months of Sapling+ membership), your site earns Centennial status. Your `name.grove.place` domain stays online for 100 years from the day you planted it—even if you stop paying, even after you're gone.
+
+*Some trees outlive the people who planted them.*
+
+---
+
+# Content & Community
+
+*Writing, moderation, and social features*
+
+---
+
+## Wisp
+**Writing Assistant** · *Integrated into editor*
+
+A wisp is a will-o'-the-wisp, a gentle, ephemeral light that appears in forests and marshes. It guides without forcing. It's there and then it's not.
+
+Wisp is Grove's ethical writing assistant. It helps polish your voice without replacing it: grammar checks, tone analysis, readability scores. Never generation, never expansion, never brainstorming. Just subtle nudges from a tool that disappears into the background when you don't need it.
+
+**Fireside** is a mode of Wisp for writers who freeze at the blank page. Some people can't start writing, but they have no trouble *talking*. Fireside is a conversation that becomes a post. Wisp asks questions, you answer naturally, and your words get organized into a draft. The fire doesn't tell the story. It just creates the space where stories emerge.
+
+All features off by default. Zero data retention. Your words analyzed, never stored. *A helper, not a writer, and sometimes, a good listener.*
+
+---
+
+## Reeds
+**Comments System** · *(integrated)*
+
+Reeds sway together at the water's edge, whispering in the breeze: a gentle murmur of community.
+
+Reeds is Grove's comment system, supporting both private replies (author-only) and public conversations (author-moderated). A dual system that encourages thoughtful engagement while giving blog authors full control over their public-facing content. Private replies remove the performance anxiety of public commenting. No reactions on comments, just threaded replies. HN-style simplicity.
+
+*Whisper together at the water's edge.*
+
+---
+
+## Thorn
+**Content Moderation** · *(internal)*
+
+Thorns protect plants from harm without being aggressive. They're natural, protective, and guard the grove from harmful content.
+
+Thorn is Grove's automated content moderation system: privacy-first, context-aware, and designed to protect without surveillance. Zero human eyes on user data during automated review. Immediate deletion of all content after review completes. No training on user data—ever. Context-aware decisions rather than keyword matching.
+
+*Every rose has thorns for protection.*
 
 ---
 
@@ -25,6 +178,51 @@ Meadow is social media that remembers what "social" means. No public metrics bre
 
 ---
 
+## Trails
+**Personal Roadmaps** · `username.grove.place/trail`
+
+A trail is the path you're walking: the route you've chosen through the forest, marked by where you've been and where you're headed. No two trails are the same.
+
+Trails lets Grove users share their own roadmaps with the world. Whether you're building a project, planning a content series, or just charting where your creative work is headed, Trails gives you a place to show the journey. Create waypoints marking milestones, group them into phases with custom names, and let visitors follow along as you make progress.
+
+For those who want to dream bigger: Oak and Evergreen users can bring the full Grove aesthetic to their trails with seasonal themes, nature decorations, custom assets. Or keep it simple with a clean timeline. Your trail, your way.
+
+**Templates available for:** Writers planning content series, developers building in public, musicians tracking album progress, restaurants showing seasonal menus, and more.
+
+*The path becomes clear by walking it.*
+
+---
+
+# Standalone Tools
+
+*Independent tools that integrate with Grove*
+
+---
+
+## Ivy
+**Email** · `ivy.grove.place`
+**Repository:** [AutumnsGrove/Ivy](https://github.com/AutumnsGrove/Ivy)
+
+Ivy climbs the lattice. It's the living connection that grows along the framework, reaching out, intertwining, linking one point to another.
+
+Ivy is email for Grove. Not a Gmail replacement, but a focused, privacy-first mail client for your `@grove.place` address. Professional correspondence for your blog. A place where contact form submissions arrive as threads. Zero-knowledge encryption means we can't read your mail; it's yours alone. One address, chosen once, that's authentically you.
+
+---
+
+## Bloom
+**Remote Coding Infrastructure** · `bloom.grove.place`
+**Repository:** [AutumnsGrove/GroveBloom](https://github.com/AutumnsGrove/GroveBloom)
+
+A bloom is the brief, brilliant moment when a flower opens: ephemeral, purposeful, then gone. It appears when conditions are right, does its work, and doesn't linger.
+
+Bloom is Grove's serverless remote coding infrastructure. It spins up temporary VPS instances on-demand, runs AI coding agents autonomously to complete development tasks, syncs your code to storage, then vanishes. Send a task from your phone during lunch. Check back later: Bloom worked through it, saved the results, and cleaned up after itself. Infrastructure that exists only when needed, costs almost nothing, and never overstays its welcome.
+
+It blooms, does its work, and fades away. By morning, there's only the code it left behind.
+
+*Brief, brilliant, gone.*
+
+---
+
 ## Forage
 **Domain Discovery** · `forage.grove.place`
 **Repository:** [AutumnsGrove/Forage](https://github.com/AutumnsGrove/Forage)
@@ -35,45 +233,13 @@ Forage is an AI-powered domain hunting tool that turns weeks of frustrating sear
 
 ---
 
-## Foliage
-**Theming System** · `foliage.grove.place`
-**Repository:** [AutumnsGrove/Foliage](https://github.com/AutumnsGrove/Foliage)
+## Nook
+**Private Video Sharing** · `nook.grove.place`
+**Repository:** [AutumnsGrove/Nook](https://github.com/AutumnsGrove/Nook)
 
-Foliage is what you see when you look at a tree. The leaves, the color, the personality that changes with the seasons. No two canopies are quite the same.
+A nook is a tucked-away corner, a quiet space set apart from the main room. Somewhere intimate and private.
 
-Foliage is visual customization for your blog, from accent colors to full theme control. Pick a curated theme or build your own. Make it warm, make it bold, make it *yours*. Your foliage is how the world sees your corner of the grove.
-
----
-
-## Heartwood
-**Authentication** · `heartwood.grove.place`
-**Repository:** [AutumnsGrove/GroveAuth](https://github.com/AutumnsGrove/GroveAuth)
-
-Cut a tree open and you'll find the heartwood at the center, the densest, most durable part. It's what remains when everything else falls away. It's the authentic core.
-
-Heartwood is centralized authentication for the Grove ecosystem. One identity, verified and protected, that works across every Grove property. Your heartwood is yours. It proves you are who you say you are.
-
----
-
-## Patina
-**Backup System** · *Internal service*
-**Repository:** [AutumnsGrove/Patina](https://github.com/AutumnsGrove/Patina)
-
-A patina is the thin layer that forms on copper and bronze over time. Not decay, but protection. It's what happens when something weathers the world and comes out stronger. The green of old statues, the warmth of handled wood, the soft wear on a favorite book's spine.
-
-Patina runs nightly automated backups of every Grove database to cold storage. Weekly archives compress the daily layers, and twelve weeks of history remain quietly preserved. You'll probably never think about it, and that's the point. When disaster strikes, Patina is already there, holding everything safe beneath its protective layer.
-
-*Age as armor. Time as protection.*
-
----
-
-## Trove
-**Library Book Discovery** · `trove.grove.place`
-**Repository:** [AutumnsGrove/TreasureTrove](https://github.com/AutumnsGrove/TreasureTrove)
-
-A trove is a collection of precious things, gathered and waiting to be discovered.
-
-Point your camera at a library shelf. Trove identifies the books, cross-references your reading history and tastes, and tells you which ones are worth your time, with visual markers showing exactly where they sit on the shelf. No more decision paralysis. No more walking out empty-handed. Just treasures, found.
+Nook is where you share moments with the people who matter. Not a YouTube channel, not a public archive. Just a tucked-away space where your closest friends can watch the videos you've been meaning to share for over a year. Intimate video sharing for close connections.
 
 ---
 
@@ -97,106 +263,45 @@ Give Aria a song you love, and it builds a playlist of tracks that share the sam
 
 ---
 
-## Lattice
-**Core Platform** · `npm: @autumnsgrove/lattice`
-**Repository:** [AutumnsGrove/GroveEngine](https://github.com/AutumnsGrove/GroveEngine)
+## Trove
+**Library Book Discovery** · `trove.grove.place`
+**Repository:** [AutumnsGrove/TreasureTrove](https://github.com/AutumnsGrove/TreasureTrove)
 
-A lattice is the framework that supports growth. Vines climb it. Gardens are built around it. It's not the thing you see, it's the thing that holds everything else up.
+A trove is a collection of precious things, gathered and waiting to be discovered.
 
-Lattice is the npm package powering every Grove site. UI components, authentication utilities, markdown rendering, database patterns: all the infrastructure that makes building on Grove feel effortless. You don't admire a lattice. You build on it, and watch what grows.
-
-**Vines** are a feature of Lattice: the widgets and content that fill your blog's gutters (the sidebar margins alongside your main content). Like vines climbing a trellis, they grow alongside your posts: related links, callouts, annotations, metadata. Gutter content that adds context without interrupting the flow.
+Point your camera at a library shelf. Trove identifies the books, cross-references your reading history and tastes, and tells you which ones are worth your time, with visual markers showing exactly where they sit on the shelf. No more decision paralysis. No more walking out empty-handed. Just treasures, found.
 
 ---
 
-## Plant
-**Onboarding** · `plant.grove.place`
+# Operations
 
-A seedbed is where seeds are planted and nurtured until they're ready to grow on their own. It's the starting place: carefully prepared soil, the right conditions, gentle care until roots take hold.
-
-Plant is Grove's onboarding system: the complete flow for new users from initial signup through payment, interactive tour, and handoff to their own blog. A frictionless, welcoming experience that gets you publishing within minutes. You arrive as a visitor. You leave with a home.
+*Internal infrastructure keeping Grove running*
 
 ---
 
-## Rings
-**Analytics** · *Integrated into admin dashboard*
+## Vista
+**Infrastructure Observability** · `vista.grove.place`
+**Repository:** [AutumnsGrove/GroveMonitor](https://github.com/AutumnsGrove/GroveMonitor)
 
-Count the rings of a tree and you learn its story. Each ring records a season: growth in plenty, resilience through hardship, the quiet accumulation of years. Rings are internal. Private. You only see them when you look closely at your own tree.
+A vista is a clearing in the forest where the canopy opens up, a place where you can finally see. The whole grove stretches out before you: what's thriving, what's struggling, what needs attention.
 
-Rings is analytics for writers, not marketers. No public view counts breeding anxiety. No leaderboards. No real-time dopamine hits. Just private insights about your own growth: who's reading, what resonates, how your garden is growing over time. Delayed by design, reflective by nature. Your rings are yours alone.
+Vista is infrastructure observability for the Grove platform. It monitors every worker, database, storage bucket, and KV namespace, tracking health, latency, error rates, and costs. Real-time dashboards show the state of the entire ecosystem at a glance. When something needs attention, Vista sends an alert before users ever notice. Ninety days of history, always available, quietly watching.
 
----
+Rings tells writers about their readers. Vista tells the grove keeper about the grove itself.
 
-## Ivy
-**Email** · `ivy.grove.place`
-**Repository:** [AutumnsGrove/Ivy](https://github.com/AutumnsGrove/Ivy)
-
-Ivy climbs the lattice. It's the living connection that grows along the framework, reaching out, intertwining, linking one point to another.
-
-Ivy is email for Grove. Not a Gmail replacement, but a focused, privacy-first mail client for your `@grove.place` address. Professional correspondence for your blog. A place where contact form submissions arrive as threads. Zero-knowledge encryption means we can't read your mail; it's yours alone. One address, chosen once, that's authentically you.
+*Where you go to see everything clearly.*
 
 ---
 
-## Amber
-**Storage Management** · `amber.grove.place`
-**Repository:** [AutumnsGrove/Amber](https://github.com/AutumnsGrove/Amber)
+## Patina
+**Backup System** · *Internal service*
+**Repository:** [AutumnsGrove/Patina](https://github.com/AutumnsGrove/Patina)
 
-Amber is fossilized tree resin, preserving moments in time, capturing life in suspended animation. It holds what matters, protecting it for centuries.
+A patina is the thin layer that forms on copper and bronze over time. Not decay, but protection. It's what happens when something weathers the world and comes out stronger. The green of old statues, the warmth of handled wood, the soft wear on a favorite book's spine.
 
-Amber is Grove's unified storage management system. Every file you upload (blog images, email attachments, profile pictures) is preserved in Amber, organized and accessible from one place. See what's using your space. Download and export your data. Clean up what you don't need. Buy more when you need it. Amber isn't trying to be Dropbox or Google Drive. It's the storage layer that already exists in Grove, made visible and manageable. Every paid user already has storage; Amber is how they understand and control it.
+Patina runs nightly automated backups of every Grove database to cold storage. Weekly archives compress the daily layers, and twelve weeks of history remain quietly preserved. You'll probably never think about it, and that's the point. When disaster strikes, Patina is already there, holding everything safe beneath its protective layer.
 
----
-
-## Shade
-**AI Content Protection** · `grove.place/shade`
-
-Shade is the cool relief beneath the canopy. Protection from the harsh glare of exposure. It's where you rest, out of sight from those who would harvest without asking.
-
-Shade is Grove's layered defense against AI crawlers, scrapers, and automated data harvesting. In a world where tech giants treat user content as training data to be extracted without consent, Shade is a quiet refusal. robots.txt directives, meta tags, rate limiting, WAF rules, and legal documentation, all working together so writers can write without worrying about becoming someone else's training data.
-
-*In a forest full of harvesters, this grove stays shaded.*
-
----
-
-## Trails
-**Personal Roadmaps** · `username.grove.place/trail`
-
-A trail is the path you're walking: the route you've chosen through the forest, marked by where you've been and where you're headed. No two trails are the same.
-
-Trails lets Grove users share their own roadmaps with the world. Whether you're building a project, planning a content series, or just charting where your creative work is headed, Trails gives you a place to show the journey. Create waypoints marking milestones, group them into phases with custom names, and let visitors follow along as you make progress.
-
-For those who want to dream bigger: Oak and Evergreen users can bring the full Grove aesthetic to their trails with seasonal themes, nature decorations, custom assets. Or keep it simple with a clean timeline. Your trail, your way.
-
-**Templates available for:** Writers planning content series, developers building in public, musicians tracking album progress, restaurants showing seasonal menus, and more.
-
-*The path becomes clear by walking it.*
-
----
-
-## Vineyard
-**Asset & Tool Showcase** · `*.grove.place/vineyard`
-
-A vineyard is where vines are tended before they're ready: rows of growth, organized and visible, trained along the lattice. It's part nursery, part gallery. A place to see what's growing and understand how it all fits together.
-
-Vineyard is the documentation and demo pattern for every Grove tool. Each product gets its own `/vineyard` route: `amber.grove.place/vineyard`, `ivy.grove.place/vineyard`, `foliage.grove.place/vineyard`. Inside, you'll find working demos where possible, visual mockups for what's coming, feature documentation, and the philosophy behind each tool. It's where you go to understand what something does before you use it, or to dream about what it will become.
-
-Some vineyards showcase mature vines ready for harvest. Others tend young shoots still finding their shape. Both belong here. The vineyard doesn't hide what's unfinished, it celebrates the growing.
-
-*Every vine starts somewhere.*
-
----
-
-## Bloom
-**Remote Coding Infrastructure** · `bloom.grove.place`
-**Repository:** [AutumnsGrove/GroveBloom](https://github.com/AutumnsGrove/GroveBloom)
-
-A bloom is the brief, brilliant moment when a flower opens: ephemeral, purposeful, then gone. It appears when conditions are right, does its work, and doesn't linger.
-
-Bloom is Grove's serverless remote coding infrastructure. It spins up temporary VPS instances on-demand, runs AI coding agents autonomously to complete development tasks, syncs your code to storage, then vanishes. Send a task from your phone during lunch. Check back later: Bloom worked through it, saved the results, and cleaned up after itself. Infrastructure that exists only when needed, costs almost nothing, and never overstays its welcome.
-
-It blooms, does its work, and fades away. By morning, there's only the code it left behind.
-
-*Brief, brilliant, gone.*
+*Age as armor. Time as protection.*
 
 ---
 
@@ -215,57 +320,142 @@ It's the invisible network beneath everything. You don't see it. You don't think
 
 ---
 
-## Vista
-**Infrastructure Observability** · `vista.grove.place`
-**Repository:** [AutumnsGrove/GroveMonitor](https://github.com/AutumnsGrove/GroveMonitor)
+## Shade
+**AI Content Protection** · `grove.place/shade`
 
-A vista is a clearing in the forest where the canopy opens up, a place where you can finally see. The whole grove stretches out before you: what's thriving, what's struggling, what needs attention.
+Shade is the cool relief beneath the canopy. Protection from the harsh glare of exposure. It's where you rest, out of sight from those who would harvest without asking.
 
-Vista is infrastructure observability for the Grove platform. It monitors every worker, database, storage bucket, and KV namespace, tracking health, latency, error rates, and costs. Real-time dashboards show the state of the entire ecosystem at a glance. When something needs attention, Vista sends an alert before users ever notice. Ninety days of history, always available, quietly watching.
+Shade is Grove's layered defense against AI crawlers, scrapers, and automated data harvesting. In a world where tech giants treat user content as training data to be extracted without consent, Shade is a quiet refusal. robots.txt directives, meta tags, rate limiting, WAF rules, and legal documentation, all working together so writers can write without worrying about becoming someone else's training data.
 
-Rings tells writers about their readers. Vista tells the grove keeper about the grove itself.
-
-*Where you go to see everything clearly.*
+*In a forest full of harvesters, this grove stays shaded.*
 
 ---
 
-## Wisp
-**Writing Assistant** · *Integrated into editor*
+## Seasons
+**Versioning System** · *(internal)*
 
-A wisp is a will-o'-the-wisp, a gentle, ephemeral light that appears in forests and marshes. It guides without forcing. It's there and then it's not.
+Seasons mark the passage of time in a forest. Spring brings new growth, summer matures it, autumn harvests, winter rests. Each season builds on the last, each version a new ring in the trunk.
 
-Wisp is Grove's ethical writing assistant. It helps polish your voice without replacing it: grammar checks, tone analysis, readability scores. Never generation, never expansion, never brainstorming. Just subtle nudges from a tool that disappears into the background when you don't need it.
-
-**Fireside** is a mode of Wisp for writers who freeze at the blank page. Some people can't start writing, but they have no trouble *talking*. Fireside is a conversation that becomes a post. Wisp asks questions, you answer naturally, and your words get organized into a draft. The fire doesn't tell the story. It just creates the space where stories emerge.
-
-All features off by default. Zero data retention. Your words analyzed, never stored. *A helper, not a writer, and sometimes, a good listener.*
+Seasons is Grove's versioning system: how Lattice evolves, how updates propagate to customer repositories, how the ecosystem grows together through breaking changes and gentle improvements alike. Semantic versioning with meaning—major versions are new seasons, minor versions are weather patterns, patches are daily cycles.
 
 ---
+
+# Patterns
+
+*Reusable patterns and architectural foundations*
+
+These are architectural patterns that power the Grove infrastructure. They follow the same naming philosophy but are internal systems rather than user-facing products. You won't see them in marketing, but they're the foundation everything else grows on.
+
+---
+
+## Prism
+**Design System** · *All Grove properties*
+
+Step into a cathedral in the forest. Your eyes adjust to the dim sanctuary, and then you look up—massive stained glass windows transforming ordinary sunlight into something that takes your breath away. A prism doesn't just transmit light. It *transfigures* it.
+
+Prism is Grove's design system: glassmorphism, seasonal theming, and organic randomization. Every page is a *place* you visit—warm like a midnight tea shop, clear like good documentation. Translucent surfaces that don't merely display—they transform.
+
+*Light enters plain and emerges transformed.*
+
+---
+
+## Loom
+**Real-Time Coordination** · *Durable Objects layer*
+
+Loom is Grove's coordination layer, built on Cloudflare Durable Objects. It's the invisible structure that makes everything feel seamless: auth that works across all properties, state that stays in sync, real-time features that just work.
+
+A loom is the framework where threads come together. Loom weaves together SessionDO, TenantDO, and PostDO into a coherent fabric.
+
+*The framework where Grove's threads come together.*
+
+---
+
+## Firefly
+**Ephemeral Server Pattern** · *Used by Bloom, Outpost*
+
+In the forest at dusk, fireflies blink into existence—brief, purposeful flashes of light. They don't stay lit all night. They appear when conditions call for them, do what they need to do, and vanish.
+
+Firefly is Grove's pattern for ephemeral infrastructure. Servers that spin up on demand, complete their work, and tear down automatically. Infrastructure that exists only when needed—costing almost nothing when idle, scaling instantly when called upon.
+
+*A brief light in the darkness.*
+
+---
+
+## Threshold
+**Rate Limiting & Abuse Prevention** · *Security layer*
+
+The forest has boundaries. Threshold enforces them.
+
+Moving beyond naive IP-based limits, Threshold uses Durable Objects for precise per-user, per-tenant, and per-endpoint rate limiting with graceful degradation. Graduated response: warning → slowdown → block → ban. Protection without punishing legitimate users.
+
+---
+
+## Sentinel
+**Load Testing & Scale Validation** · *Testing framework*
+
+The watchful guardian who tests the forest's defenses before the storm.
+
+Sentinel doesn't just ask "can it handle 500 users?"—it asks "what happens to p95 latency during the ramp-up, and which Durable Object becomes the bottleneck first?" Realistic traffic profiles, ramp-up testing, and multi-vector observation.
+
+---
+
+## Songbird
+**Prompt Injection Protection** · *AI security*
+
+In the forest, birds warn each other of danger. The canary alerts first. The kestrel watches and validates. The robin sings the safe response.
+
+Songbird is Grove's three-layer defense against prompt injection attacks. Each layer costs fractions of a cent but protects all Grove AI features from compromised responses. Cheap insurance. Essential protection.
+
+*Three birds, three layers, one defense.*
+
+---
+
+## Vineyard
+**Asset & Tool Showcase** · `*.grove.place/vineyard`
+
+A vineyard is where vines are tended before they're ready: rows of growth, organized and visible, trained along the lattice. It's part nursery, part gallery. A place to see what's growing and understand how it all fits together.
+
+Vineyard is the documentation and demo pattern for every Grove tool. Each product gets its own `/vineyard` route: `amber.grove.place/vineyard`, `ivy.grove.place/vineyard`, `foliage.grove.place/vineyard`. Inside, you'll find working demos where possible, visual mockups for what's coming, feature documentation, and the philosophy behind each tool. It's where you go to understand what something does before you use it, or to dream about what it will become.
+
+Some vineyards showcase mature vines ready for harvest. Others tend young shoots still finding their shape. Both belong here. The vineyard doesn't hide what's unfinished, it celebrates the growing.
+
+*Every vine starts somewhere.*
+
+---
+
+# Reference Tables
 
 ## The Ecosystem
 
 | Name | Purpose | Domain |
 |------|---------|--------|
-| **Meadow** | Social connection | meadow.grove.place |
-| **Forage** | Domain discovery | forage.grove.place |
-| **Foliage** | Theming system | foliage.grove.place |
+| **Lattice** | Core platform | npm package |
 | **Heartwood** | Authentication | heartwood.grove.place |
-| **Patina** | Backup system | *(internal)* |
-| **Trove** | Library book finder | trove.grove.place |
+| **Arbor** | Admin panel | {blog}.grove.place/admin |
+| **Plant** | Onboarding | plant.grove.place |
+| **Amber** | Storage management | amber.grove.place |
+| **Foliage** | Theming system | foliage.grove.place |
+| **Rings** | Analytics | *(integrated)* |
+| **Clearing** | Status page | status.grove.place |
+| **Waystone** | Help center | *(integrated)* |
+| **Centennial** | Domain preservation | *(feature)* |
+| **Wisp** | Writing assistant (+ Fireside) | *(integrated)* |
+| **Reeds** | Comments system | *(integrated)* |
+| **Thorn** | Content moderation | *(internal)* |
+| **Meadow** | Social connection | meadow.grove.place |
+| **Trails** | Personal roadmaps | username.grove.place/trail |
+| **Ivy** | Email | ivy.grove.place |
+| **Bloom** | Remote coding infrastructure | bloom.grove.place |
+| **Forage** | Domain discovery | forage.grove.place |
+| **Nook** | Private video sharing | nook.grove.place |
 | **Outpost** | Minecraft server | mc.grove.place |
 | **Aria** | Music curation | aria.grove.place |
-| **Lattice** | Core platform | npm package |
-| **Plant** | Onboarding | plant.grove.place |
-| **Rings** | Analytics | *(integrated)* |
-| **Ivy** | Email | ivy.grove.place |
-| **Amber** | Storage management | amber.grove.place |
-| **Shade** | AI content protection | grove.place/shade |
-| **Trails** | Personal roadmaps | username.grove.place/trail |
-| **Vineyard** | Asset & tool showcase | *.grove.place/vineyard |
-| **Bloom** | Remote coding infrastructure | bloom.grove.place |
-| **Mycelium** | MCP server | mycelium.grove.place |
+| **Trove** | Library book finder | trove.grove.place |
 | **Vista** | Infrastructure observability | vista.grove.place |
-| **Wisp** | Writing assistant (+ Fireside) | *(integrated)* |
+| **Patina** | Backup system | *(internal)* |
+| **Mycelium** | MCP server | mycelium.grove.place |
+| **Shade** | AI content protection | grove.place/shade |
+| **Seasons** | Versioning system | *(internal)* |
 
 ---
 
@@ -275,26 +465,47 @@ For development, debugging, and internal documentation, the `Grove[Thing]` namin
 
 | Public Name | Internal Name |
 |-------------|---------------|
-| Meadow | GroveSocial |
-| Forage | GroveDomainTool |
-| Foliage | GroveThemes |
+| Lattice | GroveEngine |
 | Heartwood | GroveAuth |
-| Patina | GrovePatina |
-| Trove | TreasureTrove |
+| Arbor | GroveArbor |
+| Plant | Seedbed |
+| Amber | GroveStorage |
+| Foliage | GroveThemes |
+| Rings | GroveAnalytics |
+| Clearing | GroveClear |
+| Waystone | GroveWaystone |
+| Centennial | GroveCentennial |
+| Wisp | GroveWisp |
+| Reeds | GroveReeds |
+| Thorn | GroveThorn |
+| Meadow | GroveSocial |
+| Trails | GroveTrails |
+| Ivy | GroveMail |
+| Bloom | GroveBloom |
+| Forage | GroveDomainTool |
+| Nook | GroveNook |
 | Outpost | GroveMC |
 | Aria | GroveMusic |
-| Lattice | GroveEngine |
-| Plant | Seedbed |
-| Rings | GroveAnalytics |
-| Ivy | GroveMail |
-| Amber | GroveStorage |
-| Shade | GroveShade |
-| Trails | GroveTrails |
-| Vineyard | GroveShowcase |
-| Bloom | GroveBloom |
-| Mycelium | GroveMCP |
+| Trove | TreasureTrove |
 | Vista | GroveMonitor |
-| Wisp | GroveWisp |
+| Patina | GrovePatina |
+| Mycelium | GroveMCP |
+| Shade | GroveShade |
+| Seasons | GroveSeasons |
+
+---
+
+## Patterns Reference
+
+| Pattern | Purpose | Internal Name |
+|---------|---------|---------------|
+| Prism | Design system | GrovePrism |
+| Loom | Real-time coordination | GroveLoom |
+| Firefly | Ephemeral servers | GroveFirefly |
+| Threshold | Rate limiting | GroveThreshold |
+| Sentinel | Load testing | GroveSentinel |
+| Songbird | AI security | GroveSongbird |
+| Vineyard | Tool showcase | GroveShowcase |
 
 ---
 
@@ -306,5 +517,5 @@ The Grove is the place. These are the things you find there.
 
 ---
 
-*Last updated: December 2025*
+*Last updated: January 2026*
 *Status: Placeholder names, pending launch*

--- a/docs/specs/heartwood-spec.md
+++ b/docs/specs/heartwood-spec.md
@@ -1,0 +1,1208 @@
+---
+aliases: []
+date created: Monday, December 15th 2025
+date modified: Saturday, January 4th 2026
+source: https://github.com/AutumnsGrove/GroveAuth/blob/main/GROVEAUTH_SPEC.md
+tags:
+  - authentication
+  - security
+  - cloudflare-workers
+  - oauth
+type: tech-spec
+---
+
+# Heartwood (GroveAuth) - Centralized Authentication Service
+
+> A Cloudflare Worker-based authentication service for all AutumnsGrove properties
+
+**Public Name**: Heartwood
+**Internal Codename**: GroveAuth
+**Public Domain**: `heartwood.grove.place`
+**API Domain**: `auth-api.grove.place` (internal backend)
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [Tech Stack](#tech-stack)
+4. [Authentication Methods](#authentication-methods)
+5. [Database Schema](#database-schema)
+6. [API Specification](#api-specification)
+7. [OAuth Flows](#oauth-flows)
+8. [Client Integration](#client-integration)
+9. [Security Requirements](#security-requirements)
+10. [Environment Configuration](#environment-configuration)
+11. [Development Guidelines](#development-guidelines)
+
+---
+
+## Overview
+
+### Purpose
+
+GroveAuth is a centralized authentication service that handles all authentication for AutumnsGrove properties. Instead of each site implementing its own auth logic, all sites redirect to GroveAuth for login and receive verified session tokens back.
+
+### Goals
+
+- **Single source of truth** for user authentication
+- **Multiple auth providers** (Google, GitHub, Magic Code)
+- **Secure token-based sessions** that client sites can verify
+- **Simple integration** for any site in the AutumnsGrove ecosystem
+- **Admin-only access** (no public registration - allowlist based)
+
+### Non-Goals
+
+- Public user registration (this is admin auth only)
+- Social features or user profiles
+- Password-based authentication
+
+---
+
+## Architecture
+
+### High-Level Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Client Sites                                 │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐               │
+│  │AutumnsGrove  │  │ Other Site   │  │ Future Site  │               │
+│  │autumnsgrove. │  │ example.     │  │ another.     │               │
+│  │   place      │  │ grove.place  │  │ grove.place  │               │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘               │
+└─────────┼─────────────────┼─────────────────┼───────────────────────┘
+          │                 │                 │
+          │    1. Redirect to auth.grove.place/login?
+          │       client_id=xxx&redirect_uri=xxx
+          │                 │                 │
+          ▼                 ▼                 ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                        GroveAuth Service                             │
+│                       auth.grove.place                               │
+│                                                                      │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                  │
+│  │   Google    │  │   GitHub    │  │ Magic Code  │                  │
+│  │   OAuth     │  │   OAuth     │  │   (Email)   │                  │
+│  └─────────────┘  └─────────────┘  └─────────────┘                  │
+│                                                                      │
+│  ┌─────────────────────────────────────────────────────┐            │
+│  │              Session & Token Management              │            │
+│  │                                                      │            │
+│  │  - JWT creation & signing                           │            │
+│  │  - Token verification endpoint                      │            │
+│  │  - Session storage (D1)                             │            │
+│  └─────────────────────────────────────────────────────┘            │
+│                                                                      │
+│  2. User authenticates via chosen method                            │
+│  3. GroveAuth redirects back with auth code                         │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+          │                 │                 │
+          │    4. Site exchanges code for token
+          │    5. Site verifies token with GroveAuth
+          │                 │                 │
+          ▼                 ▼                 ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Sites receive verified user info and create their own sessions     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Component Responsibilities
+
+| Component | Responsibility |
+|-----------|----------------|
+| **GroveAuth** | OAuth flows, magic code, token generation, user verification |
+| **Client Sites** | Redirect to GroveAuth, exchange codes, validate tokens, manage local sessions |
+| **groveengine** | Helper functions for client sites to integrate with GroveAuth |
+
+---
+
+## Tech Stack
+
+### Core
+
+- **Runtime**: Cloudflare Workers
+- **Database**: Cloudflare D1 (SQLite)
+- **Framework**: Hono.js (lightweight, fast, Workers-native)
+- **Language**: TypeScript
+
+### Dependencies
+
+```json
+{
+  "dependencies": {
+    "hono": "^4.x",
+    "jose": "^5.x"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.x",
+    "typescript": "^5.x",
+    "wrangler": "^3.x"
+  }
+}
+```
+
+### Why Hono?
+
+- Built for Cloudflare Workers
+- Minimal overhead
+- TypeScript-first
+- Middleware support for auth checks
+- Simple routing
+
+---
+
+## Authentication Methods
+
+### 1. Google OAuth 2.0
+
+**Purpose**: Primary sign-in method for admins with Google accounts
+
+**Flow**: Authorization Code Grant with PKCE
+
+**Scopes Required**:
+- `openid`
+- `email`
+- `profile`
+
+**Data Retrieved**:
+- Email address (primary identifier)
+- Name (display purposes)
+- Profile picture URL (optional)
+
+### 2. GitHub OAuth
+
+**Purpose**: Alternative sign-in for developers
+
+**Flow**: Authorization Code Grant
+
+**Scopes Required**:
+- `user:email`
+- `read:user`
+
+**Data Retrieved**:
+- Email address (primary identifier)
+- Username
+- Avatar URL (optional)
+
+### 3. Magic Code (Email)
+
+**Purpose**: Fallback for users who prefer email-based auth
+
+**Flow**:
+1. User enters email
+2. 6-digit code sent via Resend API
+3. User enters code to verify
+4. Session created on successful verification
+
+**Constraints**:
+- Code expires in 10 minutes
+- Rate limit: 3 codes per email per minute
+- Lockout: 5 failed attempts = 15-minute lockout
+
+---
+
+## Database Schema
+
+### Tables
+
+```sql
+-- Registered client applications (sites that can use GroveAuth)
+CREATE TABLE clients (
+    id TEXT PRIMARY KEY,                    -- UUID
+    name TEXT NOT NULL,                     -- "AutumnsGrove", "Other Site"
+    client_id TEXT UNIQUE NOT NULL,         -- Public identifier
+    client_secret_hash TEXT NOT NULL,       -- Hashed secret for token exchange
+    redirect_uris TEXT NOT NULL,            -- JSON array of allowed redirect URIs
+    allowed_origins TEXT NOT NULL,          -- JSON array of allowed CORS origins
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Authorized admin users
+CREATE TABLE users (
+    id TEXT PRIMARY KEY,                    -- UUID
+    email TEXT UNIQUE NOT NULL,             -- Primary identifier
+    name TEXT,                              -- Display name
+    avatar_url TEXT,                        -- Profile picture
+    provider TEXT NOT NULL,                 -- 'google', 'github', 'magic_code'
+    provider_id TEXT,                       -- ID from OAuth provider
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    last_login TEXT
+);
+
+-- Admin email allowlist
+CREATE TABLE allowed_emails (
+    email TEXT PRIMARY KEY,
+    added_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    added_by TEXT                           -- Who added this email
+);
+
+-- Authorization codes (short-lived, exchanged for tokens)
+CREATE TABLE auth_codes (
+    code TEXT PRIMARY KEY,                  -- Random code
+    client_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    redirect_uri TEXT NOT NULL,
+    code_challenge TEXT,                    -- For PKCE
+    code_challenge_method TEXT,             -- 'S256'
+    expires_at TEXT NOT NULL,
+    used INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- Refresh tokens (long-lived)
+CREATE TABLE refresh_tokens (
+    id TEXT PRIMARY KEY,
+    token_hash TEXT UNIQUE NOT NULL,        -- Hashed token
+    user_id TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    revoked INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- Magic codes for email auth
+CREATE TABLE magic_codes (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL,
+    code TEXT NOT NULL,                     -- 6-digit code
+    expires_at TEXT NOT NULL,
+    used INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Rate limiting and failed attempts
+CREATE TABLE rate_limits (
+    key TEXT PRIMARY KEY,                   -- 'email:xxx' or 'ip:xxx'
+    count INTEGER DEFAULT 1,
+    window_start TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE failed_attempts (
+    email TEXT PRIMARY KEY,
+    attempts INTEGER DEFAULT 0,
+    last_attempt TEXT,
+    locked_until TEXT
+);
+
+-- Audit log
+CREATE TABLE audit_log (
+    id TEXT PRIMARY KEY,
+    event_type TEXT NOT NULL,               -- 'login', 'logout', 'failed_login', etc.
+    user_id TEXT,
+    client_id TEXT,
+    ip_address TEXT,
+    user_agent TEXT,
+    details TEXT,                           -- JSON additional details
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### Indexes
+
+```sql
+CREATE INDEX idx_auth_codes_expires ON auth_codes(expires_at);
+CREATE INDEX idx_refresh_tokens_user ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_expires ON refresh_tokens(expires_at);
+CREATE INDEX idx_magic_codes_email ON magic_codes(email);
+CREATE INDEX idx_magic_codes_expires ON magic_codes(expires_at);
+CREATE INDEX idx_audit_log_user ON audit_log(user_id);
+CREATE INDEX idx_audit_log_created ON audit_log(created_at);
+```
+
+---
+
+## API Specification
+
+### Base URL
+
+```
+https://auth.grove.place
+```
+
+### Endpoints Overview
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/login` | Login page with provider selection |
+| GET | `/oauth/google` | Initiate Google OAuth |
+| GET | `/oauth/google/callback` | Google OAuth callback |
+| GET | `/oauth/github` | Initiate GitHub OAuth |
+| GET | `/oauth/github/callback` | GitHub OAuth callback |
+| POST | `/magic/send` | Send magic code email |
+| POST | `/magic/verify` | Verify magic code |
+| POST | `/token` | Exchange auth code for tokens |
+| POST | `/token/refresh` | Refresh access token |
+| POST | `/token/revoke` | Revoke refresh token |
+| GET | `/verify` | Verify access token |
+| GET | `/userinfo` | Get current user info |
+| POST | `/logout` | Logout and revoke tokens |
+| GET | `/health` | Health check |
+
+---
+
+### Endpoint Details
+
+#### `GET /login`
+
+**Purpose**: Display login page with authentication options
+
+**Query Parameters**:
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `client_id` | Yes | Registered client identifier |
+| `redirect_uri` | Yes | Where to redirect after auth |
+| `state` | Yes | CSRF protection (client-generated) |
+| `code_challenge` | No | PKCE challenge (recommended) |
+| `code_challenge_method` | No | Must be `S256` if challenge provided |
+
+**Response**: HTML login page with Google, GitHub, and Magic Code options
+
+**Error Responses**:
+- `400` - Missing required parameters
+- `400` - Invalid client_id
+- `400` - redirect_uri not registered for client
+
+---
+
+#### `GET /oauth/google`
+
+**Purpose**: Initiate Google OAuth flow
+
+**Query Parameters**: Same as `/login`
+
+**Response**: `302` Redirect to Google OAuth consent screen
+
+---
+
+#### `GET /oauth/google/callback`
+
+**Purpose**: Handle Google OAuth callback
+
+**Query Parameters**:
+| Parameter | Description |
+|-----------|-------------|
+| `code` | Authorization code from Google |
+| `state` | State parameter for CSRF verification |
+
+**Success Response**: `302` Redirect to client's `redirect_uri` with:
+```
+{redirect_uri}?code={auth_code}&state={state}
+```
+
+**Error Response**: `302` Redirect with error:
+```
+{redirect_uri}?error=access_denied&error_description=...&state={state}
+```
+
+---
+
+#### `GET /oauth/github`
+
+**Purpose**: Initiate GitHub OAuth flow
+
+**Query Parameters**: Same as `/login`
+
+**Response**: `302` Redirect to GitHub OAuth consent screen
+
+---
+
+#### `GET /oauth/github/callback`
+
+**Purpose**: Handle GitHub OAuth callback
+
+**Query Parameters**:
+| Parameter | Description |
+|-----------|-------------|
+| `code` | Authorization code from GitHub |
+| `state` | State parameter for CSRF verification |
+
+**Response**: Same as Google callback
+
+---
+
+#### `POST /magic/send`
+
+**Purpose**: Send magic code to email
+
+**Request Body**:
+```json
+{
+  "email": "admin@example.com",
+  "client_id": "autumnsgrove",
+  "redirect_uri": "https://autumnsgrove.place/auth/callback"
+}
+```
+
+**Success Response** (`200`):
+```json
+{
+  "success": true,
+  "message": "If this email is registered, a code has been sent."
+}
+```
+
+**Note**: Always returns success to prevent email enumeration
+
+**Rate Limit Response** (`429`):
+```json
+{
+  "error": "rate_limit",
+  "message": "Too many requests. Please try again later.",
+  "retry_after": 60
+}
+```
+
+---
+
+#### `POST /magic/verify`
+
+**Purpose**: Verify magic code and get auth code
+
+**Request Body**:
+```json
+{
+  "email": "admin@example.com",
+  "code": "123456",
+  "client_id": "autumnsgrove",
+  "redirect_uri": "https://autumnsgrove.place/auth/callback",
+  "state": "random-state-string"
+}
+```
+
+**Success Response** (`200`):
+```json
+{
+  "success": true,
+  "redirect_uri": "https://autumnsgrove.place/auth/callback?code=xxx&state=xxx"
+}
+```
+
+**Error Response** (`401`):
+```json
+{
+  "error": "invalid_code",
+  "message": "Invalid or expired code"
+}
+```
+
+**Lockout Response** (`423`):
+```json
+{
+  "error": "account_locked",
+  "message": "Too many failed attempts. Try again in 15 minutes.",
+  "locked_until": "2025-01-15T12:00:00Z"
+}
+```
+
+---
+
+#### `POST /token`
+
+**Purpose**: Exchange authorization code for tokens
+
+**Request Headers**:
+```
+Content-Type: application/x-www-form-urlencoded
+```
+
+**Request Body**:
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `grant_type` | Yes | Must be `authorization_code` |
+| `code` | Yes | Authorization code from callback |
+| `redirect_uri` | Yes | Must match original request |
+| `client_id` | Yes | Client identifier |
+| `client_secret` | Yes | Client secret |
+| `code_verifier` | No | PKCE verifier (if challenge was used) |
+
+**Success Response** (`200`):
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIs...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "dGhpcyBpcyBhIHJlZnJlc2g...",
+  "scope": "openid email profile"
+}
+```
+
+**Error Response** (`400`):
+```json
+{
+  "error": "invalid_grant",
+  "error_description": "Authorization code is invalid or expired"
+}
+```
+
+---
+
+#### `POST /token/refresh`
+
+**Purpose**: Get new access token using refresh token
+
+**Request Body**:
+```
+grant_type=refresh_token
+refresh_token=dGhpcyBpcyBhIHJlZnJlc2g...
+client_id=autumnsgrove
+client_secret=xxx
+```
+
+**Success Response** (`200`):
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIs...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "bmV3IHJlZnJlc2ggdG9rZW4..."
+}
+```
+
+**Note**: Refresh token rotation - new refresh token issued each time
+
+---
+
+#### `POST /token/revoke`
+
+**Purpose**: Revoke a refresh token
+
+**Request Body**:
+```
+token=dGhpcyBpcyBhIHJlZnJlc2g...
+token_type_hint=refresh_token
+client_id=autumnsgrove
+client_secret=xxx
+```
+
+**Response** (`200`):
+```json
+{
+  "success": true
+}
+```
+
+---
+
+#### `GET /verify`
+
+**Purpose**: Verify an access token (for client sites to validate)
+
+**Request Headers**:
+```
+Authorization: Bearer {access_token}
+```
+
+**Success Response** (`200`):
+```json
+{
+  "active": true,
+  "sub": "user-uuid",
+  "email": "admin@example.com",
+  "name": "Admin User",
+  "exp": 1705312800,
+  "iat": 1705309200,
+  "client_id": "autumnsgrove"
+}
+```
+
+**Invalid Token Response** (`200`):
+```json
+{
+  "active": false
+}
+```
+
+**Note**: Returns 200 even for invalid tokens (OAuth 2.0 introspection spec)
+
+---
+
+#### `GET /userinfo`
+
+**Purpose**: Get current user information
+
+**Request Headers**:
+```
+Authorization: Bearer {access_token}
+```
+
+**Success Response** (`200`):
+```json
+{
+  "sub": "user-uuid",
+  "email": "admin@example.com",
+  "name": "Admin User",
+  "picture": "https://...",
+  "provider": "google"
+}
+```
+
+**Error Response** (`401`):
+```json
+{
+  "error": "invalid_token",
+  "error_description": "Token is invalid or expired"
+}
+```
+
+---
+
+#### `POST /logout`
+
+**Purpose**: Logout user and revoke all tokens
+
+**Request Headers**:
+```
+Authorization: Bearer {access_token}
+```
+
+**Request Body** (optional):
+```json
+{
+  "redirect_uri": "https://autumnsgrove.place"
+}
+```
+
+**Response** (`200`):
+```json
+{
+  "success": true,
+  "redirect_uri": "https://autumnsgrove.place"
+}
+```
+
+---
+
+#### `GET /health`
+
+**Purpose**: Health check endpoint
+
+**Response** (`200`):
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-01-15T10:00:00Z"
+}
+```
+
+---
+
+## OAuth Flows
+
+### Google OAuth Flow (with PKCE)
+
+```
+┌──────────┐                              ┌───────────┐                              ┌──────────┐
+│  Client  │                              │ GroveAuth │                              │  Google  │
+│  Site    │                              │           │                              │          │
+└────┬─────┘                              └─────┬─────┘                              └────┬─────┘
+     │                                          │                                         │
+     │ 1. Generate state + code_verifier        │                                         │
+     │    code_challenge = SHA256(verifier)     │                                         │
+     │                                          │                                         │
+     │ 2. Redirect to /login?                   │                                         │
+     │    client_id=xxx&                        │                                         │
+     │    redirect_uri=xxx&                     │                                         │
+     │    state=xxx&                            │                                         │
+     │    code_challenge=xxx                    │                                         │
+     │─────────────────────────────────────────▶│                                         │
+     │                                          │                                         │
+     │                                          │ 3. Redirect to Google OAuth             │
+     │                                          │─────────────────────────────────────────▶│
+     │                                          │                                         │
+     │                                          │                    4. User logs in      │
+     │                                          │                       consents          │
+     │                                          │                                         │
+     │                                          │ 5. Callback with code                   │
+     │                                          │◀─────────────────────────────────────────│
+     │                                          │                                         │
+     │                                          │ 6. Exchange code for Google tokens      │
+     │                                          │─────────────────────────────────────────▶│
+     │                                          │                                         │
+     │                                          │ 7. Return tokens + user info            │
+     │                                          │◀─────────────────────────────────────────│
+     │                                          │                                         │
+     │                                          │ 8. Verify email is in allowlist         │
+     │                                          │    Create/update user                   │
+     │                                          │    Generate auth code                   │
+     │                                          │                                         │
+     │ 9. Redirect to client redirect_uri       │                                         │
+     │    with code + state                     │                                         │
+     │◀─────────────────────────────────────────│                                         │
+     │                                          │                                         │
+     │ 10. POST /token                          │                                         │
+     │     code + client_secret + verifier      │                                         │
+     │─────────────────────────────────────────▶│                                         │
+     │                                          │                                         │
+     │ 11. Return access_token + refresh_token  │                                         │
+     │◀─────────────────────────────────────────│                                         │
+     │                                          │                                         │
+     │ 12. Create local session                 │                                         │
+     │     Store tokens securely                │                                         │
+     │                                          │                                         │
+```
+
+### Magic Code Flow
+
+```
+┌──────────┐                              ┌───────────┐                              ┌──────────┐
+│  Client  │                              │ GroveAuth │                              │  Resend  │
+│  Site    │                              │           │                              │  (Email) │
+└────┬─────┘                              └─────┬─────┘                              └────┬─────┘
+     │                                          │                                         │
+     │ 1. Redirect to /login                    │                                         │
+     │─────────────────────────────────────────▶│                                         │
+     │                                          │                                         │
+     │                    2. User selects       │                                         │
+     │                       "Sign in with      │                                         │
+     │                        Email"            │                                         │
+     │                       Enters email       │                                         │
+     │                                          │                                         │
+     │                                          │ 3. POST /magic/send                     │
+     │                                          │    Check allowlist                      │
+     │                                          │    Generate 6-digit code                │
+     │                                          │    Store in DB                          │
+     │                                          │                                         │
+     │                                          │ 4. Send email with code                 │
+     │                                          │─────────────────────────────────────────▶│
+     │                                          │                                         │
+     │                    5. User receives      │                                         │
+     │                       email, enters      │                                         │
+     │                       code               │                                         │
+     │                                          │                                         │
+     │                                          │ 6. POST /magic/verify                   │
+     │                                          │    Validate code                        │
+     │                                          │    Check not expired                    │
+     │                                          │    Check not used                       │
+     │                                          │    Mark as used                         │
+     │                                          │    Create auth code                     │
+     │                                          │                                         │
+     │ 7. Redirect with auth code               │                                         │
+     │◀─────────────────────────────────────────│                                         │
+     │                                          │                                         │
+     │ 8. Exchange code for tokens              │                                         │
+     │   (same as OAuth flow step 10-12)        │                                         │
+     │                                          │                                         │
+```
+
+---
+
+## Client Integration
+
+### How Sites Authenticate with GroveAuth
+
+#### Step 1: Register Your Site
+
+Before a site can use GroveAuth, it must be registered in the `clients` table:
+
+```sql
+INSERT INTO clients (id, name, client_id, client_secret_hash, redirect_uris, allowed_origins)
+VALUES (
+  'uuid-here',
+  'AutumnsGrove',
+  'autumnsgrove',
+  'hashed-secret-here',
+  '["https://autumnsgrove.place/auth/callback"]',
+  '["https://autumnsgrove.place"]'
+);
+```
+
+#### Step 2: Implement Login Redirect
+
+```typescript
+// In your site's login handler
+function redirectToLogin() {
+  const state = crypto.randomUUID();
+  const codeVerifier = generateCodeVerifier(); // 43-128 chars
+  const codeChallenge = await sha256(codeVerifier);
+
+  // Store state and verifier in session/cookie
+  setCookie('auth_state', state);
+  setCookie('code_verifier', codeVerifier);
+
+  const params = new URLSearchParams({
+    client_id: 'autumnsgrove',
+    redirect_uri: 'https://autumnsgrove.place/auth/callback',
+    state: state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256'
+  });
+
+  redirect(`https://auth.grove.place/login?${params}`);
+}
+```
+
+#### Step 3: Handle Callback
+
+```typescript
+// In your site's /auth/callback handler
+async function handleCallback(request) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const error = url.searchParams.get('error');
+
+  // Check for errors
+  if (error) {
+    return redirect('/login?error=' + error);
+  }
+
+  // Verify state matches
+  const savedState = getCookie('auth_state');
+  if (state !== savedState) {
+    return redirect('/login?error=invalid_state');
+  }
+
+  // Get code verifier
+  const codeVerifier = getCookie('code_verifier');
+
+  // Exchange code for tokens
+  const tokenResponse = await fetch('https://auth.grove.place/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: code,
+      redirect_uri: 'https://autumnsgrove.place/auth/callback',
+      client_id: 'autumnsgrove',
+      client_secret: env.GROVEAUTH_CLIENT_SECRET,
+      code_verifier: codeVerifier
+    })
+  });
+
+  const tokens = await tokenResponse.json();
+
+  if (!tokenResponse.ok) {
+    return redirect('/login?error=' + tokens.error);
+  }
+
+  // Verify token and get user info
+  const userResponse = await fetch('https://auth.grove.place/userinfo', {
+    headers: {
+      'Authorization': `Bearer ${tokens.access_token}`
+    }
+  });
+
+  const user = await userResponse.json();
+
+  // Create local session
+  const sessionToken = await createLocalSession(user, tokens);
+
+  // Set session cookie and redirect to admin
+  return redirect('/admin', {
+    headers: {
+      'Set-Cookie': `session=${sessionToken}; HttpOnly; Secure; SameSite=Lax; Path=/`
+    }
+  });
+}
+```
+
+#### Step 4: Verify Tokens on Protected Routes
+
+```typescript
+// In your site's hooks or middleware
+async function verifyAuth(request) {
+  const sessionToken = getCookie('session');
+
+  if (!sessionToken) {
+    return null;
+  }
+
+  // Verify with GroveAuth
+  const response = await fetch('https://auth.grove.place/verify', {
+    headers: {
+      'Authorization': `Bearer ${sessionToken}`
+    }
+  });
+
+  const result = await response.json();
+
+  if (!result.active) {
+    return null;
+  }
+
+  return result; // { sub, email, name, ... }
+}
+```
+
+### groveengine Integration Helpers
+
+The following helpers should be added to `@autumnsgrove/groveengine` for easy integration:
+
+```typescript
+// @autumnsgrove/groveengine/auth
+
+export interface GroveAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  authBaseUrl?: string; // defaults to 'https://auth.grove.place'
+}
+
+export function createAuthClient(config: GroveAuthConfig): GroveAuthClient;
+
+export interface GroveAuthClient {
+  // Generate login URL with state and PKCE
+  getLoginUrl(): { url: string; state: string; codeVerifier: string };
+
+  // Exchange auth code for tokens
+  exchangeCode(code: string, codeVerifier: string): Promise<TokenResponse>;
+
+  // Verify access token
+  verifyToken(accessToken: string): Promise<TokenInfo | null>;
+
+  // Refresh access token
+  refreshToken(refreshToken: string): Promise<TokenResponse>;
+
+  // Revoke refresh token
+  revokeToken(refreshToken: string): Promise<void>;
+
+  // Get user info
+  getUserInfo(accessToken: string): Promise<UserInfo>;
+}
+```
+
+---
+
+## Security Requirements
+
+### Token Security
+
+1. **Access Tokens**
+   - JWT format, signed with RS256
+   - Short-lived: 1 hour expiration
+   - Contains: sub, email, name, client_id, exp, iat, iss
+   - Issuer: `https://auth.grove.place`
+
+2. **Refresh Tokens**
+   - Opaque tokens (random bytes, base64url encoded)
+   - Long-lived: 30 days expiration
+   - Stored hashed in database
+   - Rotation on use (new token issued, old revoked)
+
+3. **Authorization Codes**
+   - Short-lived: 5 minutes
+   - Single use (marked as used immediately)
+   - Bound to client_id, redirect_uri, and code_challenge
+
+### PKCE (Proof Key for Code Exchange)
+
+- **Required** for all OAuth flows
+- Method: S256 (SHA-256)
+- Prevents authorization code interception attacks
+
+### CSRF Protection
+
+- **State parameter** required on all auth initiations
+- Client generates random state, stores in cookie
+- GroveAuth returns state unchanged
+- Client verifies state matches before exchanging code
+
+### Rate Limiting
+
+| Endpoint | Limit |
+|----------|-------|
+| `/magic/send` | 3 per email per minute, 10 per IP per minute |
+| `/magic/verify` | 5 attempts before 15-min lockout |
+| `/token` | 20 per client per minute |
+| `/verify` | 100 per client per minute |
+
+### Security Headers
+
+All responses must include:
+
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'
+Referrer-Policy: strict-origin-when-cross-origin
+```
+
+### Audit Logging
+
+Log all authentication events:
+- Successful logins (provider, user, client, IP)
+- Failed login attempts (email, IP, reason)
+- Token exchanges
+- Token revocations
+- Logouts
+
+---
+
+## Environment Configuration
+
+### Required Secrets
+
+```toml
+# wrangler.toml
+[vars]
+AUTH_BASE_URL = "https://auth.grove.place"
+
+# Set via wrangler secret put
+# JWT_PRIVATE_KEY - RSA private key for signing JWTs (PEM format)
+# JWT_PUBLIC_KEY - RSA public key for verifying JWTs (PEM format)
+# GOOGLE_CLIENT_ID - Google OAuth client ID
+# GOOGLE_CLIENT_SECRET - Google OAuth client secret
+# GITHUB_CLIENT_ID - GitHub OAuth client ID
+# GITHUB_CLIENT_SECRET - GitHub OAuth client secret
+# RESEND_API_KEY - Resend API key for sending emails
+```
+
+### D1 Database Binding
+
+```toml
+[[d1_databases]]
+binding = "DB"
+database_name = "groveauth"
+database_id = "your-database-id"
+```
+
+### Environment Variables by Environment
+
+| Variable | Development | Production |
+|----------|-------------|------------|
+| `AUTH_BASE_URL` | `http://localhost:8787` | `https://auth.grove.place` |
+| `ALLOWED_ORIGINS` | `http://localhost:5173` | `https://autumnsgrove.place,...` |
+
+---
+
+## Development Guidelines
+
+### Project Structure
+
+```
+groveauth/
+├── src/
+│   ├── index.ts              # Main entry, Hono app setup
+│   ├── routes/
+│   │   ├── login.ts          # Login page handler
+│   │   ├── oauth/
+│   │   │   ├── google.ts     # Google OAuth handlers
+│   │   │   └── github.ts     # GitHub OAuth handlers
+│   │   ├── magic.ts          # Magic code handlers
+│   │   ├── token.ts          # Token exchange handlers
+│   │   └── verify.ts         # Token verification
+│   ├── middleware/
+│   │   ├── cors.ts           # CORS handling
+│   │   ├── rateLimit.ts      # Rate limiting
+│   │   └── security.ts       # Security headers
+│   ├── services/
+│   │   ├── jwt.ts            # JWT creation/verification
+│   │   ├── oauth.ts          # OAuth provider helpers
+│   │   ├── email.ts          # Email sending (Resend)
+│   │   └── user.ts           # User management
+│   ├── db/
+│   │   ├── schema.sql        # Database schema
+│   │   ├── queries.ts        # Database queries
+│   │   └── migrations/       # Schema migrations
+│   ├── utils/
+│   │   ├── crypto.ts         # Hashing, random generation
+│   │   ├── validation.ts     # Input validation
+│   │   └── constants.ts      # Magic numbers, config
+│   └── types.ts              # TypeScript types
+├── templates/
+│   ├── login.html            # Login page template
+│   └── email-code.html       # Magic code email template
+├── wrangler.toml
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+### Testing Requirements
+
+1. **Unit Tests**
+   - JWT creation/verification
+   - PKCE challenge verification
+   - Rate limiting logic
+   - Input validation
+
+2. **Integration Tests**
+   - Full OAuth flows (mocked providers)
+   - Magic code flow
+   - Token exchange
+   - Token refresh/revocation
+
+3. **Security Tests**
+   - CSRF protection
+   - Rate limiting
+   - SQL injection prevention
+   - Invalid state handling
+
+### Coding Standards
+
+- TypeScript strict mode
+- All inputs validated with Zod
+- Constant-time comparison for secrets
+- No secrets in logs
+- Meaningful error messages (but not too revealing)
+
+---
+
+## Deployment Checklist
+
+### Initial Setup
+
+- [ ] Create Cloudflare account/project
+- [ ] Create D1 database
+- [ ] Run schema migrations
+- [ ] Generate RSA keypair for JWT signing
+- [ ] Set up Google OAuth credentials (console.cloud.google.com)
+- [ ] Set up GitHub OAuth app (github.com/settings/developers)
+- [ ] Set up Resend account and verify domain
+- [ ] Configure DNS for auth.grove.place
+- [ ] Set all secrets via `wrangler secret put`
+
+### Pre-Launch
+
+- [ ] Add initial allowed admin emails
+- [ ] Register client applications (AutumnsGrove, etc.)
+- [ ] Test all auth flows end-to-end
+- [ ] Verify rate limiting works
+- [ ] Check security headers
+- [ ] Review audit logging
+
+### Post-Launch
+
+- [ ] Monitor error rates
+- [ ] Set up alerting for failed login spikes
+- [ ] Regular security audits
+- [ ] Rotate secrets periodically
+
+---
+
+## Future Enhancements (Out of Scope for v1)
+
+- WebAuthn/Passkey support
+- Session management UI (view/revoke sessions)
+- Admin dashboard for user management
+- Multi-factor authentication
+- IP-based access restrictions
+- Webhook notifications for auth events
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| **Access Token** | Short-lived JWT used to access protected resources |
+| **Refresh Token** | Long-lived opaque token used to get new access tokens |
+| **Authorization Code** | Short-lived code exchanged for tokens |
+| **PKCE** | Proof Key for Code Exchange - prevents code interception |
+| **Client** | A registered application that uses GroveAuth |
+| **Provider** | Authentication method (Google, GitHub, Magic Code) |
+
+---
+
+*Spec Version: 1.0*
+*Created: 2025-01-15*
+*Author: Claude (with guidance from Autumn)*

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -27,9 +27,11 @@ Grove specifications define the architecture, interfaces, and implementation det
 | Specification | Purpose | Status | Integration |
 |---------------|---------|--------|-------------|
 | **[Lattice](lattice-spec.md)** | Core framework & multi-tenant engine | **Active** | All components |
+| **[Heartwood](heartwood-spec.md)** | Centralized authentication service | **Active** | All services |
 | **[Engine](engine-spec.md)** | Blog rendering & content management | Active | Lattice, TenantDO |
 | **[Website](website-spec.md)** | Public marketing site & landing pages | Active | Lattice, Engine |
 | **[Meadow](meadow-spec.md)** | Community feed & social features | Planned | Lattice, PostDO |
+| **[Seasons](seasons-spec.md)** | Semantic versioning system | Active | npm, Renovate |
 
 ### 📊 Monitoring & Analytics
 
@@ -40,23 +42,44 @@ Grove specifications define the architecture, interfaces, and implementation det
 | **[Vineyard](vineyard-spec.md)** | Vista LoadTest package | **New** | Sentinel, Vista |
 | **[Vista LoadTest](vista-loadtest-spec.md)** | Load testing integration spec | **New** | Sentinel, Vista |
 
-### 🔧 Tools & Services
+### 🔧 Platform Services
 
 | Specification | Purpose | Status | Integration |
 |---------------|---------|--------|-------------|
-| **[Amber](amber-spec.md)** | Image processing & optimization | Active | R2, Engine |
-| **[Arbor](arbor-spec.md)** | Theme system & customization | Active | Engine, TenantDO |
-| **[Bloom](bloom-spec.md)** | Email newsletter system | Planned | Resend, TenantDO |
-| **[Clearing](clearing-spec.md)** | Data export & migration tools | Active | D1, R2 |
+| **[Arbor](arbor-spec.md)** | Admin panel for blog management | Active | Engine, TenantDO |
+| **[Plant](plant-spec.md)** | Tenant onboarding system | Active | Heartwood, Stripe |
+| **[Amber](amber-spec.md)** | Storage management system | Active | R2, Engine |
+| **[Foliage](foliage-project-spec.md)** | Theming & customization | Active | Engine, TenantDO |
+| **[Clearing](clearing-spec.md)** | Public status page | Planned | All services |
+| **[Waystone](waystone-spec.md)** | Built-in help center | Planned | All properties |
+| **[Centennial](centennial-spec.md)** | 100-year domain preservation | Active | Membership tiers |
 
-### 🛡️ Security & Operations
+### 💬 Content & Community
 
 | Specification | Purpose | Status | Integration |
 |---------------|---------|--------|-------------|
-| **[Mycelium](mycelium-spec.md)** | Secret management & rotation | Active | All services |
-| **[Patina](patina-spec.md)** | Backup & disaster recovery | Active | D1, R2 |
-| **[Renovate](renovate-spec.md)** | Dependency updates & security | Active | GitHub, pnpm |
-| **[Thorn](thorn-spec.md)** | Security scanning & compliance | Planned | CI/CD, D1 |
+| **[Wisp](wisp-spec.md)** | Ethical writing assistant | Planned | Editor integration |
+| **[Reeds](reeds-spec.md)** | Comments system | Planned | PostDO, TenantDO |
+| **[Thorn](thorn-spec.md)** | Content moderation | Planned | AI, Posts |
+| **[Trails](trails-spec.md)** | Personal roadmaps | Active | Blog routes |
+
+### 🛠️ Standalone Tools
+
+| Specification | Purpose | Status | Integration |
+|---------------|---------|--------|-------------|
+| **[Ivy](ivy-mail-spec.md)** | Privacy-first email | Building | R2, Resend |
+| **[Bloom](bloom-spec.md)** | Remote AI coding infrastructure | Building | Firefly pattern |
+| **[Forage](forage-spec.md)** | AI domain discovery | Active | OpenRouter |
+
+### 🛡️ Operations & Infrastructure
+
+| Specification | Purpose | Status | Integration |
+|---------------|---------|--------|-------------|
+| **[Vista](vista-spec.md)** | Infrastructure observability | Planned | All services |
+| **[Patina](patina-spec.md)** | Automated backups | Active | D1, R2 |
+| **[Mycelium](mycelium-spec.md)** | MCP server for AI agents | Building | All Grove services |
+| **[Shade](shade-spec.md)** | AI content protection | Active | All blogs |
+| **[Renovate](renovate-spec.md)** | Dependency updates | Active | GitHub, pnpm |
 
 ---
 

--- a/docs/specs/nook-spec.md
+++ b/docs/specs/nook-spec.md
@@ -1,0 +1,133 @@
+---
+aliases: []
+date created: Saturday, January 4th 2026
+date modified: Saturday, January 4th 2026
+source: https://github.com/AutumnsGrove/Nook/blob/main/nook-spec.md
+tags:
+  - video-sharing
+  - privacy
+  - ai-processing
+  - friends
+type: tech-spec
+---
+
+# Nook — Private Video Sharing
+
+> *A cozy corner of the grove. Videos for close friends.*
+
+Where you share moments with the people who matter. Not a YouTube channel, not a public archive. Just a tucked-away space where your closest friends can watch the videos you've been meaning to share.
+
+**Public Name:** Nook
+**Internal Name:** GroveNook
+**Domain:** `nook.grove.place`
+**Repository:** [AutumnsGrove/Nook](https://github.com/AutumnsGrove/Nook)
+
+A nook is a tucked-away corner, a quiet space set apart from the main room. Somewhere intimate and private.
+
+---
+
+## Overview
+
+Nook is a privacy-focused video sharing platform designed for small, trusted friend groups. It addresses a specific problem: users with extensive personal video libraries who want to share with close friends without uploading to public platforms.
+
+### Goals
+
+- **Privacy-first**: All processing happens locally before content becomes accessible
+- **Intimate sharing**: Small, trusted friend groups only
+- **AI-powered curation**: Automatic categorization and face detection
+- **Zero public exposure**: Not a YouTube channel, not a public archive
+
+### Non-Goals
+
+- Public video hosting
+- Social media features
+- Viral distribution
+
+---
+
+## Technical Architecture
+
+### Stack
+
+- **Frontend**: SvelteKit
+- **Backend**: Cloudflare Workers
+- **Storage**: Cloudflare R2
+- **Database**: Cloudflare D1
+- **Processing**: Local Mac Mini pipeline (Python)
+
+### Local Processing Pipeline
+
+Processing relies on a local Mac Mini using Python tools:
+- **Qwen3-VL**: AI categorization
+- **MediaPipe**: Face detection
+- Compression and progressive MP4 generation
+
+This decentralized approach keeps sensitive video data on local machines during processing.
+
+---
+
+## Privacy Architecture
+
+The system enforces multiple security layers:
+
+1. **Heartwood Authentication**: Centralized auth through Grove's auth system
+2. **Allowlist Gate**: Restricts access to approved users only
+3. **Non-guessable Storage**: R2 identifiers that can't be enumerated
+4. **Authenticated Streaming**: All video routes require authentication
+5. **Local Processing**: All AI processing on local hardware, not cloud
+
+### Face Privacy
+
+- Unknown individuals in videos receive automatic blurring
+- Consent management lets friends control their appearance in shared content
+- Personal moments stay private
+
+---
+
+## Development Roadmap
+
+### Phase 0: Foundation
+- Basic authentication
+- Manual video uploads
+- Simple streaming
+
+### Phase 1: Compression Pipeline
+- Progressive MP4 support
+- Efficient compression
+- Quality optimization
+
+### Phase 2: AI Categorization
+- Automatic content categorization
+- Public/private/review buckets
+- Smart organization
+
+### Phase 3: Face Privacy
+- Face detection and tracking
+- Automatic blurring of unknown faces
+- Consent-level management per person
+
+---
+
+## Cost Structure
+
+Projected monthly costs remain minimal:
+- **R2 Storage**: $0.90-$2.25 for 60-150 GB compressed video
+- **Local Compute**: Negligible (Mac Mini power)
+- **Workers/D1**: Minimal at friend-group scale
+
+**Total**: ~$1-3/month
+
+---
+
+## Integration
+
+- **Heartwood**: Authentication
+- **Amber**: Storage management integration (optional)
+- **Mycelium**: Future MCP integration for AI agent access
+
+---
+
+*See the full specification at: [AutumnsGrove/Nook](https://github.com/AutumnsGrove/Nook/blob/main/nook-spec.md)*
+
+*Spec Version: 1.0*
+*Last Updated: January 2026*


### PR DESCRIPTION
- Reorganize by category (Core, Platform, Content, Standalone, Operations, Patterns)
- Add 7 missing services: Arbor, Centennial, Clearing, Reeds, Seasons, Thorn, Waystone
- Add Nook (private video sharing) from workshop page
- Add Internal Patterns section: Prism, Loom, Firefly, Threshold, Sentinel, Songbird
- Import Heartwood spec from GroveAuth repo
- Import Nook spec from Nook repo
- Update specs index with accurate descriptions
- Update ecosystem and internal names reference tables