### PR TITLE
fix: add missing icon imports to roadmap pages

### DIFF
--- a/landing/src/routes/roadmap/+page.svelte
+++ b/landing/src/routes/roadmap/+page.svelte
@@ -23,7 +23,8 @@
 		Zap,
 		Accessibility,
 		Smartphone,
-		Puzzle
+		Puzzle,
+		Sprout
 	} from 'lucide-svelte';
 
 	// Import nature assets from engine package

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -6,6 +6,9 @@
 	// Centralized icon registry - single source of truth for all icons
 	import { toolIcons } from '$lib/utils/icons';
 
+	// Additional Lucide icons for spec/github links
+	import { FileText, Github } from 'lucide-svelte';
+
 	// Import nature assets from engine package
 	import { Logo, Lantern } from '@autumnsgrove/groveengine/ui/nature';
 


### PR DESCRIPTION
Add missing Lucide icon imports that were causing 500 errors:
- Add Sprout import to /roadmap main page
- Add FileText and Github imports to /roadmap/workshop page