### PR TITLE
fix: resolve build errors and reduce Svelte warnings

### DIFF
--- a/landing/src/routes/roadmap/+page.svelte
+++ b/landing/src/routes/roadmap/+page.svelte
@@ -471,11 +471,11 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases.thaw.features as feature}
+						{@const IconComponent = roadmapFeatureIcons[feature.icon]}
 						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-slate-900/25 backdrop-blur-sm border-l-4 border-teal-400 shadow-sm
 							{feature.internal ? 'opacity-75' : ''}">
 							<!-- Use icon lookup map with seasonal color (Thaw = teal) -->
-							<svelte:component
-								this={roadmapFeatureIcons[feature.icon]}
+							<IconComponent
 								class="w-5 h-5 text-teal-500 mt-0.5 flex-shrink-0"
 							/>
 							<div class="flex-1">
@@ -567,6 +567,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['first-buds'].features as feature}
+						{@const IconComponent = roadmapFeatureIcons[feature.icon]}
 						{@const colorMap = {
 							ivy: 'text-green-500',
 							amber: 'text-amber-500',
@@ -585,8 +586,7 @@
 							{borderMap[feature.icon] || ''}"
 						>
 							<!-- Use icon lookup map with feature-specific color -->
-							<svelte:component
-								this={roadmapFeatureIcons[feature.icon]}
+							<IconComponent
 								class="w-5 h-5 {colorMap[feature.icon] || 'text-slate-400'} mt-0.5 flex-shrink-0"
 							/>
 							<div>
@@ -674,6 +674,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['full-bloom'].features as feature}
+						{@const IconComponent = roadmapFeatureIcons[feature.icon]}
 						{@const colorMap = {
 							meadow: 'text-green-500',
 							clock: 'text-blue-500',
@@ -689,8 +690,7 @@
 							{feature.major ? 'border-2 border-green-300 dark:border-green-700' : ''}"
 						>
 							<!-- Use icon lookup map with feature-specific color -->
-							<svelte:component
-								this={roadmapFeatureIcons[feature.icon]}
+							<IconComponent
 								class="w-5 h-5 {colorMap[feature.icon] || 'text-slate-400'} mt-0.5 flex-shrink-0"
 							/>
 							<div>
@@ -785,6 +785,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['golden-hour'].features as feature}
+						{@const IconComponent = roadmapFeatureIcons[feature.icon]}
 						{@const colorMap = {
 							gem: 'text-amber-600 dark:text-amber-400',
 							zap: 'text-yellow-500',
@@ -796,8 +797,7 @@
 							{feature.major ? 'ring-2 ring-amber-400/50 dark:ring-amber-600/30' : ''}"
 						>
 							<!-- Use icon lookup map with feature-specific color (Golden Hour = amber tones) -->
-							<svelte:component
-								this={roadmapFeatureIcons[feature.icon]}
+							<IconComponent
 								class="w-5 h-5 {colorMap[feature.icon] || 'text-amber-500'} mt-0.5 flex-shrink-0"
 							/>
 							<div>
@@ -890,18 +890,18 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['midnight-bloom'].features as feature}
+						{@const IconComponent = roadmapFeatureIcons[feature.icon]}
+						{@const colorMap = {
+							coffee: 'text-amber-400',
+							qrcode: 'text-purple-300',
+							bookopen: 'text-pink-300',
+							home: 'text-amber-300'
+						}}
 						<li class="flex items-start gap-3 p-4 rounded-lg bg-purple-900/30 backdrop-blur-sm border border-purple-700/30">
-							{@const colorMap = {
-									coffee: 'text-amber-400',
-									qrcode: 'text-purple-300',
-									bookopen: 'text-pink-300',
-									home: 'text-amber-300'
-									}}
-					<!-- Use icon lookup map with feature-specific color (Midnight Bloom = mystical purples) -->
-					<svelte:component
-									this={roadmapFeatureIcons[feature.icon]}
-									class="w-5 h-5 {colorMap[feature.icon] || 'text-amber-400'} mt-0.5 flex-shrink-0"
-									/>
+							<!-- Use icon lookup map with feature-specific color (Midnight Bloom = mystical purples) -->
+							<IconComponent
+								class="w-5 h-5 {colorMap[feature.icon] || 'text-amber-400'} mt-0.5 flex-shrink-0"
+							/>
 							<div>
 								<span class="font-medium text-white">{feature.name}</span>
 								<p class="text-sm text-purple-300">{feature.description}</p>

--- a/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
+++ b/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
@@ -1100,6 +1100,7 @@
   .toolbar-btn.full-preview-btn .key {
     color: #9ac5ff;
   }
+  /* svelte-ignore css-unused-selector */
   .toolbar-divider {
     color: #4a4a4a;
     margin: 0 0.25rem;

--- a/packages/engine/src/lib/components/quota/UpgradePrompt.svelte
+++ b/packages/engine/src/lib/components/quota/UpgradePrompt.svelte
@@ -173,6 +173,7 @@
 
 {#if open}
   <!-- Backdrop -->
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
   <div
     class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
     onclick={onClose}

--- a/packages/engine/src/lib/ui/components/gallery/ImageGallery.svelte
+++ b/packages/engine/src/lib/ui/components/gallery/ImageGallery.svelte
@@ -264,6 +264,7 @@
 	<!-- Lightbox modal -->
 	{#if lightboxOpen}
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class="lightbox-backdrop"
 			onclick={(/** @type {MouseEvent} */ e) => e.target === e.currentTarget && closeLightbox()}
@@ -284,6 +285,7 @@
 			</button>
 
 			<!-- svelte-ignore a11y_click_events_have_key_events -->
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
 				class="lightbox-content"
 				onclick={(/** @type {MouseEvent} */ e) => e.target === e.currentTarget && closeLightbox()}
@@ -291,6 +293,7 @@
 					if (e.key === 'Escape') closeLightbox();
 					if (e.key === 'Enter' || e.key === ' ') closeLightbox();
 				}}
+				role="presentation"
 			>
 				<ZoomableImage
 					src={currentImage.url}

--- a/packages/engine/src/lib/ui/components/gallery/Lightbox.svelte
+++ b/packages/engine/src/lib/ui/components/gallery/Lightbox.svelte
@@ -25,6 +25,7 @@
 
 {#if isOpen}
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
 		class="lightbox-backdrop"
 		onclick={handleBackdropClick}
@@ -41,10 +42,12 @@
 			</svg>
 		</button>
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class="lightbox-content"
 			onclick={handleBackdropClick}
 			onkeydown={handleKeydown}
+			role="presentation"
 		>
 			<ZoomableImage {src} {alt} isActive={isOpen} class="lightbox-image" />
 		</div>

--- a/packages/engine/src/lib/ui/components/gallery/ZoomableImage.svelte
+++ b/packages/engine/src/lib/ui/components/gallery/ZoomableImage.svelte
@@ -137,6 +137,7 @@
 <svelte:window onmousemove={handleMouseMove} onmouseup={handleMouseUp} />
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
 <img
 	{src}
 	{alt}

--- a/packages/engine/src/lib/ui/components/ui/CollapsibleSection.svelte
+++ b/packages/engine/src/lib/ui/components/ui/CollapsibleSection.svelte
@@ -18,6 +18,8 @@
 		...restProps
 	}: Props = $props();
 
+	// defaultOpen only sets the initial state (not reactive to prop changes)
+	// svelte-ignore state_referenced_locally
 	let isOpen = $state(defaultOpen);
 
 	// Sync with external open prop if provided

--- a/packages/engine/src/lib/ui/components/ui/GlassConfirmDialog.svelte
+++ b/packages/engine/src/lib/ui/components/ui/GlassConfirmDialog.svelte
@@ -117,6 +117,14 @@
 			handleCancel();
 		}
 	}
+
+	function handleBackdropKeydown(event: KeyboardEvent) {
+		// Handle Enter and Space to close, consistent with button behavior
+		if (event.key === "Enter" || event.key === " ") {
+			event.preventDefault();
+			handleCancel();
+		}
+	}
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -126,6 +134,7 @@
 	<div
 		class="fixed inset-0 z-50 flex items-center justify-center p-4"
 		onclick={handleBackdropClick}
+		onkeydown={handleBackdropKeydown}
 		role="dialog"
 		aria-modal="true"
 		aria-labelledby="confirm-dialog-title"

--- a/packages/engine/src/lib/ui/components/ui/GlassOverlay.svelte
+++ b/packages/engine/src/lib/ui/components/ui/GlassOverlay.svelte
@@ -80,10 +80,11 @@
 	);
 </script>
 
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
 	class={computedClass}
 	role={interactive ? "button" : "presentation"}
-	tabindex={interactive ? 0 : undefined}
+	tabindex={interactive ? 0 : -1}
 	aria-label={interactive ? "Close overlay" : undefined}
 	{...restProps}
 >

--- a/packages/engine/src/lib/ui/components/ui/Input.svelte
+++ b/packages/engine/src/lib/ui/components/ui/Input.svelte
@@ -14,6 +14,7 @@
 	 * @prop {boolean} [required=false] - Whether input is required (shows asterisk)
 	 * @prop {boolean} [disabled=false] - Whether input is disabled
 	 * @prop {string} [class] - Additional CSS classes to apply
+	 * @prop {string} [id] - Input ID for label association (auto-generated if not provided)
 	 * @prop {HTMLInputElement} [ref] - Reference to the underlying input element (bindable)
 	 *
 	 * @example
@@ -34,6 +35,7 @@
 		required?: boolean;
 		disabled?: boolean;
 		class?: string;
+		id?: string;
 		ref?: HTMLInputElement | null;
 	}
 
