### PR TITLE
feat(knowledge): wire up pattern icons to Architecture Patterns cards

### DIFF
--- a/landing/src/lib/data/knowledge-base.ts
+++ b/landing/src/lib/data/knowledge-base.ts
@@ -760,6 +760,7 @@ export const patterns: Doc[] = [
     excerpt:
       "Light enters plain and emerges transformed. Prism defines Grove's visual language: glassmorphism surfaces, seasonal theming, randomized forests, and the warm aesthetic that makes every page feel like a place you want to visit.",
     category: "patterns",
+    icon: "triangle",
     lastUpdated: "2026-01-02",
     readingTime: 20,
   },
@@ -770,6 +771,7 @@ export const patterns: Doc[] = [
     excerpt:
       "The Songbird Pattern is a three-layer defense against prompt injection. Canary detects poison early, Kestrel validates semantically, Robin produces safe output. Each layer costs fractions of a cent but protects all Grove AI features.",
     category: "patterns",
+    icon: "bird",
     lastUpdated: "2026-01-01",
     readingTime: 12,
   },
@@ -781,6 +783,7 @@ export const patterns: Doc[] = [
     excerpt:
       "The framework where Grove's threads come together. Loom coordinates auth, state, and real-time features using Cloudflare Durable Objects—the invisible structure that makes everything feel seamless.",
     category: "patterns",
+    icon: "spool",
     lastUpdated: "2026-01-01",
     readingTime: 18,
   },
@@ -792,6 +795,7 @@ export const patterns: Doc[] = [
     excerpt:
       "The forest has boundaries. Threshold enforces them with four-layer rate limiting: Cloudflare edge protection, tenant fairness, user abuse detection, and endpoint-specific limits. Uses Durable Objects for precision and graduated response.",
     category: "patterns",
+    icon: "gauge",
     lastUpdated: "2026-01-01",
     readingTime: 15,
   },
@@ -802,6 +806,7 @@ export const patterns: Doc[] = [
     excerpt:
       "Vineyard is a documentation pattern every Grove tool implements. Visit toolname.grove.place/vineyard to explore what each tool does, how it works, and where it's headed. A consistent way to showcase the ecosystem.",
     category: "patterns",
+    icon: "grape",
     lastUpdated: "2025-12-30",
     readingTime: 5,
   },
@@ -813,6 +818,7 @@ export const patterns: Doc[] = [
     excerpt:
       "The watchful guardian who tests the forest's defenses before the storm. Sentinel doesn't just ask 'can it handle 500 users?'—it asks 'what happens to p95 latency during the ramp-up, and which Durable Object becomes the bottleneck first?'",
     category: "patterns",
+    icon: "radar",
     lastUpdated: "2026-01-01",
     readingTime: 20,
   },
@@ -824,6 +830,7 @@ export const patterns: Doc[] = [
     excerpt:
       "A brief light in the darkness. Firefly defines Grove's pattern for ephemeral infrastructure—servers that spin up on demand, complete their work, and tear down automatically. Near-zero idle cost, sub-minute availability, full VM capabilities.",
     category: "patterns",
+    icon: "webhook",
     lastUpdated: "2026-01-01",
     readingTime: 18,
   },

--- a/landing/src/routes/knowledge/+page.svelte
+++ b/landing/src/routes/knowledge/+page.svelte
@@ -2,6 +2,7 @@
   import { goto } from '$app/navigation';
   import SEO from '$lib/components/SEO.svelte';
   import { Header, Footer } from '@autumnsgrove/groveengine/ui/chrome';
+  import { toolIcons } from '$lib/utils/icons';
 
   let { data } = $props();
   const { specs, helpArticles, legalDocs, marketingDocs, patterns } = data;
@@ -211,8 +212,13 @@
         <div class="grid md:grid-cols-3 gap-4 mb-4">
           {#each patterns as pattern}
             <div class="text-sm p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg">
-              <a href="/knowledge/patterns/{pattern.slug}" class="text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 font-medium transition-colors">
-                {pattern.title}
+              <a href="/knowledge/patterns/{pattern.slug}" class="flex items-start gap-2 text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 font-medium transition-colors group">
+                {#if pattern.icon && toolIcons[pattern.icon]}
+                  <div class="flex-shrink-0 w-5 h-5 mt-0.5">
+                    <svelte:component this={toolIcons[pattern.icon]} class="w-5 h-5" />
+                  </div>
+                {/if}
+                <span>{pattern.title}</span>
               </a>
               <p class="text-foreground-subtle text-xs mt-1">{pattern.description}</p>
             </div>


### PR DESCRIPTION
Add icon properties to all 7 architecture patterns (Prism, Songbird, Loom, Threshold, Sentinel, Firefly, Vineyard) and display them alongside pattern titles in the Knowledge page grid. Icons are sourced from the existing toolIcons registry using Lucide icons for consistency with the Prism design system.