### PR TITLE
fix(engine): resolve TypeScript errors in auth rate limiting

### DIFF
--- a/packages/engine/src/lib/server/rate-limits/config.ts
+++ b/packages/engine/src/lib/server/rate-limits/config.ts
@@ -53,6 +53,7 @@ export const TIER_RATE_LIMITS = {
 export const ENDPOINT_RATE_LIMITS = {
 	// Auth endpoints (most sensitive)
 	'auth/login': { limit: 5, windowSeconds: 300 },
+	'auth/callback': { limit: 10, windowSeconds: 300 },
 	'auth/token': { limit: 10, windowSeconds: 60 },
 	'auth/password-reset': { limit: 3, windowSeconds: 3600 },
 
@@ -116,13 +117,22 @@ export interface RateLimitConfig {
 // ============================================================================
 
 /**
- * Get rate limit configuration for an endpoint.
+ * Get rate limit configuration for an endpoint by method and pathname.
  * Returns default limits if endpoint is not explicitly configured.
  */
 export function getEndpointLimit(method: string, pathname: string): RateLimitConfig {
 	const key = `${method}:${pathname}`;
 	const endpointKey = ENDPOINT_MAP[key] ?? 'default';
 	return ENDPOINT_RATE_LIMITS[endpointKey];
+}
+
+/**
+ * Get rate limit configuration by direct endpoint key.
+ * Use this when you know the endpoint key directly (e.g., 'auth/login', 'auth/callback').
+ * Returns default limits if the key is not found.
+ */
+export function getEndpointLimitByKey(key: EndpointKey): RateLimitConfig {
+	return ENDPOINT_RATE_LIMITS[key] ?? ENDPOINT_RATE_LIMITS['default'];
 }
 
 /**

--- a/packages/engine/src/lib/server/rate-limits/index.ts
+++ b/packages/engine/src/lib/server/rate-limits/index.ts
@@ -37,6 +37,7 @@ export {
 	ENDPOINT_RATE_LIMITS,
 	ENDPOINT_MAP,
 	getEndpointLimit,
+	getEndpointLimitByKey,
 	getTierLimit,
 	isValidTier
 } from './config.js';

--- a/packages/engine/src/routes/auth/callback/+server.ts
+++ b/packages/engine/src/routes/auth/callback/+server.ts
@@ -15,7 +15,7 @@ import {
   checkRateLimit,
   buildRateLimitKey,
   getClientIP,
-  getEndpointLimit,
+  getEndpointLimitByKey,
 } from "$lib/server/rate-limits";
 
 // ============================================================================
@@ -146,7 +146,7 @@ export const GET: RequestHandler = async ({
   const kv = platform?.env?.CACHE_KV;
   if (kv) {
     const clientIp = getClientIP(request);
-    const limitConfig = getEndpointLimit("auth/callback");
+    const limitConfig = getEndpointLimitByKey("auth/callback");
     const rateLimitKey = buildRateLimitKey("auth/callback", clientIp);
 
     const { response: rateLimitResponse } = await checkRateLimit({

--- a/packages/engine/src/routes/auth/login/start/+server.ts
+++ b/packages/engine/src/routes/auth/login/start/+server.ts
@@ -19,7 +19,7 @@ import {
   checkRateLimit,
   buildRateLimitKey,
   getClientIP,
-  getEndpointLimit,
+  getEndpointLimitByKey,
 } from "$lib/server/rate-limits";
 
 /**
@@ -61,7 +61,7 @@ export const GET: RequestHandler = async ({
   const kv = platform?.env?.CACHE_KV;
   if (kv) {
     const clientIp = getClientIP(request);
-    const limitConfig = getEndpointLimit("auth/login");
+    const limitConfig = getEndpointLimitByKey("auth/login");
     const rateLimitKey = buildRateLimitKey("auth/login", clientIp);
 
     const { response: rateLimitResponse } = await checkRateLimit({


### PR DESCRIPTION
Add getEndpointLimitByKey helper function for direct endpoint key
lookups, fixing the function signature mismatch where getEndpointLimit
expects (method, pathname) but was being called with just an endpoint
key. Also adds 'auth/callback' to ENDPOINT_RATE_LIMITS config.