### PR TITLE
fix: make subdomain links clickable on roadmap pages

### DIFF
--- a/landing/src/routes/roadmap/beyond/+page.svelte
+++ b/landing/src/routes/roadmap/beyond/+page.svelte
@@ -148,7 +148,12 @@
 						<div class="pt-4 border-t border-slate-700 space-y-2">
 							<div class="flex items-center gap-2 text-sm">
 								<span class="text-slate-500">Domain:</span>
-								<code class="px-2 py-0.5 rounded bg-slate-700 text-slate-300">{tool.domain}</code>
+								<a
+									href="https://{tool.domain}"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="px-2 py-0.5 rounded bg-slate-700 text-slate-300 hover:text-white hover:bg-slate-600 transition-colors font-mono text-sm"
+								>{tool.domain}</a>
 							</div>
 							<div class="flex items-center gap-2 text-sm">
 								<span class="text-slate-500">Stack:</span>

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -518,7 +518,16 @@
 									{#if tool.domain}
 										<div class="flex items-center gap-2 text-sm">
 											<span class="text-foreground-faint">Domain:</span>
-											<code class="px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-700 text-foreground-muted">{tool.domain}</code>
+											{#if tool.domain.includes('{you}')}
+												<code class="px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-700 text-foreground-muted">{tool.domain}</code>
+											{:else}
+												<a
+													href="https://{tool.domain}"
+													target="_blank"
+													rel="noopener noreferrer"
+													class="px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-700 text-foreground-muted hover:text-accent hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors font-mono text-sm"
+												>{tool.domain}</a>
+											{/if}
 										</div>
 									{/if}
 									<div class="text-sm text-foreground-faint">


### PR DESCRIPTION
Convert static domain text to interactive links on the workshop
and beyond pages. Users can now click subdomain references like
meadow.grove.place to visit them directly.

- Workshop page: domains now link to https://{domain}
- Beyond page: same treatment for standalone tools
- Special handling for template domains like {you}.grove.place