### PR TITLE
Document Claude API plan upgrade to $200 and all other expenses

### DIFF
--- a/docs/business/development-expenses.md
+++ b/docs/business/development-expenses.md
@@ -52,6 +52,7 @@ Actual usage is closer to 95% for Grove, but maintaining conservative estimate f
 | Field | Value |
 |-------|-------|
 | **Domain** | grove.place |
+| **Registrar** | Cloudflare (at-cost pricing, no markup) |
 | **Cost** | $17/year |
 | **Renewal Date** | December 2025 |
 | **Business Use** | 100% |


### PR DESCRIPTION
## Summary

- Add `docs/business/development-expenses.md` to track Grove-related business expenses for tax write-off purposes
- Document Claude Max subscription upgrade ($100 → $200/month) with 75-80% business allocation
- Track infrastructure costs: domain, email forwarding, Cloudflare Workers, and mobile hotspot for remote development

## Expenses Tracked

| Expense | Annual Cost | Business % | Deductible |
|---------|-------------|------------|------------|
| Claude Max | $2,400 | 75-80% | $1,800-1,920 |
| Domain (grove.place) | $17 | 100% | $17 |
| Forward Email | $36 | 100% | $36 |
| Cloudflare Workers | $60 | 100% | $60 |
| Mobile Hotspot | $199 | 85% | $169 |
| **Total** | **$2,712** | — | **~$2,082-2,202** |

## Test plan

- [x] Document is properly formatted markdown
- [x] All expense details are accurate
- [x] Business use percentages are conservative estimates
