### PR TITLE
refactor: unify icons across pricing and roadmap pages

### DIFF
--- a/landing/src/routes/roadmap/beyond/+page.svelte
+++ b/landing/src/routes/roadmap/beyond/+page.svelte
@@ -4,10 +4,10 @@
 	import SEO from '$lib/components/SEO.svelte';
 
 	// Centralized icon registry - single source of truth for all icons
-	import { toolIcons } from '$lib/utils/icons';
+	import { toolIcons, featureIcons } from '$lib/utils/icons';
 
-	// Lucide Icons - only for social links
-	import { Github } from 'lucide-svelte';
+	// Use centralized registry for social link icons
+	const Github = featureIcons.github;
 
 	// Import nature assets from engine package
 	import { StarCluster, Moon } from '@autumnsgrove/groveengine/ui/nature';

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -4,10 +4,11 @@
 	import SEO from '$lib/components/SEO.svelte';
 
 	// Centralized icon registry - single source of truth for all icons
-	import { toolIcons } from '$lib/utils/icons';
+	import { toolIcons, featureIcons, contentIcons } from '$lib/utils/icons';
 
-	// Additional Lucide icons for spec/github links
-	import { FileText, Github } from 'lucide-svelte';
+	// Use centralized registry for spec/github link icons
+	const FileText = contentIcons.filetext;
+	const Github = featureIcons.github;
 
 	// Import nature assets from engine package
 	import { Logo, Lantern } from '@autumnsgrove/groveengine/ui/nature';

--- a/packages/engine/src/lib/ui/components/content/RoadmapPreview.svelte
+++ b/packages/engine/src/lib/ui/components/content/RoadmapPreview.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import type { Snippet } from "svelte";
 	import { cn } from "$lib/ui/utils";
