### PR TITLE
refactor(auth): remove GitHub authentication from Heartwood

### DIFF
--- a/.claude/skills/heartwood-auth/SKILL.md
+++ b/.claude/skills/heartwood-auth/SKILL.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 ### Key Features
 
-- **OAuth Providers**: Google, GitHub
+- **OAuth Providers**: Google
 - **Magic Links**: Click-to-login emails via Resend
 - **Passkeys**: WebAuthn passwordless authentication
 - **KV-Cached Sessions**: Sub-100ms validation

--- a/docs/oauth-client-setup.md
+++ b/docs/oauth-client-setup.md
@@ -125,7 +125,7 @@ Add documentation comments to your site's `wrangler.toml`:
 2. Test the login flow:
    - Navigate to `https://yoursite.com/admin` (or protected route)
    - Should redirect to `https://auth.grove.place/login`
-   - Choose Google, GitHub, or Magic Code authentication
+   - Choose Google or Magic Code authentication
    - After authentication, should redirect back to `/auth/callback`
    - Should create session and redirect to your app
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,6 @@ The groundwork laid in stillness. Foundations built when no one was watching.
 
 - [x] **Authentication (Heartwood):** Secure OAuth 2.0 + PKCE
   - Google OAuth provider
-  - GitHub OAuth provider
   - Magic code email auth via Resend
   - Session management in D1
   - Cross-subdomain cookies
@@ -67,7 +66,7 @@ Grove opens its doors. The first trees take root.
 ### Active Work
 
 - [x] **Sign Up Flow:** plant.grove.place
-  - Google, GitHub, email auth options
+  - Google, email auth options
   - Profile creation with username
   - Plan selection (Seedling/Sapling/Oak/Evergreen)
   - Stripe checkout integration

--- a/docs/specs/heartwood-spec.md
+++ b/docs/specs/heartwood-spec.md
@@ -61,7 +61,7 @@ GroveAuth is a centralized authentication service that handles all authenticatio
 ### Goals
 
 - **Single source of truth** for user authentication
-- **Multiple auth providers** (Google, GitHub, Magic Code)
+- **Multiple auth providers** (Google, Magic Code)
 - **Secure token-based sessions** that client sites can verify
 - **Simple integration** for any site in the AutumnsGrove ecosystem
 - **Admin-only access** (no public registration - allowlist based)
@@ -96,10 +96,9 @@ GroveAuth is a centralized authentication service that handles all authenticatio
 │                        GroveAuth Service                            │
 │                       auth.grove.place                              │
 │                                                                     │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                  │
-│  │   Google    │  │   GitHub    │  │ Magic Code  │                  │
-│  │   OAuth     │  │   OAuth     │  │   (Email)   │                  │
-│  └─────────────┘  └─────────────┘  └─────────────┘                  │
+│  ┌─────────────────────────┐  ┌─────────────────────────┐          │
+│  │      Google OAuth      │  │   Magic Code (Email)    │          │
+│  └─────────────────────────┘  └─────────────────────────┘          │
 │                                                                     │
 │  ┌─────────────────────────────────────────────────────┐            │
 │  │              Session & Token Management             │            │
@@ -186,22 +185,7 @@ GroveAuth is a centralized authentication service that handles all authenticatio
 - Name (display purposes)
 - Profile picture URL (optional)
 
-### 2. GitHub OAuth
-
-**Purpose**: Alternative sign-in for developers
-
-**Flow**: Authorization Code Grant
-
-**Scopes Required**:
-- `user:email`
-- `read:user`
-
-**Data Retrieved**:
-- Email address (primary identifier)
-- Username
-- Avatar URL (optional)
-
-### 3. Magic Code (Email)
+### 2. Magic Code (Email)
 
 **Purpose**: Fallback for users who prefer email-based auth
 
