### PR TITLE
fix(footer): change dividers from horizontal to vertical orientation

### DIFF
--- a/packages/engine/src/lib/ui/components/chrome/defaults.ts
+++ b/packages/engine/src/lib/ui/components/chrome/defaults.ts
@@ -38,7 +38,7 @@ export const DIVIDER_VERTICAL = {
   count: 9,
   size: "xs" as const,
   glass: true,
-  vertical: false,
+  vertical: true,
   spacing: "0.5rem",
 } as const;
 


### PR DESCRIPTION
Update DIVIDER_VERTICAL configuration to set vertical: true, making
the footer column separators render as vertical dividers instead of
horizontal rows of stars.