### PR TITLE
fix(MobileMenu): remove scroll-shadow causing black boxes on mobile

### DIFF
--- a/packages/engine/src/lib/ui/components/chrome/MobileMenu.svelte
+++ b/packages/engine/src/lib/ui/components/chrome/MobileMenu.svelte
@@ -137,8 +137,8 @@
 		</button>
 	</div>
 
-	<!-- Navigation with scroll shadow -->
-	<nav class="p-2 overflow-y-auto flex-1 scroll-shadow">
+	<!-- Navigation -->
+	<nav class="p-2 overflow-y-auto flex-1">
 		<!-- Main Navigation Items -->
 		{#each items as item}
 			{@const Icon = item.icon}
@@ -235,36 +235,3 @@
 	</nav>
 </div>
 
-<style>
-	/*
-	 * Scroll shadow indicator
-	 * Shows gradient shadows at top/bottom when content is scrollable.
-	 * Uses background-attachment: local/scroll trick for pure CSS solution.
-	 */
-	.scroll-shadow {
-		/* Shadow and surface colors - uses theme CSS variables with sensible fallbacks */
-		--scroll-shadow-color: rgb(0 0 0 / 0.08);
-		--scroll-shadow-size: 16px;
-		/* Surface color for cover gradients - matches bg-surface */
-		--scroll-surface-light: hsl(var(--surface, 0 0% 100%));
-		--scroll-surface-dark: hsl(var(--surface, 240 10% 4%));
-		--scroll-surface: var(--scroll-surface-light);
-
-		background:
-			/* Top shadow - fades in when scrolled down */
-			linear-gradient(to bottom, var(--scroll-shadow-color), transparent) top / 100% var(--scroll-shadow-size),
-			/* Bottom shadow - fades in when more content below */
-			linear-gradient(to top, var(--scroll-shadow-color), transparent) bottom / 100% var(--scroll-shadow-size),
-			/* Top cover - hides shadow when at scroll top */
-			linear-gradient(to bottom, var(--scroll-surface), var(--scroll-surface)) top / 100% var(--scroll-shadow-size),
-			/* Bottom cover - hides shadow when at scroll bottom */
-			linear-gradient(to top, var(--scroll-surface), var(--scroll-surface)) bottom / 100% var(--scroll-shadow-size);
-		background-repeat: no-repeat;
-		background-attachment: local, local, scroll, scroll;
-	}
-
-	:global(.dark) .scroll-shadow {
-		--scroll-shadow-color: rgb(0 0 0 / 0.3);
-		--scroll-surface: var(--scroll-surface-dark);
-	}
-</style>


### PR DESCRIPTION
The scroll-shadow CSS used background-attachment: local which has known
compatibility issues on iOS Safari, causing black rectangular artifacts
to appear between dividers and section headers in the mobile menu.