### PR TITLE
fix(icons): replace non-existent Toolbox with Wrench icon

### DIFF
--- a/landing/src/lib/utils/icons.ts
+++ b/landing/src/lib/utils/icons.ts
@@ -179,7 +179,7 @@ import {
   Pyramid,
   Blinds,
   RockingChair,
-  Toolbox,
+  Wrench,
   Dock,
   IdCardLanyard,
 } from 'lucide-svelte';
@@ -404,7 +404,7 @@ export const toolIcons = {
   pyramid: Pyramid,              // Core Infrastructure TOC
   blinds: Blinds,                // Shade - AI protection
   'rocking-chair': RockingChair, // Porch - front porch conversations
-  toolbox: Toolbox,              // Standalone Tools TOC
+  toolbox: Wrench,               // Standalone Tools TOC
   dock: Dock,                    // Operations TOC
   'id-card-lanyard': IdCardLanyard, // Content & Community TOC
 } as const;


### PR DESCRIPTION
The Toolbox icon was added in a previous commit but doesn't exist in
lucide-svelte v0.554.0, causing builds to fail with:

"Toolbox" is not exported by lucide-svelte

Replaced with Wrench which serves the same purpose for the
"Standalone Tools TOC" category in the workshop page.