### PR TITLE
feat(workshop): add subicons for 7 workshop features

### DIFF
--- a/landing/src/lib/utils/icons.ts
+++ b/landing/src/lib/utils/icons.ts
@@ -140,6 +140,18 @@ import {
   Eye,
   BookOpenCheck,
   Goal,
+  // Additional subicon imports (round 2)
+  Chrome,
+  Wand2,
+  Layout,
+  Image,
+  Reply,
+  Bot,
+  Bug,
+  Cpu,
+  Frame,
+  Shapes,
+  Share2,
 } from 'lucide-svelte';
 
 // ============================================================================
@@ -319,6 +331,21 @@ export const toolIcons = {
   eye: Eye,                      // Rings - Views
   bookopencheck: BookOpenCheck,  // Rings - Readers
   goal: Goal,                    // Rings - Resonance
+  // Additional subicons (round 2)
+  chrome: Chrome,                // Heartwood - Google
+  github: Github,                // Heartwood - GitHub
+  wand2: Wand2,                  // Heartwood - Magic
+  penline: PenLine,              // Arbor - Posts
+  layout: Layout,                // Arbor - Pages
+  image: Image,                  // Arbor - Media
+  reply: Reply,                  // Reeds - Replies
+  messagecircle: MessageCircle,  // Reeds - Comments
+  bot: Bot,                      // Shade - Bot
+  bug: Bug,                      // Shade - Scraper
+  cpu: Cpu,                      // Vista - Workers
+  frame: Frame,                  // Terrarium - Canvas
+  shapes: Shapes,                // Terrarium - Assets
+  share2: Share2,                // Terrarium - Export
 } as const;
 
 // ============================================================================

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -78,7 +78,12 @@
 					icon: 'shieldcheck',
 					domain: 'heartwood.grove.place',
 					integration: 'Powers authentication for all Grove services',
-					github: 'https://github.com/AutumnsGrove/GroveAuth'
+					github: 'https://github.com/AutumnsGrove/GroveAuth',
+					subComponents: [
+						{ name: 'Google', icon: 'chrome', description: 'Google OAuth' },
+						{ name: 'GitHub', icon: 'github', description: 'GitHub OAuth' },
+						{ name: 'Magic', icon: 'wand2', description: 'Email magic links' }
+					]
 				},
 				{
 					name: 'Arbor',
@@ -88,7 +93,12 @@
 					icon: 'dashboard',
 					domain: '{you}.grove.place/admin',
 					integration: 'Built into every Grove blog',
-					spec: '/knowledge/specs/arbor-spec'
+					spec: '/knowledge/specs/arbor-spec',
+					subComponents: [
+						{ name: 'Posts', icon: 'penline', description: 'Write & edit' },
+						{ name: 'Pages', icon: 'layout', description: 'Static pages' },
+						{ name: 'Media', icon: 'image', description: 'Image gallery' }
+					]
 				},
 				{
 					name: 'Plant',
@@ -144,7 +154,12 @@
 					status: 'planned',
 					icon: 'pencilruler',
 					integration: 'Creative tool for building blog decorations',
-					spec: '/knowledge/specs/terrarium-spec'
+					spec: '/knowledge/specs/terrarium-spec',
+					subComponents: [
+						{ name: 'Canvas', icon: 'frame', description: 'Design space' },
+						{ name: 'Assets', icon: 'shapes', description: 'Nature components' },
+						{ name: 'Export', icon: 'share2', description: 'Publish to blog' }
+					]
 				},
 				{
 					name: 'Weave',
@@ -226,7 +241,11 @@
 					status: 'planned',
 					icon: 'messagessquare',
 					integration: 'Comments and replies for Grove blogs',
-					spec: '/knowledge/specs/reeds-spec'
+					spec: '/knowledge/specs/reeds-spec',
+					subComponents: [
+						{ name: 'Replies', icon: 'reply', description: 'Private to author' },
+						{ name: 'Comments', icon: 'messagecircle', description: 'Public discussion' }
+					]
 				},
 				{
 					name: 'Thorn',
@@ -344,7 +363,12 @@
 					domain: 'vista.grove.place',
 					integration: 'Internal infrastructure monitoring for Grove operators',
 					github: 'https://github.com/AutumnsGrove/GroveMonitor',
-					spec: '/knowledge/specs/vista-spec'
+					spec: '/knowledge/specs/vista-spec',
+					subComponents: [
+						{ name: 'Workers', icon: 'cpu', description: 'Cloudflare Workers' },
+						{ name: 'Database', icon: 'database', description: 'D1 databases' },
+						{ name: 'Storage', icon: 'harddrive', description: 'R2 & KV' }
+					]
 				},
 				{
 					name: 'Patina',
@@ -374,7 +398,12 @@
 					status: 'live',
 					icon: 'brickwallshield',
 					integration: 'Automatic protection for all Grove blogs',
-					spec: '/knowledge/specs/shade-spec'
+					spec: '/knowledge/specs/shade-spec',
+					subComponents: [
+						{ name: 'Bot', icon: 'bot', description: 'Bot detection' },
+						{ name: 'Scraper', icon: 'bug', description: 'Scraper blocking' },
+						{ name: 'Shield', icon: 'shieldcheck', description: 'Content protection' }
+					]
 				},
 			]
 		},


### PR DESCRIPTION
Add subComponents to workshop tools following Weave's pattern:
- Lattice: Vines (gutter system)
- Songbird: Canary, Kestrel, Robin (3-layer defense)
- Threshold: Edge, Tenant, User, Endpoint (4-layer rate limiting)
- Loom: Session, Tenant, Post (Durable Objects)
- Foliage: Themes, Customizer, Fonts (theming)
- Ivy: Compose, Encrypt, Contacts (email)
- Rings: Views, Readers, Resonance (analytics)

Add 20 new Lucide icons to icons.ts toolIcons map.