@@ -46,9 +48,14 @@
 		required = false,
 		disabled = false,
 		class: className,
+		id,
 		ref = $bindable(null),
 		...restProps
 	}: Props = $props();
+
+	// Generate unique ID for label association if not provided
+	// svelte-ignore state_referenced_locally - id is intentionally captured at initialization for stable IDs
+	const inputId = id ?? `input-${crypto.randomUUID()}`;
 
 	const inputClass = $derived(
 		cn(
@@ -60,7 +67,7 @@
 
 <div class="flex flex-col gap-1.5">
 	{#if label}
-		<label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+		<label for={inputId} class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
 			{label}
 			{#if required}
 				<span class="text-destructive">*</span>
@@ -69,6 +76,7 @@
 	{/if}
 
 	<ShadcnInput
+		id={inputId}
 		bind:ref={ref}
 		bind:value
 		{type}

--- a/packages/engine/src/lib/ui/components/ui/Textarea.svelte
+++ b/packages/engine/src/lib/ui/components/ui/Textarea.svelte
@@ -14,6 +14,7 @@
 	 * @prop {boolean} [required=false] - Whether textarea is required (shows asterisk)
 	 * @prop {boolean} [disabled=false] - Whether textarea is disabled
 	 * @prop {string} [class] - Additional CSS classes to apply
+	 * @prop {string} [id] - Textarea ID for label association (auto-generated if not provided)
 	 *
 	 * @example
 	 * <Textarea label="Description" bind:value={description} required />
@@ -33,6 +34,7 @@
 		required?: boolean;
 		disabled?: boolean;
 		class?: string;
+		id?: string;
 	}
 
 	let {
@@ -44,8 +46,13 @@
 		required = false,
 		disabled = false,
 		class: className,
+		id,
 		...restProps
 	}: Props = $props();
+
+	// Generate unique ID for label association if not provided
+	// svelte-ignore state_referenced_locally - id is intentionally captured at initialization for stable IDs
+	const textareaId = id ?? `textarea-${crypto.randomUUID()}`;
 
 	const textareaClass = $derived(
 		cn(
@@ -57,7 +64,7 @@
 
 <div class="flex flex-col gap-1.5">
 	{#if label}
-		<label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+		<label for={textareaId} class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
 			{label}
 			{#if required}
 				<span class="text-destructive">*</span>
@@ -66,6 +73,7 @@
 	{/if}
 
 	<ShadcnTextarea
+		id={textareaId}
 		bind:value
 		{placeholder}
 		{rows}


### PR DESCRIPTION
- Fix @const tag placement error in roadmap page (midnight-bloom section)
- Replace deprecated <svelte:component> with direct component usage in roadmap
- Add a11y improvements to Input, Textarea, GlassConfirmDialog, GlassOverlay
- Add svelte-ignore directives for intentional accessibility patterns in gallery components
- Fix state_referenced_locally warnings with appropriate comments
- All builds now pass successfully