### PR TITLE
feat: update Waystone icon from helpCircle to signpost

### DIFF
--- a/landing/src/lib/utils/icons.ts
+++ b/landing/src/lib/utils/icons.ts
@@ -102,6 +102,7 @@ import {
   Bird,
   Triangle,
   Terminal,
+  Signpost,
 } from 'lucide-svelte';
 
 // ============================================================================
@@ -230,6 +231,7 @@ export const toolIcons = {
   users: Users,
   map: MapPin,
   helpcircle: HelpCircle,
+  signpost: Signpost,
   triangle: Triangle,
   gauge: Gauge,
   radar: Radar,
@@ -263,6 +265,7 @@ export const roadmapFeatureIcons = {
   shieldcheck: ShieldCheck,
   download: Download,
   lifebuoy: HelpCircle,
+  signpost: Signpost,
   terminal: FileText,
   network: Github,
   database: HardDrive,

--- a/landing/src/routes/roadmap/+page.svelte
+++ b/landing/src/routes/roadmap/+page.svelte
@@ -96,7 +96,7 @@
 				{ name: 'RSS Feed', description: 'Built-in, because it should be', done: true, icon: 'rss' },
 				{ name: 'Shade', description: 'AI content protection — crawlers blocked at the gate', done: true, icon: 'shieldcheck' },
 				{ name: 'Data Export', description: 'Your words, always portable — a core feature', done: true, icon: 'download' },
-				{ name: 'Waystone', description: 'Help center — guidance when you need it', done: true, icon: 'lifebuoy' },
+				{ name: 'Waystone', description: 'Help center — guidance when you need it', done: true, icon: 'signpost' },
 				{ name: 'Bloom', description: 'Remote coding infrastructure — ephemeral, autonomous', done: true, icon: 'terminal', internal: true },
 				{ name: 'Mycelium', description: 'MCP server — the wood wide web', done: true, icon: 'network', internal: true },
 				{ name: 'Patina', description: 'Nightly backups — age as armor', done: false, icon: 'database', internal: true }

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -146,7 +146,7 @@
 					tagline: 'Help Center',
 					description: 'Integrated help that meets you where you are. Waystone is Grove\'s help system—contextual assistance built directly into the platform, no external docs site required. When you need help, it\'s already there.',
 					status: 'live',
-					icon: 'helpCircle',
+					icon: 'signpost',
 					integration: 'Built into all Grove properties',
 					spec: '/knowledge/specs/waystone-spec'
 				},


### PR DESCRIPTION
Replace generic help icon with Signpost across all pages for better semantic
alignment. Waystone is a landmark for guidance—Signpost better communicates
this purpose while maintaining Grove's nature-first aesthetic.

Changes:
- Add Signpost import to icons registry
- Add signpost to toolIcons (workshop page)
- Add signpost to roadmapFeatureIcons (roadmap page)
- Update Waystone icon references in both pages