### PR TITLE
fix: add terrarium-spec to knowledge base and update icons

### DIFF
--- a/landing/src/lib/data/knowledge-base.ts
+++ b/landing/src/lib/data/knowledge-base.ts
@@ -98,6 +98,16 @@ export const specs: Doc[] = [
     readingTime: 8,
   },
   {
+    slug: "terrarium-spec",
+    title: "Terrarium — Creative Canvas",
+    description: "Visual scene composition tool for blog decorations",
+    excerpt:
+      "A sealed world under glass—a miniature ecosystem you design, arrange, and watch grow. Drag nature components onto an open space, compose scenes from trees and creatures and flowers, then bring them home to your blog as decorations.",
+    category: "specs",
+    lastUpdated: "2026-01-05",
+    readingTime: 15,
+  },
+  {
     slug: "clearing-spec",
     title: "Clearing — Status Page",
     description:

--- a/landing/src/routes/roadmap/+page.svelte
+++ b/landing/src/routes/roadmap/+page.svelte
@@ -37,6 +37,7 @@
 		Database,
 		// First Buds icons
 		TreeDeciduous,
+		SwatchBook,
 		// Full Bloom icons
 		Clock,
 		MessageCircle,
@@ -142,7 +143,7 @@
 				{ name: 'Amber', description: 'Storage dashboard — see and manage your files', done: false, icon: 'amber' },
 				{ name: 'Trails', description: 'Personal roadmaps — share your journey', done: false, icon: 'trails' },
 				{ name: 'Sapling Tier', description: 'More space, more themes', done: false, icon: 'tree' },
-				{ name: 'Foliage', description: 'Theme library — more color for your corner', done: false, icon: 'palette' }
+				{ name: 'Foliage', description: 'Theme library — more color for your corner', done: false, icon: 'swatchbook' }
 			]
 		},
 		'full-bloom': {
@@ -625,7 +626,7 @@
 							{feature.icon === 'amber' ? 'border-l-4 border-amber-500' : ''}
 							{feature.icon === 'trails' ? 'border-l-4 border-teal-500' : ''}
 							{feature.icon === 'tree' ? 'border-l-4 border-emerald-500' : ''}
-							{feature.icon === 'palette' ? 'border-l-4 border-violet-500' : ''}"
+							{feature.icon === 'swatchbook' ? 'border-l-4 border-violet-500' : ''}"
 						>
 							{#if feature.icon === 'ivy'}
 								<Mail class="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
@@ -635,8 +636,8 @@
 								<Compass class="w-5 h-5 text-teal-500 mt-0.5 flex-shrink-0" />
 							{:else if feature.icon === 'tree'}
 								<TreeDeciduous class="w-5 h-5 text-emerald-500 mt-0.5 flex-shrink-0" />
-							{:else if feature.icon === 'palette'}
-								<Palette class="w-5 h-5 text-violet-500 mt-0.5 flex-shrink-0" />
+							{:else if feature.icon === 'swatchbook'}
+								<SwatchBook class="w-5 h-5 text-violet-500 mt-0.5 flex-shrink-0" />
 							{:else}
 								<Circle class="w-5 h-5 text-slate-400 dark:text-slate-500 mt-0.5 flex-shrink-0" />
 							{/if}

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -4,7 +4,7 @@
 	import SEO from '$lib/components/SEO.svelte';
 
 	// Lucide Icons
-	import { Search, Pickaxe, Github, Mail, HardDrive, Palette, ShieldCheck, Cloud, Archive, Upload, Video, Network, Wind, Eye, Bird, LayoutDashboard, Activity, UserPlus, MessageCircle, Shield, BarChart3, Grape, Boxes, Users, Map, HelpCircle, FileText, Triangle, Gauge, Radar, Sparkles, Terminal, Database, Compass, Layers } from 'lucide-svelte';
+	import { Search, Pickaxe, Github, Mail, HardDrive, Palette, ShieldCheck, Cloud, Archive, Upload, Video, Network, Wind, Eye, Bird, LayoutDashboard, Activity, UserPlus, MessageCircle, Shield, BarChart3, Grape, Boxes, Users, Map, HelpCircle, FileText, Triangle, Gauge, Radar, Sparkles, Terminal, Database, Compass, Layers, PencilRuler, SwatchBook } from 'lucide-svelte';
 
 	// Import nature assets from engine package
 	import { Logo, Lantern } from '@autumnsgrove/groveengine/ui/nature';
@@ -48,6 +48,8 @@
 		database: Database,
 		compass: Compass,
 		layers: Layers,
+		pencilruler: PencilRuler,
+		swatchbook: SwatchBook,
 	};
 
 	function getCardClass(categoryName: string) {
@@ -144,7 +146,7 @@
 					tagline: 'Theming Engine',
 					description: 'Visual customization for your blog—from accent colors to full theme control. Pick a curated theme or build your own. Make it warm, make it bold, make it yours. Your foliage is how the world sees your corner of the grove.',
 					status: 'complete',
-					icon: 'palette',
+					icon: 'swatchbook',
 					domain: 'foliage.grove.place',
 					integration: 'Theme customization for all Grove blogs',
 					github: 'https://github.com/AutumnsGrove/Foliage',
@@ -155,7 +157,7 @@
 					tagline: 'Creative Canvas',
 					description: 'A sealed world under glass—a miniature ecosystem you design, arrange, and watch grow. Drag nature components onto an open space, compose scenes from trees and creatures and flowers, then bring them home to your blog as decorations. Your terrarium becomes your foliage.',
 					status: 'planned',
-					icon: 'layers',
+					icon: 'pencilruler',
 					integration: 'Creative tool for building blog decorations',
 					spec: '/knowledge/specs/terrarium-spec'
 				},


### PR DESCRIPTION
- Add terrarium-spec entry to knowledge base with proper metadata
- Update Terrarium icon from layers to pencil-ruler
- Update Foliage icon from palette to swatch-book
- Import PencilRuler and SwatchBook icons from lucide-svelte
- Update icon mappings in both workshop and roadmap pages