### PR TITLE
fix(workshop): add missing icons to registry

### DIFF
--- a/landing/src/lib/utils/icons.ts
+++ b/landing/src/lib/utils/icons.ts
@@ -175,6 +175,13 @@ import {
   ScanQrCode,
   SendToBack,
   Regex,
+  // Icon additions for workshop TOC and tools
+  Pyramid,
+  Blinds,
+  RockingChair,
+  Toolbox,
+  Dock,
+  IdCardLanyard,
 } from 'lucide-svelte';
 
 // ============================================================================
@@ -393,6 +400,13 @@ export const toolIcons = {
   // Scout & Trove
   'shopping-basket': ShoppingBasket, // Scout - shopping research
   'scan-qr-code': ScanQrCode,    // Trove - book discovery
+  // Workshop TOC icons
+  pyramid: Pyramid,              // Core Infrastructure TOC
+  blinds: Blinds,                // Shade - AI protection
+  'rocking-chair': RockingChair, // Porch - front porch conversations
+  toolbox: Toolbox,              // Standalone Tools TOC
+  dock: Dock,                    // Operations TOC
+  'id-card-lanyard': IdCardLanyard, // Content & Community TOC
 } as const;
 
 // ============================================================================


### PR DESCRIPTION
The previous commits updated workshop icons to names that weren't
registered in the icon registry, causing fallback to circle icons.

Added to icons.ts:
- pyramid (Core Infrastructure TOC)
- blinds (Shade - AI protection)
- rocking-chair (Porch - front porch conversations)
- toolbox (Standalone Tools TOC)
- dock (Operations TOC)
- id-card-lanyard (Content & Community TOC)