-	import { MapPin, ArrowRight } from "lucide-svelte";
+	// Use centralized icon registry instead of direct lucide-svelte imports
+	import { MapPin, ArrowRight } from "$lib/ui/components/icons";
 
 	/**
 	 * RoadmapPreview - A glass card showing current development phase

--- a/packages/engine/src/lib/ui/components/icons/index.ts
+++ b/packages/engine/src/lib/ui/components/icons/index.ts
@@ -1,11 +1,58 @@
 // GroveUI - Icon Components
 //
-// This module exports SVG icon components used across the Grove platform
+// This module exports SVG icon components and Lucide icon registries
+// used across the Grove platform.
 //
 // Usage:
-//   import { Icons, IconLegend } from '@groveengine/ui/icons';
+//   import { Icons, IconLegend } from '@autumnsgrove/groveengine/ui/icons';
+//   import { stateIcons, pricingIcons, Check } from '@autumnsgrove/groveengine/ui/icons';
 
+// Custom SVG components
 export { default as Icons } from './Icons.svelte';
 export { default as IconLegend } from './IconLegend.svelte';
 
-export const ICONS_VERSION = '0.2.0';
+// Lucide icon registries and utilities
+export {
+  // Icon maps (semantic groupings)
+  navIcons,
+  stateIcons,
+  pricingIcons,
+  featureIcons,
+  growthIcons,
+  phaseIcons,
+  actionIcons,
+  metricsIcons,
+  allIcons,
+  // Types
+  type IconKey,
+  // Utilities
+  getIcon,
+  getIconFromAll,
+  // Direct icon exports (commonly used)
+  Check,
+  CheckCircle,
+  X,
+  ArrowRight,
+  ArrowLeft,
+  MapPin,
+  Sprout,
+  Trees,
+  TreeDeciduous,
+  Crown,
+  Flower2,
+  Leaf,
+  Heart,
+  Home,
+  Menu,
+  Settings,
+  ExternalLink,
+  Loader2,
+  AlertTriangle,
+  HelpCircle,
+  Clock,
+  TrendingUp,
+  Users,
+  Activity,
+} from './lucide';
+
+export const ICONS_VERSION = '0.3.0';

--- a/packages/engine/src/lib/ui/components/icons/lucide.ts
+++ b/packages/engine/src/lib/ui/components/icons/lucide.ts
@@ -1,0 +1,304 @@
+/**
+ * Shared Lucide icon registry for Grove Platform.
+ * Single source of truth for commonly used icons across all Grove apps.
+ *
+ * DO: Import icons from '@autumnsgrove/groveengine/ui/icons'
+ * DON'T: Import directly from 'lucide-svelte' in app components
+ *
+ * @example
+ * ```svelte
+ * import { stateIcons, navIcons } from '@autumnsgrove/groveengine/ui/icons';
+ *
+ * <svelte:component this={stateIcons.check} class="w-5 h-5" />
+ * ```
+ */
+
+import {
+  // Navigation
+  Home,
+  Info,
+  Telescope,
+  MapPin,
+  CircleDollarSign,
+  BookOpen,
+  Trees,
+  PenLine,
+  ArrowRight,
+  ArrowLeft,
+  ChevronRight,
+  ChevronLeft,
+  ExternalLink,
+  // Features & Content
+  Mail,
+  HardDrive,
+  Palette,
+  ShieldCheck,
+  Cloud,
+  SearchCode,
+  Archive,
+  Upload,
+  MessagesSquare,
+  MessageCircle,
+  FileText,
+  Tag,
+  // Nature/Growth (Grove themed)
+  Sprout,
+  Heart,
+  Leaf,
+  Flower2,
+  TreeDeciduous,
+  Crown,
+  // States & Feedback
+  Check,
+  CheckCircle,
+  X,
+  Loader2,
+  AlertTriangle,
+  HelpCircle,
+  Info as InfoIcon,
+  Circle,
+  // Phases & Special
+  Gem,
+  Sparkles,
+  Star,
+  Moon,
+  Sun,
+  // Actions
+  Compass,
+  Megaphone,
+  Lightbulb,
+  Download,
+  Settings,
+  Menu,
+  // Metrics
+  Clock,
+  TrendingUp,
+  TrendingDown,
+  Activity,
+  Users,
+  ShieldUser,
+  BarChart3,
+  // Pricing
+  Globe,
+  CalendarDays,
+  LifeBuoy,
+} from 'lucide-svelte';
+
+// ============================================================================
+// NAVIGATION ICONS
+// ============================================================================
+/** Icons for main navigation items */
+export const navIcons = {
+  home: Home,
+  about: Info,
+  vision: Telescope,
+  roadmap: MapPin,
+  pricing: CircleDollarSign,
+  knowledge: BookOpen,
+  forest: Trees,
+  blog: PenLine,
+  arrow: ArrowRight,
+  arrowLeft: ArrowLeft,
+  chevron: ChevronRight,
+  chevronLeft: ChevronLeft,
+  external: ExternalLink,
+} as const;
+
+// ============================================================================
+// STATE & FEEDBACK ICONS
+// ============================================================================
+/** Icons for states: success, error, loading, etc. */
+export const stateIcons = {
+  check: Check,
+  checkcircle: CheckCircle,
+  x: X,
+  loader: Loader2,
+  warning: AlertTriangle,
+  help: HelpCircle,
+  info: InfoIcon,
+  circle: Circle,
+} as const;
+
+// ============================================================================
+// PRICING & TIER ICONS
+// ============================================================================
+/** Icons for pricing tiers and feature comparison */
+export const pricingIcons = {
+  // Tier icons (growth progression)
+  sprout: Sprout,
+  treedeciduous: TreeDeciduous,
+  trees: Trees,
+  crown: Crown,
+  // Feature row icons
+  penline: PenLine,
+  filetext: FileText,
+  harddrive: HardDrive,
+  palette: Palette,
+  flower2: Flower2,
+  messagecircle: MessageCircle,
+  globe: Globe,
+  searchcode: SearchCode,
+  mail: Mail,
+  lifebuoy: LifeBuoy,
+  calendardays: CalendarDays,
+  clock: Clock,
+  // Checkmark for feature availability
+  check: Check,
+} as const;
+
+// ============================================================================
+// CONTENT & FEATURE ICONS
+// ============================================================================
+/** Icons for features, tools, and content types */
+export const featureIcons = {
+  mail: Mail,
+  harddrive: HardDrive,
+  palette: Palette,
+  shieldcheck: ShieldCheck,
+  cloud: Cloud,
+  searchcode: SearchCode,
+  archive: Archive,
+  upload: Upload,
+  messagessquare: MessagesSquare,
+  externallink: ExternalLink,
+  filetext: FileText,
+  tag: Tag,
+} as const;
+
+// ============================================================================
+// GROWTH & NATURE ICONS
+// ============================================================================
+/** Icons representing growth and nature (Grove themed) */
+export const growthIcons = {
+  sprout: Sprout,
+  heart: Heart,
+  leaf: Leaf,
+  flower2: Flower2,
+  trees: Trees,
+  treedeciduous: TreeDeciduous,
+} as const;
+
+// ============================================================================
+// PHASE & DREAM ICONS
+// ============================================================================
+/** Icons for phases, refinement, and mystical/future content */
+export const phaseIcons = {
+  gem: Gem,
+  sparkles: Sparkles,
+  star: Star,
+  moon: Moon,
+  sun: Sun,
+  sprout: Sprout,
+} as const;
+
+// ============================================================================
+// ACTION ICONS
+// ============================================================================
+/** Icons for user actions and processes */
+export const actionIcons = {
+  compass: Compass,
+  megaphone: Megaphone,
+  lightbulb: Lightbulb,
+  download: Download,
+  settings: Settings,
+  menu: Menu,
+  trend: TrendingUp,
+  trenddown: TrendingDown,
+  arrow: ArrowRight,
+} as const;
+
+// ============================================================================
+// METRICS ICONS
+// ============================================================================
+/** Icons for analytics and metrics display */
+export const metricsIcons = {
+  clock: Clock,
+  trending: TrendingUp,
+  trenddown: TrendingDown,
+  activity: Activity,
+  users: Users,
+  shield: ShieldUser,
+  barchart: BarChart3,
+} as const;
+
+// ============================================================================
+// UNIFIED EXPORT
+// ============================================================================
+/** All icons in one map (use specific maps above when possible) */
+export const allIcons = {
+  ...navIcons,
+  ...stateIcons,
+  ...featureIcons,
+  ...growthIcons,
+  ...phaseIcons,
+  ...actionIcons,
+  ...metricsIcons,
+} as const;
+
+/** Type for any icon key in the registry */
+export type IconKey = keyof typeof allIcons;
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+/**
+ * Get an icon from a specific map by key
+ * @example
+ * ```ts
+ * const icon = getIcon(stateIcons, 'check');
+ * ```
+ */
+export function getIcon<T extends Record<string, any>>(
+  map: T,
+  key: keyof T | string
+) {
+  return (map as Record<string, any>)[key as string];
+}
+
+/**
+ * Get an icon from the unified map
+ * @example
+ * ```ts
+ * const icon = getIconFromAll('check');
+ * ```
+ */
+export function getIconFromAll(key: string) {
+  return (allIcons as Record<string, any>)[key];
+}
+
+// ============================================================================
+// DIRECT EXPORTS (for convenience)
+// ============================================================================
+// Re-export commonly used icons directly for simple imports
+export {
+  // Most commonly used
+  Check,
+  CheckCircle,
+  X,
+  ArrowRight,
+  ArrowLeft,
+  MapPin,
+  // Growth icons
+  Sprout,
+  Trees,
+  TreeDeciduous,
+  Crown,
+  Flower2,
+  Leaf,
+  Heart,
+  // Navigation
+  Home,
+  Menu,
+  Settings,
+  ExternalLink,
+  // States
+  Loader2,
+  AlertTriangle,
+  HelpCircle,
+  // Metrics
+  Clock,
+  TrendingUp,
+  Users,
+  Activity,
+};

--- a/plant/src/routes/plans/+page.svelte
+++ b/plant/src/routes/plans/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Check } from 'lucide-svelte';
+	// Use centralized icon registry for consistent icons across Grove
+	import { Check } from '@autumnsgrove/groveengine/ui/icons';
 	import { GlassCard } from '@autumnsgrove/groveengine/ui';
 
 	let { data } = $props();


### PR DESCRIPTION
- Create shared Lucide icons module in engine package (@autumnsgrove/groveengine/ui/icons)
- Update RoadmapPreview component to use centralized icons
- Update Plant plans page to import Check from shared registry
- Update roadmap workshop/beyond pages to use featureIcons for Github/FileText
- Bump icons module version to 0.3.0

This enables consistent icon usage across all Grove apps by providing
a shared icons registry in the engine package that apps can import from.