### PR TITLE
refactor: sync roadmap icons with centralized registry

### DIFF
--- a/landing/src/lib/utils/icons.ts
+++ b/landing/src/lib/utils/icons.ts
@@ -55,6 +55,7 @@ import {
   Sparkles,
   Star,
   Moon,
+  Sun,
   // Actions
   Compass,
   Megaphone,
@@ -182,6 +183,7 @@ export const phaseIcons = {
   sparkles: Sparkles,
   star: Star,
   moon: Moon,
+  sun: Sun,
   sprout: Sprout,
 } as const;
 

--- a/landing/src/routes/roadmap/+page.svelte
+++ b/landing/src/routes/roadmap/+page.svelte
@@ -4,28 +4,25 @@
 	import Footer from '$lib/components/Footer.svelte';
 	import SEO from '$lib/components/SEO.svelte';
 
-	// Centralized icon registry
-	import { roadmapFeatureIcons, seasonalIconColors, getPhaseColor } from '$lib/utils/icons';
-
-	// Additional Lucide icons for hero/nav
+	// Centralized icon registry - single source of truth for all icons
 	import {
-		MapPin,
-		Check,
-		CheckCircle,
-		Sun,
-		Sparkles,
-		Star,
-		Flower2,
-		Moon as MoonIcon,
-		TreeDeciduous,
-		SwatchBook,
-		Gem,
-		Zap,
-		Accessibility,
-		Smartphone,
-		Puzzle,
-		Sprout
-	} from 'lucide-svelte';
+		roadmapFeatureIcons,
+		seasonalIconColors,
+		getPhaseColor,
+		stateIcons,
+		navIcons,
+		phaseIcons
+	} from '$lib/utils/icons';
+
+	// Local aliases from centralized registry for cleaner template usage
+	const MapPin = navIcons.roadmap;
+	const Check = stateIcons.check;
+	const CheckCircle = stateIcons.checkcircle;
+	const Sun = phaseIcons.sun;
+	const Gem = phaseIcons.gem;
+	const MoonIcon = phaseIcons.moon;
+	const Star = phaseIcons.star;
+	const Sprout = phaseIcons.sprout;
 
 	// Import nature assets from engine package
 	import {


### PR DESCRIPTION
- Add Sun icon to phaseIcons in icons.ts for "On the Horizon" badge
- Replace direct lucide-svelte imports with centralized registry imports
- Remove 8 unused icon imports (Sparkles, Flower2, TreeDeciduous, etc.)
- Use local aliases for cleaner template syntax while maintaining single source of truth