### PR TITLE
feat(workshop): add Loam icon sub-component to Plant

### DIFF
--- a/landing/src/lib/utils/icons.ts
+++ b/landing/src/lib/utils/icons.ts
@@ -122,6 +122,7 @@ import {
   Waves,
   Waypoints,
   Route,
+  Funnel,
   // Subicon additions for workshop features
   LayoutList,
   Origami,
@@ -381,6 +382,8 @@ export const toolIcons = {
   monitorcloud: MonitorCloud,    // Outpost - main icon
   // Lab icons (experimental @lucide/lab)
   bee: BeeIcon,                  // Swarm - agentic swarm mode
+  // Loam - name protection & validation
+  funnel: Funnel,                // Loam - filters valid names
 } as const;
 
 // ============================================================================

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -116,7 +116,10 @@
 					icon: 'landplot',
 					domain: 'plant.grove.place',
 					integration: 'Signup and onboarding for new Grove users',
-					spec: '/knowledge/specs/plant-spec'
+					spec: '/knowledge/specs/plant-spec',
+					subComponents: [
+						{ name: 'Loam', icon: 'funnel', description: 'Name protection & validation', href: '/knowledge/specs/loam-spec' }
+					]
 				},
 				{
 					name: 'Amber',


### PR DESCRIPTION
Add Loam (name protection & validation) as a clickable sub-icon for Plant in the workshop roadmap. Uses Funnel icon from Lucide to represent the filtering/validation nature of the name blocklist system.

- Import Funnel icon from lucide-svelte
- Add funnel to toolIcons registry
- Add Loam sub-component to Plant tool with link to Loam spec