@@ -241,7 +225,7 @@ CREATE TABLE users (
     email TEXT UNIQUE NOT NULL,             -- Primary identifier
     name TEXT,                              -- Display name
     avatar_url TEXT,                        -- Profile picture
-    provider TEXT NOT NULL,                 -- 'google', 'github', 'magic_code'
+    provider TEXT NOT NULL,                 -- 'google', 'magic_code'
     provider_id TEXT,                       -- ID from OAuth provider
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     last_login TEXT
@@ -346,8 +330,6 @@ https://auth.grove.place
 | GET | `/login` | Login page with provider selection |
 | GET | `/oauth/google` | Initiate Google OAuth |
 | GET | `/oauth/google/callback` | Google OAuth callback |
-| GET | `/oauth/github` | Initiate GitHub OAuth |
-| GET | `/oauth/github/callback` | GitHub OAuth callback |
 | POST | `/magic/send` | Send magic code email |
 | POST | `/magic/verify` | Verify magic code |
 | POST | `/token` | Exchange auth code for tokens |
@@ -375,7 +357,7 @@ https://auth.grove.place
 | `code_challenge` | No | PKCE challenge (recommended) |
 | `code_challenge_method` | No | Must be `S256` if challenge provided |
 
-**Response**: HTML login page with Google, GitHub, and Magic Code options
+**Response**: HTML login page with Google and Magic Code options
 
 **Error Responses**:
 - `400` - Missing required parameters
@@ -413,30 +395,6 @@ https://auth.grove.place
 ```
 {redirect_uri}?error=access_denied&error_description=...&state={state}
 ```
-
----
-
-#### `GET /oauth/github`
-
-**Purpose**: Initiate GitHub OAuth flow
-
-**Query Parameters**: Same as `/login`
-
-**Response**: `302` Redirect to GitHub OAuth consent screen
-
----
-
-#### `GET /oauth/github/callback`
-
-**Purpose**: Handle GitHub OAuth callback
-
-**Query Parameters**:
-| Parameter | Description |
-|-----------|-------------|
-| `code` | Authorization code from GitHub |
-| `state` | State parameter for CSRF verification |
-
-**Response**: Same as Google callback
 
 ---
 
@@ -1065,8 +1023,6 @@ AUTH_BASE_URL = "https://auth.grove.place"
 # JWT_PUBLIC_KEY - RSA public key for verifying JWTs (PEM format)
 # GOOGLE_CLIENT_ID - Google OAuth client ID
 # GOOGLE_CLIENT_SECRET - Google OAuth client secret
-# GITHUB_CLIENT_ID - GitHub OAuth client ID
-# GITHUB_CLIENT_SECRET - GitHub OAuth client secret
 # RESEND_API_KEY - Resend API key for sending emails
 ```
 
@@ -1099,8 +1055,7 @@ groveauth/
 │   ├── routes/
 │   │   ├── login.ts          # Login page handler
 │   │   ├── oauth/
-│   │   │   ├── google.ts     # Google OAuth handlers
-│   │   │   └── github.ts     # GitHub OAuth handlers
+│   │   │   └── google.ts     # Google OAuth handlers
 │   │   ├── magic.ts          # Magic code handlers
 │   │   ├── token.ts          # Token exchange handlers
 │   │   └── verify.ts         # Token verification
@@ -1170,7 +1125,6 @@ groveauth/
 - [ ] Run schema migrations
 - [ ] Generate RSA keypair for JWT signing
 - [ ] Set up Google OAuth credentials (console.cloud.google.com)
-- [ ] Set up GitHub OAuth app (github.com/settings/developers)
 - [ ] Set up Resend account and verify domain
 - [ ] Configure DNS for auth.grove.place
 - [ ] Set all secrets via `wrangler secret put`
@@ -1213,7 +1167,7 @@ groveauth/
 | **Authorization Code** | Short-lived code exchanged for tokens |
 | **PKCE** | Proof Key for Code Exchange - prevents code interception |
 | **Client** | A registered application that uses GroveAuth |
-| **Provider** | Authentication method (Google, GitHub, Magic Code) |
+| **Provider** | Authentication method (Google, Magic Code) |
 
 ---
 

--- a/docs/specs/tenant-onboarding-implementation-plan.md
+++ b/docs/specs/tenant-onboarding-implementation-plan.md
@@ -32,7 +32,7 @@
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | **Subdomain** | `create.grove.place` | Dedicated signup experience, separate from landing |
-| **Auth Provider** | Heartwood (GroveAuth) | Already integrated; handles Google, GitHub, magic code |
+| **Auth Provider** | Heartwood (GroveAuth) | Already integrated; handles Google, magic code |
 | **Auth Flow** | Heartwood first → collect profile after | Leverages existing OAuth, avoids duplicate systems |
 | **Tour Location** | `example.grove.place` + `autumnsgrove.com` | Demo site (Midnight Bloom) + real-world example |
 | **D1 Creation** | After profile completion (free) or payment (paid) | Ensures commitment before provisioning |
@@ -49,7 +49,7 @@
 │     └─→ "Start your blog" button → create.grove.place                       │
 │                                                                             │
 │  2. Create Subdomain (create.grove.place)                                   │
-│     ├─→ /                     Welcome + auth options (Google/GitHub/Email)  │
+│     ├─→ /                     Welcome + auth options (Google/Email)         │
 │     ├─→ /auth/callback        Heartwood callback → redirect to /profile     │
 │     ├─→ /profile              Collect: username, display name, color, etc.  │
 │     ├─→ /plans                Select plan (Seedling/Sapling/Oak/Evergreen)  │
@@ -207,7 +207,7 @@ INSERT OR IGNORE INTO reserved_usernames (username, reason) VALUES
 │   │   │   ├── email.ts                    # Email sending
 │   │   │   └── validation.ts               # Username validation
 │   │   └── components/
-│   │       ├── AuthButtons.svelte          # Google/GitHub/Email buttons
+│   │       ├── AuthButtons.svelte          # Google/Email buttons
 │   │       ├── UsernameInput.svelte        # Username with availability check
 │   │       ├── ColorPicker.svelte          # Favorite color selector
 │   │       ├── InterestsPicker.svelte      # Multi-select interests
@@ -229,14 +229,14 @@ INSERT OR IGNORE INTO reserved_usernames (username, reason) VALUES
 #### 3.1 Welcome Page (`/`)
 
 ```svelte
-<!-- Shows auth options: Google, GitHub, Email -->
+<!-- Shows auth options: Google, Email -->
 <!-- Warm welcome message -->
 <!-- Links to pricing for comparison -->
 <!-- Progress indicator: Step 1 of 4 -->
 ```
 
 **Functionality:**
-- Display auth buttons (Google, GitHub, Magic Code)
+- Display auth buttons (Google, Magic Code)
 - Each button initiates Heartwood OAuth with appropriate provider
 - Store `return_to` in cookie for post-auth redirect
 
@@ -244,7 +244,7 @@ INSERT OR IGNORE INTO reserved_usernames (username, reason) VALUES
 
 **`/auth` (GET):**
 - Initiate Heartwood OAuth
-- Query param: `?provider=google|github|email`
+- Query param: `?provider=google|email`
 - Set PKCE state cookies
 - Redirect to GroveAuth authorize endpoint
 

--- a/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/landing/src/routes/roadmap/workshop/+page.svelte
@@ -80,7 +80,7 @@
 				{
 					name: 'Heartwood',
 					tagline: 'Centralized Authentication',
-					description: 'One identity, verified and protected, that works across every Grove property. Google OAuth, GitHub, or magic email codes, all secured with PKCE, rate limiting, and comprehensive audit logging. The authentic core of the ecosystem.',
+					description: 'One identity, verified and protected, that works across every Grove property. Google OAuth or magic email codes, all secured with PKCE, rate limiting, and comprehensive audit logging. The authentic core of the ecosystem.',
 					status: 'live',
 					icon: 'shieldcheck',
 					domain: 'heartwood.grove.place',
@@ -88,7 +88,6 @@
 					github: 'https://github.com/AutumnsGrove/GroveAuth',
 					subComponents: [
 						{ name: 'Google', icon: 'chrome', description: 'Google OAuth' },
-						{ name: 'GitHub', icon: 'github', description: 'GitHub OAuth' },
 						{ name: 'Magic', icon: 'wand2', description: 'Email magic links' },
 						{ name: 'Identity', icon: 'idcard', description: 'Verified identity' }
 					]

--- a/packages/engine/src/app.d.ts
+++ b/packages/engine/src/app.d.ts
@@ -18,7 +18,7 @@ declare global {
         name?: string;
         /** Profile picture URL */
         picture?: string;
-        /** Auth provider (google, github, magic_code) */
+        /** Auth provider (google, magic_code) */
         provider?: string;
         /** Whether user has admin privileges */
         isAdmin?: boolean;

--- a/packages/engine/src/lib/groveauth/types.ts
+++ b/packages/engine/src/lib/groveauth/types.ts
@@ -46,7 +46,7 @@ export interface UserInfo {
   email: string;
   name: string | null;
   picture: string | null;
-  provider: "google" | "github" | "magic_code";
+  provider: "google" | "magic_code";
 }
 
 export interface LoginUrlResult {

--- a/plant/src/routes/+page.svelte
+++ b/plant/src/routes/+page.svelte
@@ -9,7 +9,6 @@
 		Mail,
 		LogIn,
 		ChevronDown,
-		Github,
 		// Feature icons
 		Leaf,
 		Shield,
@@ -339,12 +338,6 @@
 					<a href="/auth?provider=google" class="btn-auth bg-grove-600 hover:bg-grove-700 text-white border-grove-600 hover:border-grove-700">
 						{@html GoogleIcon}
 						<span>Continue with Google</span>
-					</a>
-
-					<!-- GitHub -->
-					<a href="/auth?provider=github" class="btn-auth">
-						<Github class="w-5 h-5" />
-						<span>Continue with GitHub</span>
 					</a>
 
 					<!-- Divider -->

--- a/plant/src/routes/auth/+server.ts
+++ b/plant/src/routes/auth/+server.ts
@@ -2,7 +2,7 @@
  * OAuth Initiation - Start Heartwood OAuth flow
  *
  * Redirects to GroveAuth with PKCE parameters.
- * Supports providers: google, github, email
+ * Supports providers: google, email
  */
 
 import { redirect } from "@sveltejs/kit";
@@ -43,7 +43,7 @@ async function generatePKCE(): Promise<{
 
 export const GET: RequestHandler = async ({ url, cookies, platform }) => {
   const provider = url.searchParams.get("provider") || "google";
-  const validProviders = ["google", "github", "email"];
+  const validProviders = ["google", "email"];
 
   if (!validProviders.includes(provider)) {
     redirect(302, "/?error=invalid_provider");


### PR DESCRIPTION
GitHub signups aren't working and are being removed from the platform.
Authentication is now limited to Google OAuth and magic email codes.

Changes:
- Remove GitHub login button from plant homepage
- Remove github from valid providers in auth handler
- Update GroveAuth types to remove github provider option
- Update heartwood-spec.md to remove GitHub OAuth endpoints
- Update all documentation referencing GitHub auth