### PR TITLE
fix: resolve deployment type errors in plant package

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -173,6 +173,10 @@
     "./config/terrarium": {
       "types": "./dist/config/terrarium.d.ts",
       "default": "./dist/config/terrarium.js"
+    },
+    "./groveauth": {
+      "types": "./dist/groveauth/index.d.ts",
+      "default": "./dist/groveauth/index.js"
     }
   },
   "files": [

--- a/packages/engine/src/lib/ui/components/icons/index.ts
+++ b/packages/engine/src/lib/ui/components/icons/index.ts
@@ -66,6 +66,17 @@ export {
   TrendingUp,
   Users,
   Activity,
+  // Actions
+  Plus,
+  Copy,
+  Trash2,
+  RefreshCw,
+  // Authentication
+  Fingerprint,
+  Key,
+  Link2,
+  // Also export the authIcons map
+  authIcons,
 } from './lucide';
 
 export const ICONS_VERSION = '0.3.0';

--- a/plant/src/routes/account/+page.svelte
+++ b/plant/src/routes/account/+page.svelte
@@ -95,8 +95,8 @@
 		if (form?.success) {
 			if (form.action === 'enableTwoFactor' && form.qrCodeUrl) {
 				twoFactorSetupStep = 'qr';
-				twoFactorSecret = form.secret;
-				twoFactorQrCode = form.qrCodeUrl;
+				twoFactorSecret = form.secret ?? null;
+				twoFactorQrCode = form.qrCodeUrl ?? null;
 			} else if (form.action === 'verifyTwoFactor' && form.backupCodes) {
 				twoFactorSetupStep = 'backup';
 				backupCodes = form.backupCodes;


### PR DESCRIPTION
- Add groveauth export path to engine package.json
- Export missing icons (Fingerprint, Link2, Plus, Trash2, Copy, Key, RefreshCw) from icons module
- Fix type mismatch (undefined vs null) in plant account page 2FA setup