### PR TITLE
feat(knowledge-base): add Philosophy, Design, and Developer categories

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1295,6 +1295,12 @@ Create a dedicated `/vineyard/palettes` page showcasing ALL project color palett
 
 - [ ] Add usage examples for tenants
 - [ ] Write testing documentation
+- [ ] **Write AI Development Process Guide** — Document the full workflow for building Grove with Claude Code, Kilo Code, and AI-assisted development
+  - How to structure prompts and context
+  - Working with Claude Code CLI vs web vs mobile
+  - The mental model behind rapid prototyping with AI
+  - Tips for maintaining code quality at speed
+  - Placeholder added to Knowledge Base at `/knowledge/developer/ai-development-process`
 
 ---
 

--- a/docs/design/grove-product-standards.md
+++ b/docs/design/grove-product-standards.md
@@ -1,0 +1,331 @@
+# Grove Product Standards
+
+> *How we build things in the Grove.*
+
+---
+
+## Repository Architecture
+
+Grove follows a **monorepo-per-product** architecture. Each product with a public-facing domain gets its own repository that imports `groveengine` as the shared foundation.
+
+> **Note:** The npm package is currently published as `groveengine`. It will be renamed to `@autumnsgrove/lattice` in a future release.
+
+### The Pattern
+
+```
+GroveEngine/              ← Lattice: shared npm package
+├── src/                  ← UI components, utilities, patterns
+├── docs/specs/           ← Planning docs for all products (pre-implementation)
+└── package.json          ← groveengine (future: @autumnsgrove/lattice)
+
+grove-ivy/                ← Ivy: standalone product
+├── src/                  ← SvelteKit app
+├── package.json          ← depends on groveengine
+└── wrangler.toml         ← Cloudflare Workers config
+
+grove-amber/             ← Amber: standalone product
+├── ...
+└── package.json          ← depends on groveengine
+```
+
+### What Goes Where
+
+| Content | Location |
+|---------|----------|
+| **Specs & Planning** | `GroveEngine/docs/specs/` (until implementation) |
+| **Shared UI Components** | `GroveEngine/src/` (Lattice) |
+| **Shared Utilities** | `GroveEngine/src/` (Lattice) |
+| **Product Frontend** | Product's own repo |
+| **Product Backend/Workers** | Product's own repo |
+| **Product-Specific Assets** | Product's own repo |
+
+---
+
+## Product Categories
+
+### External Products (Own Repo Required)
+
+Products with public domains that users interact with directly:
+
+| Product | Public Name | Domain | Repo |
+|---------|-------------|--------|------|
+| GroveMail | **Ivy** | ivy.grove.place | `grove-ivy` |
+| GroveStorage | **Amber** | amber.grove.place | `grove-amber` |
+| GroveSocial | **Meadow** | meadow.grove.place | `grove-meadow` |
+| GroveDomainTool | **Forage** | forage.grove.place | `grove-forage` |
+| TreasureTrove | **Trove** | trove.grove.place | `grove-trove` |
+| GroveMusic | **Aria** | aria.grove.place | `grove-aria` |
+| GroveMC | **Outpost** | mc.grove.place | `grove-outpost` |
+
+### External Services (Own Repo, No User-Facing Frontend)
+
+Backend services that need isolation for security or operational reasons:
+
+| Product | Public Name | Repo | Reason |
+|---------|-------------|------|--------|
+| GroveAuth | **Heartwood** | `GroveAuth` | Security isolation |
+| GrovePatina | **Patina** | `Patina` | Operational isolation |
+
+### Internal/Integrated (Stay in Lattice)
+
+Features that are deeply embedded in other products:
+
+| Product | Public Name | Location | Reason |
+|---------|-------------|----------|--------|
+| GroveAnalytics | **Rings** | Integrated into admin | Not standalone |
+| GroveEngine | **Lattice** | This repo | Is the foundation |
+
+---
+
+## Standard Repository Structure
+
+Every Grove product repo should follow this structure:
+
+```
+grove-{product}/
+├── .github/
+│   └── workflows/          # CI/CD (deploy to Cloudflare)
+├── src/
+│   ├── routes/             # SvelteKit routes
+│   ├── lib/
+│   │   ├── components/     # Product-specific components
+│   │   ├── server/         # Server-only code (Workers)
+│   │   └── stores/         # Svelte stores
+│   └── app.html
+├── static/                 # Static assets
+├── tests/
+│   ├── unit/
+│   └── e2e/
+├── docs/                   # Product-specific docs (if needed)
+├── package.json
+├── svelte.config.js
+├── wrangler.toml           # Cloudflare Workers config
+├── AGENT.md                # AI agent instructions
+├── CLAUDE.md               # Points to AGENT.md
+└── README.md
+```
+
+### Package.json Requirements
+
+```json
+{
+  "name": "grove-{product}",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "wrangler pages dev",
+    "deploy": "wrangler pages deploy",
+    "test": "vitest",
+    "lint": "eslint .",
+    "check": "svelte-check"
+  },
+  "dependencies": {
+    "groveengine": "^latest"
+  }
+}
+```
+
+### Wrangler.toml Template
+
+```toml
+name = "grove-{product}"
+compatibility_date = "2024-01-01"
+
+[vars]
+ENVIRONMENT = "production"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "grove-{product}"
+database_id = "..."
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "grove-storage"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "..."
+```
+
+---
+
+## Lattice Integration
+
+Every Grove product imports Lattice (currently `groveengine`) for shared functionality:
+
+### What Lattice Provides
+
+```typescript
+// UI Components
+import { Button, Card, Modal, Toast } from 'groveengine';
+import { GroveLayout, Sidebar, Header } from 'groveengine/layout';
+
+// Authentication
+import { requireAuth, getUser, withHeartwood } from 'groveengine/auth';
+
+// Database Patterns
+import { createD1Client, withTransaction } from 'groveengine/db';
+
+// Utilities
+import { formatDate, slugify, debounce } from 'groveengine/utils';
+
+// Markdown
+import { renderMarkdown, parseMarkdown } from 'groveengine/markdown';
+
+// Theming
+import { theme, applyTheme } from 'groveengine/theme';
+```
+
+### What Products Own
+
+Products should NOT put these in Lattice:
+- Product-specific business logic
+- Product-specific API routes
+- Product-specific database schemas
+- Product-specific UI that won't be reused
+
+---
+
+## Naming Conventions
+
+### Public Names (User-Facing)
+
+Single evocative words from nature/shelter themes:
+- Ivy, Amber, Meadow, Acorn, Trove, Aria, Outpost
+- Used in marketing, UI, documentation
+- Domain: `{name}.grove.place`
+
+### Internal Names (Developer-Facing)
+
+`Grove{Thing}` pattern for clarity:
+- GroveMail, GroveStorage, GroveSocial, etc.
+- Used in code, logs, debugging
+- Repo: `grove-{lowercase}` or `Grove{Thing}`
+
+### Code Style
+
+```typescript
+// Constants: SCREAMING_SNAKE_CASE
+const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024;
+
+// Config objects: PRODUCT_CONFIG
+const IVY_CONFIG = { ... };
+const AMBER_CONFIG = { ... };
+
+// Functions: camelCase
+async function sendNewsletter() { ... }
+
+// Types/Interfaces: PascalCase
+interface EmailThread { ... }
+type StorageFile = { ... };
+```
+
+---
+
+## Development Workflow
+
+### Starting a New Product
+
+1. **Spec first**: Create spec in `GroveEngine/docs/specs/{product}-spec.md`
+2. **Get approval**: Review spec, iterate on design
+3. **Create repo**: `grove-{product}` following standard structure
+4. **Set up CI**: GitHub Actions for Cloudflare deployment
+5. **Import Lattice**: Add `@autumnsgrove/lattice` dependency
+6. **Build**: Implement against the spec
+7. **Move spec**: Optionally move spec to product repo's `/docs`
+
+### Making Changes to Lattice
+
+If a product needs new shared functionality:
+
+1. Check if it's truly reusable across products
+2. If yes → PR to GroveEngine, add to Lattice
+3. If no → Keep it in the product repo
+
+### Environment Setup
+
+All Grove products use:
+- **Runtime:** Cloudflare Workers
+- **Framework:** SvelteKit
+- **Database:** Cloudflare D1
+- **Storage:** Cloudflare R2
+- **Auth:** Heartwood (via Lattice)
+- **DNS:** Cloudflare
+
+---
+
+## Security Standards
+
+### Authentication
+
+All authenticated routes use Heartwood:
+
+```typescript
+// In +page.server.ts or +server.ts
+import { requireAuth } from 'groveengine/auth';
+
+export const load = async ({ cookies }) => {
+  const user = await requireAuth(cookies);
+  // user is guaranteed to exist here
+};
+```
+
+### Secrets Management
+
+- Never commit secrets
+- Use Cloudflare Workers secrets: `wrangler secret put SECRET_NAME`
+- Access via `env.SECRET_NAME` in Workers
+
+### Rate Limiting
+
+All public endpoints must have rate limiting:
+
+```typescript
+import { rateLimit } from 'groveengine/security';
+
+// In API route
+const allowed = await rateLimit(env.KV, request, {
+  limit: 100,
+  window: '1h',
+});
+```
+
+---
+
+## Migration Checklist
+
+When migrating a product out of GroveEngine:
+
+- [ ] Create new repo with standard structure
+- [ ] Copy product-specific code (routes, components, logic)
+- [ ] Update imports to use `@autumnsgrove/lattice`
+- [ ] Set up wrangler.toml with correct bindings
+- [ ] Configure GitHub Actions for deployment
+- [ ] Update DNS to point to new deployment
+- [ ] Remove old code from GroveEngine
+- [ ] Update any cross-references in other products
+
+---
+
+## Current Status
+
+| Product | Spec | Repo | Frontend | Backend | Status |
+|---------|:----:|:----:|:--------:|:-------:|--------|
+| Ivy | ✓ | — | — | — | Spec complete |
+| Amber | ✓ | — | — | — | Spec complete |
+| Acorn | — | ✓ | ⚠️ In GroveEngine | ✓ | Needs frontend migration |
+| Heartwood | — | ✓ | ✓ | ✓ | Complete |
+| Patina | ✓ | ✓ | — | — | Spec updated, repo exists |
+| Meadow | — | — | — | — | Not started |
+| Trove | — | — | — | — | Not started |
+| Aria | — | — | — | — | Not started |
+| Outpost | — | — | — | — | Not started |
+| Rings | — | — | — | — | Will be integrated |
+
+---
+
+*Last updated: December 2025*
+*Maintainer: Grove Engineering*

--- a/docs/design/grove-ui-patterns.md
+++ b/docs/design/grove-ui-patterns.md
@@ -1,0 +1,278 @@
+# Grove UI Patterns
+
+> *Every design choice should feel welcoming, organic, readable, and alive.*
+
+Grove is a place. Nature-themed, warm, inviting. Like a midnight tea shop with good documentation. This guide covers the visual patterns that make Grove feel like home.
+
+---
+
+## Core Principles
+
+From the project's guiding philosophy:
+
+> Write with the warmth of a midnight tea shop and the clarity of good documentation.
+
+**Every design choice should feel:**
+- **Welcoming** — like entering a cozy space
+- **Organic** — natural, not rigid or corporate
+- **Readable** — content-first, decorations enhance, never obstruct
+- **Alive** — subtle animations, seasonal changes, randomization
+
+---
+
+## Glassmorphism
+
+Glass effects create readability while revealing hints of background decoration.
+
+### The Layering Formula
+
+```
+Background (gradients, vines, nature)
+    ↓
+Decorative Elements (trees, clouds, particles)
+    ↓
+Glass Surface (translucent + blur)
+    ↓
+Content (text, cards, UI)
+```
+
+### Glass Variants
+
+| Variant | Use Case | Light Mode | Dark Mode |
+|---------|----------|------------|-----------|
+| `surface` | Headers, navbars | 95% white | 95% slate |
+| `tint` | Text over backgrounds | 60% white | 50% slate |
+| `card` | Content cards | 80% white | 70% slate |
+| `accent` | Callouts, highlights | 30% accent | 20% accent |
+| `overlay` | Modal backdrops | 50% black | 60% black |
+| `muted` | Subtle backgrounds | 40% white | 30% slate |
+
+### Usage
+
+```svelte
+import { Glass, GlassCard, GlassButton } from '@groveengine/ui/ui';
+
+<Glass variant="tint" class="p-6 rounded-xl">
+  <p>Readable text over busy backgrounds</p>
+</Glass>
+
+<GlassCard title="Settings" variant="default" hoverable>
+  Content here
+</GlassCard>
+
+<GlassButton variant="accent">Subscribe</GlassButton>
+```
+
+---
+
+## Seasonal Theme System
+
+Grove uses four seasons, each with distinct colors, weather effects, and moods.
+
+| Season | Primary Colors | Mood |
+|--------|---------------|------|
+| **Spring** | Yellow-green new growth, cherry blossoms, wildflowers | Renewal, hope |
+| **Summer** | Deep greens, pink blossoms | Growth, warmth |
+| **Autumn** | Amber, rust, gold, maple reds | Harvest, reflection |
+| **Winter** | Frost, snow, frosted evergreens | Rest, stillness |
+
+### Color Palette Organization
+
+Colors are organized **dark-to-light** for atmospheric depth. Darker colors go in the background, lighter in the foreground.
+
+```typescript
+import { greens, autumn, winter, springFoliage } from '@autumnsgrove/groveengine/ui/nature';
+
+// Dark to light
+greens.darkForest  // Background trees
+greens.deepGreen   // Mid-distance
+greens.grove       // Grove brand primary
+greens.meadow      // Standard foliage
+greens.mint        // Light accent
+```
+
+### Seasonal Weather Effects
+
+```svelte
+<!-- Winter -->
+<SnowfallLayer count={40} zIndex={5} opacity={{ min: 0.4, max: 0.8 }} />
+
+<!-- Spring -->
+<FallingPetalsLayer count={80} zIndex={100} />
+
+<!-- Autumn -->
+<FallingLeavesLayer trees={forestTrees} season={$season} />
+```
+
+---
+
+## Randomized Forests
+
+The forest should feel alive and different every visit.
+
+### Key Principles
+
+1. **Generate on mount** — Trees generate once when page loads
+2. **Stable during reading** — Never regenerate on scroll
+3. **Respect spacing** — 8% minimum gap between trees
+4. **Create depth** — Larger trees = higher z-index, higher opacity
+
+### Aspect Ratio for Natural Variation
+
+```typescript
+const TREE_ASPECT_RATIO_RANGE = { min: 1.0, max: 1.5 };
+// height = size * aspectRatio
+```
+
+### Responsive Density
+
+```typescript
+if (width < 768) return 1;        // Mobile: base count
+if (width < 1024) return 1.3;     // Tablet
+if (width < 1440) return 1.8;     // Desktop
+if (width < 2560) return 2.5;     // Large desktop
+return 3.5;                        // Ultrawide
+```
+
+---
+
+## Icons: Lucide Only
+
+**NEVER use emojis. ALWAYS use Lucide icons.**
+
+```svelte
+import { MapPin, Check, Leaf, Trees, Mail } from 'lucide-svelte';
+
+<!-- Good -->
+<MapPin class="w-4 h-4" />
+
+<!-- Bad - NEVER do this -->
+<!-- ❌ 🌱 📧 ✅ -->
+```
+
+### Standard Icon Mapping
+
+| Concept | Icon |
+|---------|------|
+| Home | `Home` |
+| Vision | `Telescope` |
+| Pricing | `HandCoins` |
+| Knowledge | `BookOpen` |
+| Forest | `Trees` |
+| Email | `Mail` |
+| Storage | `HardDrive` |
+| Success | `Check` |
+| Error | `X` |
+| Loading | `Loader2` (with animate-spin) |
+| Growth | `Sprout` |
+
+### Icon Sizing
+
+```svelte
+<!-- Inline with text -->
+<span class="inline-flex items-center gap-1.5">
+  <Leaf class="w-4 h-4" /> Feature name
+</span>
+
+<!-- Button icon -->
+<button class="p-2"><Menu class="w-5 h-5" /></button>
+
+<!-- Large decorative -->
+<Gem class="w-8 h-8 text-amber-400" />
+```
+
+---
+
+## Icon Composition
+
+> *"The grove doesn't need to be drawn. It just needs to be arranged."*
+
+For custom logos and illustrations, compose existing Lucide icons rather than drawing custom SVG.
+
+### Why This Works
+
+- **Consistency** — Icons match Lucide aesthetic (24x24 grid, 2px strokes)
+- **Maintainable** — Updating Lucide updates your compositions
+- **MIT licensed** — All paths come from open-source icons
+
+### Transform Cheatsheet
+
+| Transform | Effect |
+|-----------|--------|
+| `translate(x, y)` | Move origin |
+| `scale(s)` | Uniform size |
+| `rotate(deg, cx, cy)` | Rotation around point |
+
+### Create Depth
+
+- Larger = foreground (opacity 0.9)
+- Smaller = background (opacity 0.5-0.7)
+
+---
+
+## Midnight Bloom Palette
+
+For dreamy, far-future, mystical content. The tea shop at the edge of tomorrow.
+
+```typescript
+midnightBloom.deepPlum   // #581c87 - Night sky depth
+midnightBloom.purple     // #7c3aed - Soft purple glow
+midnightBloom.violet     // #8b5cf6 - Lighter accent
+midnightBloom.amber      // #f59e0b - Lantern warmth
+midnightBloom.warmCream  // #fef3c7 - Tea steam, page glow
+midnightBloom.softGold   // #fcd34d - Fairy lights
+```
+
+Use with stars, moon, fireflies, and purple glass effects for nighttime sections.
+
+---
+
+## Mobile Considerations
+
+### Decorative Elements
+
+| Element | Mobile Treatment |
+|---------|-----------------|
+| Trees | Reduce count (density = 1) |
+| Particles | Reduce count (40→20) |
+| Clouds | Keep 2-3 |
+| Touch targets | Minimum 44x44px |
+
+### Respect Reduced Motion
+
+```svelte
+{#if !prefersReducedMotion}
+  <FallingLeavesLayer ... />
+{/if}
+```
+
+---
+
+## When to Use / When Not to Use
+
+| Pattern | Good For | Avoid When |
+|---------|----------|------------|
+| **Glassmorphism** | Text over backgrounds, navbars, cards | Data-dense pages, forms |
+| **Randomized forests** | Story pages, about pages | Simple informational content |
+| **Seasonal themes** | Roadmaps, emotional storytelling | Brand-critical contexts |
+| **Midnight Bloom** | Future features, dreams | Practical documentation |
+| **Weather particles** | Hero sections, transitions | Performance-critical pages |
+
+---
+
+## Quick Checklist
+
+Before shipping a Grove page:
+
+- [ ] Glass effects used for text readability?
+- [ ] Lucide icons, no emojis?
+- [ ] Mobile overflow menu for navigation?
+- [ ] Decorative elements respect `prefers-reduced-motion`?
+- [ ] Touch targets at least 44x44px?
+- [ ] Seasonal colors match emotional tone?
+- [ ] Trees have proper spacing (8% minimum gap)?
+- [ ] Dark mode supported?
+
+---
+
+*Every pixel is an invitation. Make it feel like home.*

--- a/docs/design/icon-standards.md
+++ b/docs/design/icon-standards.md
@@ -1,0 +1,201 @@
+# Icon Standards
+
+> *Icons enhance accessibility, visual hierarchy, and consistency across the entire platform.*
+
+Grove uses **Lucide icons exclusively**. No emojis in UI components.
+
+---
+
+## The Rules
+
+1. **Never use emojis** in UI components
+2. **Always use the centralized icon registry** (`landing/src/lib/utils/icons.ts`)
+3. **Never import lucide-svelte directly** in components
+4. **Be consistent** — use the same icon for the same concept everywhere
+
+---
+
+## Icon Registry
+
+### Navigation
+
+| Concept | Icon | Usage |
+|---------|------|-------|
+| Home | `Home` | Landing page, return home |
+| About | `Info` | Information, learn more |
+| Vision | `Telescope` | Looking forward, future plans |
+| Roadmap | `MapPin` | Journey, development phases |
+| Pricing | `HandCoins` | Costs, subscription tiers |
+| Knowledge | `BookOpen` | Learning, documentation |
+| Forest | `Trees` | Grove blogs, community content |
+| Blog | `PenLine` | Writing, personal blog |
+
+### Features
+
+| Concept | Icon | Usage |
+|---------|------|-------|
+| Email | `Mail` | Email contact, inbox |
+| Storage | `HardDrive` | File storage, data |
+| Theming | `Palette` | Color customization, design |
+| Authentication | `ShieldCheck` | Security, identity |
+| Cloud | `Cloud` | Remote, serverless, sync |
+| Search | `SearchCode` | Advanced search, discovery |
+| Archives | `Archive` | Backups, history |
+| Upload | `Upload` | File upload, content creation |
+| Comments | `MessagesSquare` | User discussions, feedback |
+| External | `ExternalLink` | Opens new tab |
+| GitHub | `Github` | Repository links |
+
+### Content & Growth
+
+| Concept | Icon | Usage |
+|---------|------|-------|
+| Posts | `FileText` | Blog posts, articles |
+| Tags | `Tag` | Categorization, taxonomy |
+| Growth | `Sprout` | New beginnings, progress |
+| Heart | `Heart` | Love, care, favorites |
+| Location | `MapPin` | Current position |
+
+### States
+
+| Concept | Icon | Usage |
+|---------|------|-------|
+| Success | `Check` | Verified, done |
+| Error | `X` | Error, dismiss, close |
+| Loading | `Loader2` | In progress (with animate-spin) |
+| Info | `Info` | Information, help |
+| Warning | `AlertTriangle` | Caution |
+| Help | `HelpCircle` | Support, questions |
+
+### Phases & Dreams
+
+| Concept | Icon | Usage |
+|---------|------|-------|
+| Coming Soon | `Sprout` | Future growth |
+| Refinement | `Gem` | Quality, polish |
+| Mystical | `Sparkles` | Far future, dreams (use sparingly!) |
+| Night | `Star` | Night themes, hopes |
+| Moon | `Moon` | Night, resting |
+
+### Actions
+
+| Concept | Icon | Usage |
+|---------|------|-------|
+| Getting Started | `Compass` | Guidance, direction |
+| What's New | `Megaphone` | Announcements |
+| Next Steps | `Lightbulb` | Ideas, suggestions |
+| Download | `Download` | Export, get data |
+| Settings | `Settings` | Configuration |
+| Menu | `Menu` | Navigation menu |
+
+---
+
+## Seasonal Colors
+
+Icons should use seasonal colors based on context:
+
+| Season | Color Class |
+|--------|-------------|
+| Winter | `text-blue-500` or `text-slate-500` |
+| Spring | `text-teal-500` or `text-pink-500` |
+| Summer | `text-green-500` or `text-emerald-500` |
+| Autumn | `text-amber-500` or `text-orange-500` |
+| Midnight Bloom | `text-purple-300` or `text-amber-400` |
+
+### Status Colors
+
+| Status | Color Class |
+|--------|-------------|
+| Success | `text-green-500` |
+| Pending | `text-amber-500` |
+| Planned | `text-slate-400` |
+| Error | `text-red-500` |
+
+---
+
+## Implementation
+
+### The Icon Utility
+
+All icons are centralized in `landing/src/lib/utils/icons.ts`:
+
+```typescript
+import { featureIcons, navIcons, stateIcons } from '$lib/utils/icons';
+
+// Use in components
+{#each features as feature}
+  <svelte:component this={featureIcons[feature.icon]} class="w-5 h-5" />
+{/each}
+```
+
+### Sizing
+
+```svelte
+<!-- Inline with text -->
+<span class="inline-flex items-center gap-1.5">
+  <Leaf class="w-4 h-4" /> Feature name
+</span>
+
+<!-- Button icon -->
+<button class="p-2">
+  <Menu class="w-5 h-5" />
+</button>
+
+<!-- Large decorative -->
+<Gem class="w-8 h-8 text-amber-400" />
+```
+
+---
+
+## Icon Composition
+
+For custom logos and illustrations, compose existing Lucide icons rather than drawing custom SVG.
+
+### Why
+
+- **Consistency** — Icons match Lucide aesthetic (24x24 grid, 2px strokes, round caps)
+- **Maintainable** — Updating Lucide updates your compositions
+- **MIT licensed** — All paths come from open-source icons
+
+### Key Lucide Paths
+
+```typescript
+// TreePine - conifer silhouette
+const treePine = {
+  canopy: 'm17 14 3 3.3a1 1 0 0 1-.7 1.7H4.7a1 1 0 0 1-.7-1.7L7 14...',
+  trunk: 'M12 22v-3'
+};
+
+// Moon - crescent
+const moon = 'M20.985 12.486a9 9 0 1 1-9.473-9.472...';
+```
+
+### Creating Depth
+
+Use transforms to position, scale, and create depth:
+
+- Larger = foreground (opacity 0.9)
+- Smaller = background (opacity 0.5-0.7)
+
+```svelte
+<g transform="translate(2, 4) scale(0.85)"
+   stroke={color} stroke-width="2" opacity="0.9">
+  <path d={treePine.canopy} />
+</g>
+```
+
+---
+
+## Quick Reference
+
+| Do | Don't |
+|----|-------|
+| Use centralized icon registry | Import lucide-svelte directly |
+| Use Lucide icons | Use emojis |
+| Match icon to semantic meaning | Pick icons for decoration only |
+| Use consistent icons for concepts | Use different icons for same concept |
+| Apply seasonal/status colors | Use random colors |
+
+---
+
+*The full icon registry is at `landing/src/lib/utils/icons.ts`.*

--- a/docs/developer/ai-development-process.md
+++ b/docs/developer/ai-development-process.md
@@ -1,0 +1,71 @@
+# Building with AI: The Grove Development Process
+
+> *How Grove was built in 50 days using Claude Code, Kilo Code, and AI-assisted development.*
+
+---
+
+## Coming Soon
+
+This guide is being written. It will cover:
+
+### The Workflow
+
+- How to structure prompts and context effectively
+- Working with Claude Code CLI vs web vs mobile
+- When to use which interface
+- Managing long-running development sessions
+
+### The Mental Model
+
+- Thinking alongside AI instead of just prompting it
+- Breaking complex features into AI-friendly chunks
+- When to let AI lead vs when to direct specifically
+- Building intuition for what AI does well
+
+### Rapid Prototyping
+
+- Moving fast without breaking things
+- Using AI for exploration vs implementation
+- Iteration patterns that work at speed
+- Knowing when to slow down
+
+### Code Quality at Speed
+
+- Maintaining standards during rapid development
+- Review patterns for AI-generated code
+- Testing strategies when moving fast
+- Documentation that keeps pace
+
+### Tools Used
+
+- **Claude Code CLI** — Primary development interface
+- **Claude Web** — Mobile and browser-based sessions
+- **Kilo Code** — Additional AI coding assistant
+- **The skills system** — Custom workflows for common tasks
+
+---
+
+## Why This Matters
+
+Grove was built from scratch in under 50 days:
+
+- Full multi-tenant blogging platform
+- Authentication system (Heartwood)
+- Status page (Clearing)
+- Knowledge base with 300+ documents
+- 30+ technical specifications
+- Design system with seasonal themes
+- Nature components library
+- And much more
+
+This isn't about AI replacing developers. It's about a new way of working where AI amplifies what's possible for a solo developer or small team.
+
+---
+
+## Until Then
+
+Check the [credits page](/credits) for tool acknowledgments, or explore the [philosophy](/knowledge/philosophy) section to understand the thinking behind Grove.
+
+---
+
+*This guide will be written by Autumn when there's time to slow down and document the process properly.*

--- a/docs/developer/ai-gateway-integration.md
+++ b/docs/developer/ai-gateway-integration.md
@@ -1,0 +1,184 @@
+# AI Gateway Integration
+
+> *Central observability and per-tenant quota management for all AI features in Grove.*
+
+All AI features in Grove route through Cloudflare AI Gateway. This provides central observability, per-tenant quotas, cost attribution, and fallback routing.
+
+---
+
+## Architecture
+
+```
+User → Grove Worker → Cloudflare AI Gateway → OpenRouter → AI Providers
+                 ↑              ↑
+           Heartwood      Rate Limits
+           (tenant)       + Logging
+```
+
+### What This Gives Us
+
+- **Central observability** — One dashboard for all AI usage
+- **Per-tenant quotas** — Enforce limits based on pricing tiers
+- **Cost attribution** — Know which tenants consume what
+- **Fallback routing** — Resilience when upstream providers fail
+- **Guardrails** — Content filtering before requests hit providers
+
+---
+
+## Setup
+
+### 1. Create Gateway
+
+In Cloudflare Dashboard: **AI** → **AI Gateway** → **Create Gateway**
+
+Name it `grove-production` and note your `gateway_id` and `account_id`.
+
+### 2. Environment Variables
+
+```toml
+# wrangler.toml
+[vars]
+CF_ACCOUNT_ID = "your-account-id"
+CF_GATEWAY_ID = "grove-production"
+
+# In secrets (wrangler secret put)
+# CF_AIG_TOKEN = "your-aig-token"
+```
+
+---
+
+## Usage
+
+### The AI Client
+
+```typescript
+import { TenantContext } from '@grove/heartwood';
+
+interface AIRequestOptions {
+  tenant: TenantContext;
+  feature: string;  // 'post-summary', 'alt-text', etc.
+  userId?: string;
+}
+
+const baseUrl = `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}`;
+
+const response = await fetch(`${baseUrl}/compat/chat/completions`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'cf-aig-authorization': `Bearer ${aigToken}`,
+    'cf-aig-metadata': JSON.stringify({
+      tenant_id: options.tenant.id,
+      tenant_tier: options.tenant.pricingTier,
+      feature: options.feature,
+    }),
+  },
+  body: JSON.stringify({
+    model: `openrouter/${model}`,
+    messages,
+    max_tokens: 4096,
+  }),
+});
+```
+
+---
+
+## Per-Tenant Quotas
+
+Quotas are enforced in the Worker before requests hit the gateway:
+
+```typescript
+const quotas = {
+  seedling: { monthly: 0, maxTokensPerRequest: 0 },
+  oak: { monthly: 50, maxTokensPerRequest: 4096 },
+  evergreen: { monthly: 200, maxTokensPerRequest: 8192 },
+  centennial: { monthly: 500, maxTokensPerRequest: 16384 },
+};
+
+async function checkQuota(tenant: TenantContext, db: D1Database) {
+  const quota = quotas[tenant.pricingTier];
+  if (!quota.monthly) return { allowed: false, reason: 'NO_AI_ACCESS' };
+
+  const usage = await getMonthlyUsage(db, tenant.id);
+  if (usage >= quota.monthly) return { allowed: false, reason: 'QUOTA_EXCEEDED' };
+
+  return { allowed: true, remaining: quota.monthly - usage };
+}
+```
+
+### Pricing Tier Features
+
+| Tier | Monthly Requests | Max Tokens | Features |
+|------|------------------|------------|----------|
+| Seedling | 0 | — | No AI |
+| Oak | 50 | 4,096 | Alt-text, summaries |
+| Evergreen | 200 | 8,192 | + Writing assistance |
+| Centennial | 500 | 16,384 | + All features |
+
+---
+
+## Observability
+
+### Cloudflare Dashboard
+
+AI Gateway provides:
+- Request/response logging
+- Latency metrics
+- Token usage tracking
+- Error rates by provider
+
+### Custom Logging
+
+Log to D1 for per-tenant analytics:
+
+```typescript
+await db.prepare(`
+  INSERT INTO ai_usage (tenant_id, feature, model, tokens, cost, timestamp)
+  VALUES (?, ?, ?, ?, ?, ?)
+`).bind(tenantId, feature, model, tokens, cost, Date.now()).run();
+```
+
+---
+
+## Error Handling
+
+### Graceful Degradation
+
+```typescript
+try {
+  const result = await ai.chat(messages, model, options);
+  return { success: true, result };
+} catch (error) {
+  if (error instanceof QuotaExceededError) {
+    return { success: false, reason: 'quota_exceeded', message: 'AI limit reached for this month' };
+  }
+  if (error instanceof RateLimitError) {
+    return { success: false, reason: 'rate_limited', message: 'Try again in a moment' };
+  }
+  // Log and return generic error
+  console.error('AI error:', error);
+  return { success: false, reason: 'ai_unavailable', message: 'AI features temporarily unavailable' };
+}
+```
+
+### User-Facing Messages
+
+| Error | Message |
+|-------|---------|
+| Quota exceeded | "You've used all your AI requests for this month. Upgrade for more." |
+| Rate limited | "Please wait a moment before trying again." |
+| Provider error | "AI features are temporarily unavailable. Your content is saved." |
+
+---
+
+## Best Practices
+
+1. **Always include tenant metadata** — Every request needs tenant_id and tier
+2. **Check quotas before calling** — Don't waste gateway requests on denied users
+3. **Handle failures gracefully** — AI is optional, never block core functionality
+4. **Log everything** — You'll need usage data for billing and debugging
+5. **Use appropriate models** — Don't use expensive models for simple tasks
+
+---
+
+*The full integration guide is at `docs/grove-ai-gateway-integration.md`.*

--- a/docs/developer/cloudflare-infrastructure.md
+++ b/docs/developer/cloudflare-infrastructure.md
@@ -1,0 +1,189 @@
+# Cloudflare Infrastructure
+
+> *Workers for compute, D1 for databases, KV for caching, R2 for storage.*
+
+Grove is built entirely on Cloudflare's edge infrastructure. This guide covers the key services, their limits, and how we use them.
+
+---
+
+## The Stack
+
+| Service | Purpose | Grove Usage |
+|---------|---------|-------------|
+| **Workers** | Compute | API routes, server-side rendering |
+| **Pages** | Static hosting + Workers | Main site deployment |
+| **D1** | SQLite database | Posts, users, settings |
+| **KV** | Key-value cache | Config, sessions, content cache |
+| **R2** | Object storage | Images, media uploads |
+| **Durable Objects** | Stateful coordination | Rate limiting, real-time features |
+
+---
+
+## Critical Limits
+
+### Free Tier
+
+| Service | Limit | Notes |
+|---------|-------|-------|
+| Workers | 100K requests/day | Resets at midnight UTC |
+| D1 | 5M rows read/day, 100K writes/day | 500 MB per database |
+| KV | 100K reads/day, 1K writes/day | 1 GB total storage |
+| R2 | 10 GB storage | Zero egress fees |
+| DNS | 200-1000 records | Depends on zone creation date |
+
+### Workers Paid ($5/month)
+
+| Service | Included | Overage |
+|---------|----------|---------|
+| Workers | 10M requests/month | $0.30/million |
+| D1 reads | 25B rows/month | $0.001/million |
+| D1 writes | 50M rows/month | $1.00/million |
+| KV reads | 10M/month | $0.50/million |
+| R2 storage | 10 GB | $0.015/GB |
+
+---
+
+## Architecture Patterns
+
+### Wildcard Routing
+
+A single wildcard CNAME (`*.grove.place`) routes all subdomains to one Worker:
+
+```javascript
+export default {
+  async fetch(request, env) {
+    const hostname = new URL(request.url).hostname;
+    const tenantId = hostname.split('.')[0]; // username.grove.place → username
+
+    const tenantConfig = await env.KV.get(`tenant:${tenantId}:config`, 'json');
+    if (!tenantConfig) return new Response('Not found', { status: 404 });
+
+    return handleTenantRequest(tenantId, request, env);
+  }
+};
+```
+
+### KV Caching
+
+Cache D1 queries to stay within limits:
+
+```typescript
+async function getTenantConfig(env, tenantId: string) {
+  const cacheKey = `tenant:${tenantId}:config`;
+
+  // Try cache first
+  const cached = await env.KV.get(cacheKey, 'json');
+  if (cached) return cached;
+
+  // Miss: query D1
+  const result = await env.DB.prepare(
+    'SELECT * FROM tenants WHERE id = ?'
+  ).bind(tenantId).first();
+
+  // Store in cache (5 min TTL)
+  await env.KV.put(cacheKey, JSON.stringify(result), { expirationTtl: 300 });
+
+  return result;
+}
+```
+
+### R2 Media Storage
+
+Tenant-prefixed paths for isolation:
+
+```typescript
+async function uploadMedia(env, tenantId: string, file: File) {
+  const key = `tenants/${tenantId}/media/${Date.now()}-${file.name}`;
+  await env.R2_BUCKET.put(key, file.stream());
+  return `https://media.grove.place/${key}`;
+}
+```
+
+---
+
+## Cost Projections
+
+Assuming typical blog: 5,000 pageviews/month, 100 images (50 MB), 3 KV reads per page, 2 D1 queries per page.
+
+| Tenants | Monthly Cost | Per Tenant |
+|---------|-------------|------------|
+| 50 | $5.00 | $0.10 |
+| 100 | $5.00 | $0.05 |
+| 200 | $5.00 | $0.025 |
+| 500 | $6.13 | $0.012 |
+| 1,000 | $13.50 | $0.0135 |
+
+**Key insight:** Cloudflare exhibits strong economies of scale. Cost per tenant drops 97% from 10 to 1,000 clients.
+
+---
+
+## Data Isolation
+
+### D1: Shared Database + tenant_id
+
+Every table has a `tenant_id` column. Every query filters by it.
+
+```sql
+SELECT * FROM posts WHERE tenant_id = ? AND slug = ?
+```
+
+### KV: Key Prefixing
+
+```
+tenant:{tenantId}:{resource}:{id}
+tenant:dave:post:123
+tenant:dave:settings
+```
+
+### R2: Path Prefixing
+
+```
+tenants/{tenantId}/media/{year}/{month}/{filename}
+tenants/dave/media/2026/01/photo.jpg
+```
+
+---
+
+## SSL & Domains
+
+### Automatic SSL
+
+Universal SSL (free) covers:
+- `grove.place`
+- `*.grove.place` (all first-level subdomains)
+
+**Second-level subdomains** (like `admin.dave.grove.place`) require Advanced Certificate Manager ($10/month) or Business plan.
+
+### Custom Domains
+
+Cloudflare for SaaS: $0.10/month per custom domain
+
+- Automated SSL provisioning
+- Domain validation
+- CNAME flattening
+
+---
+
+## Performance Tips
+
+1. **Cache aggressively** — KV reads are much cheaper than D1 queries
+2. **Use `waitUntil()`** — For async cache updates after response
+3. **Minimize D1 writes** — 1000/minute limit is the real constraint
+4. **R2 egress is free** — Serve media directly from R2, not through Workers
+5. **Use Durable Objects sparingly** — They have per-request costs
+
+---
+
+## Local Development
+
+```bash
+# Start local dev with all bindings
+wrangler pages dev --d1=DB --kv=KV --r2=R2_BUCKET
+
+# Seed local D1
+wrangler d1 execute DB --local --file=./schema.sql
+```
+
+---
+
+*The full infrastructure guide is at `docs/cloudflare-architecture-guide.md`.*

--- a/docs/developer/multi-tenant-architecture.md
+++ b/docs/developer/multi-tenant-architecture.md
@@ -1,0 +1,144 @@
+# Multi-Tenant Architecture
+
+> *Single deployment serving all tenants, like YouTube or Twitter.*
+
+Grove uses a multi-tenant architecture where a single codebase serves all users. Each user gets their own subdomain (`username.grove.place`) while sharing underlying infrastructure.
+
+---
+
+## The Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    grove-router Worker                      │
+│              (catches *.grove.place requests)               │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   groveengine Pages                         │
+│                  (single deployment)                        │
+├─────────────────────────────────────────────────────────────┤
+│  hooks.server.ts                                            │
+│  ├── Extract subdomain from X-Forwarded-Host                │
+│  ├── Look up tenant in D1                                   │
+│  └── Set context: { type: 'tenant', tenant: {...} }         │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+          ┌───────────────┼───────────────┐
+          ▼               ▼               ▼
+      ┌───────┐      ┌───────┐      ┌───────┐
+      │  D1   │      │  R2   │      │  KV   │
+      │(data) │      │(media)│      │(cache)│
+      └───────┘      └───────┘      └───────┘
+```
+
+---
+
+## Key Design Decisions
+
+### Content Storage
+
+| Data Type | Storage | Pattern |
+|-----------|---------|---------|
+| Posts & Pages | D1 | `tenant_id` column, markdown stored in DB |
+| Media | R2 | Tenant prefix: `tenants/{tenant_id}/media/...` |
+| Config/Cache | KV | Key prefix: `tenant:{tenant_id}:...` |
+
+### Caching Strategy
+
+D1 has write limits (1000/minute), so caching is critical:
+
+```
+Request → KV Cache → D1 Database
+              ↑
+        (cache miss = read from D1, store in KV)
+```
+
+**Cache TTLs:**
+- Tenant config: 5 minutes
+- Post list: 1 minute
+- Individual post: 5 minutes
+- Site settings: 5 minutes
+
+### Route Structure
+
+```
+(tenant)/
+├── +layout.server.ts        # Load tenant context
+├── +page.svelte             # Home (load from D1)
+├── blog/
+│   ├── +page.svelte         # Post list
+│   └── [slug]/+page.svelte  # Single post
+└── admin/                   # Tenant admin panel
+    ├── +layout.server.ts    # Require auth + ownership
+    ├── posts/               # Post management
+    └── settings/            # Tenant settings
+```
+
+### Authentication Flow
+
+1. User visits `dave.grove.place`
+2. Clicks "Sign In" → redirects to `auth.grove.place` (Heartwood)
+3. Auth completes → redirect back with session cookie (`.grove.place` domain)
+4. `hooks.server.ts` validates session, sets `locals.user`
+5. Admin routes check: `user.email === tenant.owner_email`
+
+**Key rule:** Tenants can only edit their OWN content.
+
+---
+
+## Data Isolation
+
+Grove uses a **shared database with tenant_id columns** pattern:
+
+- Every table has a `tenant_id` column
+- Every query MUST filter by `tenant_id`
+- KV keys prefixed: `tenant:{id}:{resource}:{key}`
+- R2 paths prefixed: `tenants/{id}/...`
+
+### Why Not Per-Tenant Databases?
+
+- Simpler schema management
+- Straightforward cross-tenant analytics
+- D1's 10GB limit is plenty for shared use
+- Migration complexity not worth isolation benefits at current scale
+
+---
+
+## Cost Analysis
+
+### At 100 Tenants
+
+| Service | Usage | Cost |
+|---------|-------|------|
+| D1 reads | ~3,000/day (with KV cache) | ~$0.003/mo |
+| D1 writes | ~500/week | Free |
+| KV reads | 90%+ cache hit | Minimal |
+| R2 storage | 5GB | Free |
+
+**Total: ~$5/month** (Workers Paid base)
+
+### Scaling
+
+D1 writes: Even at 10,000 tenants × 2 posts/week = ~2 writes/minute (well under 1000/min limit)
+
+**Real bottleneck:** R2 storage costs at scale → solved with per-plan storage limits
+
+---
+
+## Theming
+
+Per-tenant themes stored in D1:
+
+```sql
+tenant_settings (tenant_id, setting_key, setting_value)
+-- ('tenant-123', 'theme', 'forest')
+-- ('tenant-123', 'primary_color', '#2d5016')
+```
+
+Applied at runtime via CSS variables.
+
+---
+
+*The full architecture doc is at `docs/multi-tenant-architecture.md`.*

--- a/docs/philosophy/grove-naming.md
+++ b/docs/philosophy/grove-naming.md
@@ -1,0 +1,433 @@
+# The Grove Naming System
+
+> *A forest of voices. Every user is a tree in the grove.*
+
+---
+
+## The Philosophy
+
+The internet used to be a place of personal expression. Somewhere along the way, we traded that for algorithms and engagement metrics. Grove is a return to something simpler: a place where people can plant their thoughts and watch them grow.
+
+These names aren't just branding. They're the language of an ecosystem. Each one draws from the same soil: forests, growth, shelter, connection. Beneath the surface, roots intermingle. Trees share nutrients through mycorrhizal networks. The oldest trees nurture the saplings. 
+
+This is how we build.
+
+---
+
+## Meadow
+**The Social Layer** · `meadow.grove.place`
+
+A meadow is where the forest opens up. Sunlight reaches the ground. You can see the people around you clearly, without the dense canopy of algorithmic noise blocking the view.
+
+Meadow is social media that remembers what "social" means. No public metrics breeding hierarchy. No viral mechanics rewarding the loudest voice. Just a chronological feed of people you chose to follow, with reactions that only the author can see. Encouragement without performance. Connection without competition.
+
+*In development*
+
+---
+
+## Forage
+**Domain Discovery** · `forage.grove.place`
+**Repository:** [AutumnsGrove/Forage](https://github.com/AutumnsGrove/Forage)
+
+Before you can plant, you have to search. You walk the forest floor, looking for what you need: something that fits, something that's *available*, something worth bringing home.
+
+Forage is an AI-powered domain hunting tool that turns weeks of frustrating searches into hours. Tell it about your project, your vibe, your budget, and it returns a curated list of available domains that actually fit. Finding the right name takes effort. Forage does the searching so you can focus on choosing.
+
+---
+
+## Foliage
+**Theming System** · `foliage.grove.place`
+**Repository:** [AutumnsGrove/Foliage](https://github.com/AutumnsGrove/Foliage)
+
+Foliage is what you see when you look at a tree. The leaves, the color, the personality that changes with the seasons. No two canopies are quite the same.
+
+Foliage is visual customization for your blog, from accent colors to full theme control. Pick a curated theme or build your own. Make it warm, make it bold, make it *yours*. Your foliage is how the world sees your corner of the grove.
+
+---
+
+## Heartwood
+**Authentication** · `heartwood.grove.place`
+**Repository:** [AutumnsGrove/GroveAuth](https://github.com/AutumnsGrove/GroveAuth)
+
+Cut a tree open and you'll find the heartwood at the center, the densest, most durable part. It's what remains when everything else falls away. It's the authentic core.
+
+Heartwood is centralized authentication for the Grove ecosystem. One identity, verified and protected, that works across every Grove property. Your heartwood is yours. It proves you are who you say you are.
+
+---
+
+## Patina
+**Backup System** · *Internal service*
+**Repository:** [AutumnsGrove/Patina](https://github.com/AutumnsGrove/Patina)
+
+A patina is the thin layer that forms on copper and bronze over time. Not decay, but protection. It's what happens when something weathers the world and comes out stronger. The green of old statues, the warmth of handled wood, the soft wear on a favorite book's spine.
+
+Patina runs nightly automated backups of every Grove database to cold storage. Weekly archives compress the daily layers, and twelve weeks of history remain quietly preserved. You'll probably never think about it, and that's the point. When disaster strikes, Patina is already there, holding everything safe beneath its protective layer.
+
+*Age as armor. Time as protection.*
+
+---
+
+## Trove
+**Library Book Discovery** · `trove.grove.place`
+**Repository:** [AutumnsGrove/TreasureTrove](https://github.com/AutumnsGrove/TreasureTrove)
+
+A trove is a collection of precious things, gathered and waiting to be discovered.
+
+Point your camera at a library shelf. Trove identifies the books, cross-references your reading history and tastes, and tells you which ones are worth your time, with visual markers showing exactly where they sit on the shelf. No more decision paralysis. No more walking out empty-handed. Just treasures, found.
+
+---
+
+## Outpost
+**Minecraft Server** · `mc.grove.place`
+**Repository:** [AutumnsGrove/GroveMC](https://github.com/AutumnsGrove/GroveMC)
+
+An outpost is where you gather at the edge of the wilderness. A place to rest, regroup, and adventure together.
+
+Outpost is an on-demand Minecraft server for friends. It spins up when someone wants to play, shuts down when the world goes quiet, and costs almost nothing to run. No 24/7 hosting fees for a server that sits empty. Just a place that's there when you need it.
+
+---
+
+## Aria
+**Music Curation** · `aria.grove.place`
+**Repository:** [AutumnsGrove/GroveMusic](https://github.com/AutumnsGrove/GroveMusic)
+
+An aria is a self-contained melody, a single voice carrying emotion through song.
+
+Give Aria a song you love, and it builds a playlist of tracks that share the same musical DNA. Not just "similar artists" or genre tags, but actual sonic and emotional connections, with explanations for why each song belongs. Your aria becomes a chorus. One voice finds its kindred.
+
+---
+
+## Lattice
+**Core Platform** · `npm: @autumnsgrove/lattice`
+**Repository:** [AutumnsGrove/GroveEngine](https://github.com/AutumnsGrove/GroveEngine)
+
+A lattice is the framework that supports growth. Vines climb it. Gardens are built around it. It's not the thing you see, it's the thing that holds everything else up.
+
+Lattice is the npm package powering every Grove site. UI components, authentication utilities, markdown rendering, database patterns: all the infrastructure that makes building on Grove feel effortless. You don't admire a lattice. You build on it, and watch what grows.
+
+**Vines** are a feature of Lattice: the widgets and content that fill your blog's gutters (the sidebar margins alongside your main content). Like vines climbing a trellis, they grow alongside your posts: related links, callouts, annotations, metadata. Gutter content that adds context without interrupting the flow.
+
+---
+
+## Plant
+**Onboarding** · `plant.grove.place`
+
+A seedbed is where seeds are planted and nurtured until they're ready to grow on their own. It's the starting place: carefully prepared soil, the right conditions, gentle care until roots take hold.
+
+Plant is Grove's onboarding system: the complete flow for new users from initial signup through payment, interactive tour, and handoff to their own blog. A frictionless, welcoming experience that gets you publishing within minutes. You arrive as a visitor. You leave with a home.
+
+---
+
+## Rings
+**Analytics** · *Integrated into admin dashboard*
+
+Count the rings of a tree and you learn its story. Each ring records a season: growth in plenty, resilience through hardship, the quiet accumulation of years. Rings are internal. Private. You only see them when you look closely at your own tree.
+
+Rings is analytics for writers, not marketers. No public view counts breeding anxiety. No leaderboards. No real-time dopamine hits. Just private insights about your own growth: who's reading, what resonates, how your garden is growing over time. Delayed by design, reflective by nature. Your rings are yours alone.
+
+---
+
+## Ivy
+**Email** · `ivy.grove.place`
+**Repository:** [AutumnsGrove/Ivy](https://github.com/AutumnsGrove/Ivy)
+
+Ivy climbs the lattice, reaching out, intertwining, linking one point to another. But ivy does something else too: what it covers, it conceals. An ivy-covered wall disappears into green. The structure beneath becomes invisible to anyone outside.
+
+Ivy is email for Grove. Not a Gmail replacement, but a focused, privacy-first mail client for your `@grove.place` address. Professional correspondence for your blog. A place where contact form submissions arrive as threads. Zero-knowledge encryption means your messages travel along the ivy—connected point to point—but wrapped in leaves that only you can see through. We can't read your mail; it's yours alone. One address, chosen once, that's authentically you.
+
+*Connected and concealed.*
+
+---
+
+## Amber
+**Storage Management** · `amber.grove.place`
+**Repository:** [AutumnsGrove/Amber](https://github.com/AutumnsGrove/Amber)
+
+Amber is fossilized tree resin, preserving moments in time, capturing life in suspended animation. It holds what matters, protecting it for centuries.
+
+Amber is Grove's unified storage management system. Every file you upload (blog images, email attachments, profile pictures) is preserved in Amber, organized and accessible from one place. See what's using your space. Download and export your data. Clean up what you don't need. Buy more when you need it. Amber isn't trying to be Dropbox or Google Drive. It's the storage layer that already exists in Grove, made visible and manageable. Every paid user already has storage; Amber is how they understand and control it.
+
+---
+
+## Shade
+**AI Content Protection** · `grove.place/shade`
+
+Shade is the cool relief beneath the canopy. Protection from the harsh glare of exposure. It's where you rest, out of sight from those who would harvest without asking.
+
+Shade is Grove's layered defense against AI crawlers, scrapers, and automated data harvesting. In a world where tech giants treat user content as training data to be extracted without consent, Shade is a quiet refusal. robots.txt directives, meta tags, rate limiting, WAF rules, and legal documentation, all working together so writers can write without worrying about becoming someone else's training data.
+
+*In a forest full of harvesters, this grove stays shaded.*
+
+---
+
+## Trails
+**Personal Roadmaps** · `username.grove.place/trail`
+
+A trail is the path you're walking: the route you've chosen through the forest, marked by where you've been and where you're headed. No two trails are the same.
+
+Trails lets Grove users share their own roadmaps with the world. Whether you're building a project, planning a content series, or just charting where your creative work is headed, Trails gives you a place to show the journey. Create waypoints marking milestones, group them into phases with custom names, and let visitors follow along as you make progress.
+
+For those who want to dream bigger: Oak and Evergreen users can bring the full Grove aesthetic to their trails with seasonal themes, nature decorations, custom assets. Or keep it simple with a clean timeline. Your trail, your way.
+
+**Templates available for:** Writers planning content series, developers building in public, musicians tracking album progress, restaurants showing seasonal menus, and more.
+
+*The path becomes clear by walking it.*
+
+---
+
+## Vineyard
+**Asset & Tool Showcase** · `*.grove.place/vineyard`
+
+A vineyard is where vines are tended before they're ready: rows of growth, organized and visible, trained along the lattice. It's part nursery, part gallery. A place to see what's growing and understand how it all fits together.
+
+Vineyard is the documentation and demo pattern for every Grove tool. Each product gets its own `/vineyard` route: `amber.grove.place/vineyard`, `ivy.grove.place/vineyard`, `foliage.grove.place/vineyard`. Inside, you'll find working demos where possible, visual mockups for what's coming, feature documentation, and the philosophy behind each tool. It's where you go to understand what something does before you use it, or to dream about what it will become.
+
+Some vineyards showcase mature vines ready for harvest. Others tend young shoots still finding their shape. Both belong here. The vineyard doesn't hide what's unfinished, it celebrates the growing.
+
+*Every vine starts somewhere.*
+
+---
+
+## Bloom
+**Remote Coding Infrastructure** · `bloom.grove.place`
+**Repository:** [AutumnsGrove/GroveBloom](https://github.com/AutumnsGrove/GroveBloom)
+
+A bloom is the brief, brilliant moment when a flower opens: ephemeral, purposeful, then gone. It appears when conditions are right, does its work, and doesn't linger.
+
+Bloom is Grove's serverless remote coding infrastructure. It spins up temporary VPS instances on-demand, runs AI coding agents autonomously to complete development tasks, syncs your code to storage, then vanishes. Send a task from your phone during lunch. Check back later: Bloom worked through it, saved the results, and cleaned up after itself. Infrastructure that exists only when needed, costs almost nothing, and never overstays its welcome.
+
+It blooms, does its work, and fades away. By morning, there's only the code it left behind.
+
+*Brief, brilliant, gone.*
+
+---
+
+## Mycelium
+**MCP Server** · `mycelium.grove.place`
+
+In the forest, mycelium is the wood wide web: invisible fungal threads connecting every tree, sharing nutrients and signals across the entire ecosystem. It's how the forest communicates with itself.
+
+Mycelium is Grove's Model Context Protocol (MCP) server, the communication layer that lets AI agents interact with the entire Grove ecosystem. Through Mycelium, Claude can read your blog posts, start Bloom coding sessions, manage files in Amber, and tap into every Grove service, all through a single, unified interface. Just as forest mycelium supports seedlings that can't yet photosynthesize on their own, Mycelium extends your reach, letting AI agents work on your behalf across the grove.
+
+It's the invisible network beneath everything. You don't see it. You don't think about it. But it's how the whole system stays connected.
+
+*In development. Repository: [AutumnsGrove/GroveMCP](https://github.com/AutumnsGrove/GroveMCP)*
+
+*The forest speaks through its roots.*
+
+---
+
+## Vista
+**Infrastructure Observability** · `vista.grove.place`
+**Repository:** [AutumnsGrove/GroveMonitor](https://github.com/AutumnsGrove/GroveMonitor)
+
+A vista is a clearing in the forest where the canopy opens up, a place where you can finally see. The whole grove stretches out before you: what's thriving, what's struggling, what needs attention.
+
+Vista is infrastructure observability for the Grove platform. It monitors every worker, database, storage bucket, and KV namespace, tracking health, latency, error rates, and costs. Real-time dashboards show the state of the entire ecosystem at a glance. When something needs attention, Vista sends an alert before users ever notice. Ninety days of history, always available, quietly watching.
+
+Rings tells writers about their readers. Vista tells the grove keeper about the grove itself.
+
+*Where you go to see everything clearly.*
+
+---
+
+## Press
+**Image Processing CLI** · *Developer tool*
+**Repository:** [AutumnsGrove/CDNUploader](https://github.com/AutumnsGrove/CDNUploader)
+
+A press is a tool of transformation. The olive press extracts oil from fruit. The wine press releases juice from grapes. The printing press prepares words for the world. Every press takes something raw and makes it ready.
+
+Press is Grove's image processing CLI. It takes your raw photos and presses them into web-ready form: converted to WebP, described by AI for accessibility, deduplicated by content hash, and uploaded to Cloudflare R2. One command, and your images are ready to publish.
+
+*Raw in. Ready out. Going to press.*
+
+---
+
+## Wisp
+**Writing Assistant** · *Integrated into editor*
+
+A wisp is a will-o'-the-wisp, a gentle, ephemeral light that appears in forests and marshes. It guides without forcing. It's there and then it's not.
+
+Wisp is Grove's ethical writing assistant. It helps polish your voice without replacing it: grammar checks, tone analysis, readability scores. Never generation, never expansion, never brainstorming. Just subtle nudges from a tool that disappears into the background when you don't need it.
+
+**Fireside** is a mode of Wisp for writers who freeze at the blank page. Some people can't start writing, but they have no trouble *talking*. Fireside is a conversation that becomes a post. Wisp asks questions, you answer naturally, and your words get organized into a draft. The fire doesn't tell the story. It just creates the space where stories emerge.
+
+All features off by default. Zero data retention. Your words analyzed, never stored. *A helper, not a writer, and sometimes, a good listener.*
+
+---
+
+## Terrarium
+**Creative Canvas** · `grove.place/terrarium`
+
+A terrarium is a sealed world under glass—a miniature ecosystem you design, arrange, and watch grow. Moss, stones, tiny plants, all placed with intention.
+
+Terrarium is Grove's creative canvas. Drag nature components onto an open space, compose scenes from trees and creatures and flowers, then bring them home to your blog as decorations. Your terrarium becomes your foliage. Same creative freedom as MySpace, but with Grove's curated aesthetic—guardrails that ensure your space looks beautiful while staying uniquely yours.
+
+Create a scene in Terrarium, export it as a decoration, apply it via Foliage to your blog's header, sidebar, footer, or background. The component library is the guardrail: every tree, firefly, and lattice is curated. Users get creative freedom within Grove's nature palette.
+
+*A little world, all your own.*
+
+---
+
+## Pantry
+**Shop & Provisioning** · `pantry.grove.place`
+
+A pantry is where you keep what sustains you. Flour, honey, preserves—the things you reach for when you need them. It's not a storefront with bright lights and sales pressure. It's a cupboard in a warm kitchen, stocked and waiting.
+
+Pantry is Grove's shop. Subscriptions, merchandise, credits, gift cards—the things that keep the grove running and growing. You come when you need something, find what you're looking for, and take it home. Simple, warm, no fuss.
+
+*The cupboard is always stocked.*
+
+---
+
+## Nook
+**Private Video Sharing** · `nook.grove.place`
+**Repository:** [AutumnsGrove/Nook](https://github.com/AutumnsGrove/Nook)
+
+A nook is a tucked-away corner, a quiet space set apart from the main room. Somewhere intimate and private.
+
+Nook is a privacy-focused video sharing platform for small, trusted friend groups. Not a YouTube channel, not a public archive—just a cozy space where your closest friends can watch the videos you've been meaning to share. All processing happens locally before content becomes accessible. Unknown faces automatically blurred. Your moments, shared only with people you choose.
+
+*Gather close. Share quietly.*
+
+---
+
+## Clearing
+**Status Page** · `status.grove.place`
+
+A clearing is an open space in the forest where the trees part and visibility opens up. You can see what's around you, assess the situation, and understand what's happening.
+
+Clearing is Grove's public status page: transparent, real-time communication about platform health. When something goes wrong or maintenance is planned, users can check the clearing to understand what's happening without needing to contact support. Honest updates, component status, incident history. No spin, just clarity.
+
+*Where you go to see what's happening.*
+
+---
+
+## Waystone
+**Help Center** · *Integrated into platform*
+
+Waystones are the markers travelers leave along forest paths—guiding those who follow, showing the way forward.
+
+Waystone is Grove's built-in help center: searchable documentation, contextual help buttons throughout the interface, and a lantern to light your path when you're lost. Not an external docs site, not a separate login. Just help, right where you need it.
+
+*Trail markers for when you're lost.*
+
+---
+
+## Reeds
+**Comments System** · *Integrated into blogs*
+
+Reeds sway together at the water's edge, whispering in the breeze: a gentle murmur of community.
+
+Reeds is Grove's comment system, supporting both private replies (author-only) and public conversations (author-moderated). The dual system encourages thoughtful engagement while giving blog authors full control over their public-facing content. No reactions on comments—just threaded replies, HN-style simplicity.
+
+*Whisper together at the water's edge.*
+
+---
+
+## Porch
+**Front Porch Conversations** · `porch.grove.place`
+
+A porch is where you sit and talk. Not a ticket counter. Not a help desk. Just two people on a porch, figuring things out together. You come up the steps, have a seat, and the grove keeper comes out to chat.
+
+Porch is Grove's support system—but it's more than that. It's where you reach out when you need help, or when you just want to say hi. Submit a question, start a conversation, or drop by to see what Autumn's up to. Every visit is tracked, but it never feels like a ticket number.
+
+*Have a seat on the porch. We'll figure it out together.*
+
+---
+
+## Loam
+**Name Protection** · *Internal service*
+
+Loam is the ideal soil. Rich, dark, perfectly balanced. Sand for drainage, silt for nutrients, clay for structure. Every gardener knows it. It's what you want beneath your roots, the foundation that decides what can grow.
+
+Loam is Grove's username and domain validation system. Every name passes through it before taking root: reserved words, impersonation attempts, harmful content, fraud patterns. You won't notice it working. That's the point. Good soil doesn't announce itself. It just quietly ensures that what grows here belongs here.
+
+*What flourishes starts with what the soil allows.*
+
+---
+
+## The Ecosystem
+
+| Name | Purpose | Domain |
+|------|---------|--------|
+| **Meadow** | Social connection | meadow.grove.place |
+| **Forage** | Domain discovery | forage.grove.place |
+| **Foliage** | Theming system | foliage.grove.place |
+| **Terrarium** | Creative canvas | grove.place/terrarium |
+| **Heartwood** | Authentication | heartwood.grove.place |
+| **Patina** | Backup system | *(internal)* |
+| **Trove** | Library book finder | trove.grove.place |
+| **Outpost** | Minecraft server | mc.grove.place |
+| **Aria** | Music curation | aria.grove.place |
+| **Lattice** | Core platform | npm package |
+| **Plant** | Onboarding | plant.grove.place |
+| **Rings** | Analytics | *(integrated)* |
+| **Ivy** | Email | ivy.grove.place |
+| **Amber** | Storage management | amber.grove.place |
+| **Shade** | AI content protection | grove.place/shade |
+| **Trails** | Personal roadmaps | username.grove.place/trail |
+| **Vineyard** | Asset & tool showcase | *.grove.place/vineyard |
+| **Bloom** | Remote coding infrastructure | bloom.grove.place |
+| **Mycelium** | MCP server | mycelium.grove.place |
+| **Vista** | Infrastructure observability | vista.grove.place |
+| **Press** | Image processing CLI | *(developer tool)* |
+| **Wisp** | Writing assistant (+ Fireside) | *(integrated)* |
+| **Pantry** | Shop & provisioning | pantry.grove.place |
+| **Nook** | Private video sharing | nook.grove.place |
+| **Clearing** | Status page | status.grove.place |
+| **Waystone** | Help center | *(integrated)* |
+| **Reeds** | Comments system | *(integrated)* |
+| **Porch** | Front porch conversations | porch.grove.place |
+| **Loam** | Name protection | *(internal)* |
+
+---
+
+## Internal Names
+
+For development, debugging, and internal documentation, the `Grove[Thing]` naming convention remains useful. It's explicit and functional: exactly what you want at 2am when something breaks.
+
+| Public Name | Internal Name |
+|-------------|---------------|
+| Meadow | GroveSocial |
+| Forage | GroveDomainTool |
+| Foliage | GroveThemes |
+| Terrarium | GroveTerrarium |
+| Heartwood | GroveAuth |
+| Patina | GrovePatina |
+| Trove | TreasureTrove |
+| Outpost | GroveMC |
+| Aria | GroveMusic |
+| Lattice | GroveEngine |
+| Plant | Seedbed |
+| Rings | GroveAnalytics |
+| Ivy | GroveMail |
+| Amber | GroveStorage |
+| Shade | GroveShade |
+| Trails | GroveTrails |
+| Vineyard | GroveShowcase |
+| Bloom | GroveBloom |
+| Mycelium | GroveMCP |
+| Vista | GroveMonitor |
+| Press | GrovePress |
+| Wisp | GroveWisp |
+| Pantry | GroveShop |
+| Nook | GroveNook |
+| Clearing | GroveClear |
+| Waystone | GroveWaystone |
+| Reeds | GroveReeds |
+| Porch | GrovePorch |
+| Loam | GroveLoam |
+
+---
+
+## A Note on Naming
+
+These names share common ground: nature, shelter, things that grow. But none of them are *about* trees directly. They're about what happens in and around the forest. Where people gather (Meadow). What you search for and find (Forage). Where you find treasure (Trove). What holds everything together (Lattice).
+
+The Grove is the place. These are the things you find there.
+
+---
+
+*Last updated: January 7, 2026*
+*Status: Placeholder names, pending launch*

--- a/docs/philosophy/grove-sustainability.md
+++ b/docs/philosophy/grove-sustainability.md
@@ -1,0 +1,202 @@
+# How Grove Lasts: A Sustainability Promise
+
+> *Some trees outlive the people who planted them.*
+
+When Grove promises your words can live for 100 years, that's not marketing. It's a commitment backed by financial structure, not just good intentions. Here's how it works.
+
+---
+
+## The Honest Reality
+
+Grove is built by one person. Right now, if this doesn't work, I'm going to go work at Waffle House. That's not self-deprecation—it's honesty. I'm putting everything into this because I believe in what we're building.
+
+But here's the thing: I also know I won't live 100 years.
+
+So how can I promise your words will?
+
+---
+
+## The Three Phases
+
+### Phase 1: Getting Started (0–1,000 users)
+
+In the early days, Grove is simple:
+
+- Server costs come first (always)
+- What's left goes to keeping the creator alive
+- Margins hover near zero—maybe 5%
+
+This phase is about survival. Building something real. Proving the model works.
+
+### Phase 2: Finding Stability (1,000–5,000 users)
+
+Once Grove has a real community:
+
+- I start taking a salary (not "all the profits")
+- Grove becomes its own entity—not just Autumn's side project
+- Revenue beyond salary and costs goes into **The Reserve**
+
+This is the transition from "person with a project" to "sustainable organization."
+
+### Phase 3: Building Legacy (5,000+ users)
+
+This is where the 100-year promise becomes real:
+
+- Grove holds its own assets
+- The Reserve grows
+- The organization can outlive its founder
+
+At scale, with $500,000 in reserve, Grove could run for 50+ years on interest alone—even with no new subscribers.
+
+---
+
+## Why This Actually Works
+
+### The Math Is On Our Side
+
+Grove runs on Cloudflare infrastructure. Here's what that means:
+
+| Service | Cost at 1,000 users | Cost at 10,000 users |
+|---------|--------------------:|---------------------:|
+| Workers | ~$5/month | ~$5/month |
+| D1 (Database) | ~$0.50/month | ~$5/month |
+| R2 (Storage) | ~$2/month | ~$20/month |
+| KV | ~$0/month | ~$0.50/month |
+| **Total infrastructure** | **~$8/month** | **~$31/month** |
+
+*Note: These are infrastructure costs only. Additional operational costs include payment processing (~3% of revenue via Stripe), email service (~$3/month), domain registration for Evergreen users, and support tools. Total operational overhead runs 5-10% of revenue—still dramatically lower than typical SaaS.*
+
+At 1,000 users paying an average of $11/month, that's $11,000/month in revenue against ~$800-1,100/month in total costs (infrastructure + operations).
+
+The margins aren't 10%. They're 90%+.
+
+This isn't normal. Most SaaS products spend 30-50% of revenue on infrastructure. Grove's architecture means almost every dollar can go toward sustainability, not servers.
+
+### The Scaling Secret
+
+Cloudflare's pricing is nearly flat at our scale. Whether we have 1,000 or 10,000 users, the infrastructure cost barely moves. This means:
+
+- More users = more reserve, not more overhead
+- Growth compounds into stability
+- The 100-year promise gets *more* achievable over time, not less
+
+---
+
+## The Reserve
+
+Once Grove reaches stability, excess revenue goes into The Reserve—a fund specifically for long-term sustainability.
+
+### What The Reserve Does
+
+1. **Covers emergencies**: If subscriptions drop suddenly, The Reserve keeps servers running
+2. **Funds transitions**: If I can't run Grove anymore, The Reserve funds the handoff
+3. **Guarantees Centennial**: The Reserve is what makes the 100-year promise real
+
+### How The Reserve Grows
+
+| Monthly Revenue | After Salary & Costs | Annual Reserve Growth |
+|----------------:|---------------------:|----------------------:|
+| $5,000 | ~$2,000 | ~$24,000 |
+| $10,000 | ~$5,000 | ~$60,000 |
+| $25,000 | ~$15,000 | ~$180,000 |
+
+At $25,000/month revenue with ~2,000 users, The Reserve could hit $500,000 in under 3 years.
+
+### What $500,000 Means
+
+With $500,000 in reserve, earning 4% annually in a simple index fund:
+
+- **Annual return**: $20,000
+- **Annual infrastructure costs**: ~$500
+- **Years of runway with zero revenue**: 50+ years
+
+That's not a promise. That's math.
+
+### Structure & Governance
+
+The Reserve isn't just a concept—it needs real structure:
+
+- **Held separately**: Dedicated high-yield savings or index fund account, separate from operating funds
+- **Protected from creditors**: Once Grove incorporates, The Reserve will be structured to survive business disputes
+- **Withdrawal triggers**: Only used for emergencies (sudden revenue drop >50%), succession transitions, or Centennial obligations
+- **Transparency**: Annual public reporting on Reserve status (growing/stable/drawing)
+
+During Phase 1 (current), The Reserve is a line item I'm building toward. By Phase 2, it becomes a legally distinct fund.
+
+---
+
+## Succession Planning
+
+I won't live forever. Neither will Grove in its current form. But your words can.
+
+### The Succession Plan
+
+1. **Legal structure**: Grove is currently a sole proprietorship. Target: LLC or benefit corporation formation by end of Phase 1 (~500 users), with clear succession rules and Reserve protection built in from day one.
+2. **Documentation**: Everything about running Grove is documented—infrastructure, processes, contacts, credentials. A successor could take over with the docs alone.
+3. **Designated successors**: Trusted people who can take over, identified before Phase 2.
+4. **Worst-case protocol**: If no successor available, The Reserve funds a managed wind-down:
+   - Minimum 3 years notice to all users
+   - Full data export support (API + bulk download)
+   - Static HTML archives uploaded to Internet Archive
+   - Graceful transition, not sudden shutdown
+
+### What "Succession" Looks Like
+
+- **Best case**: Someone I trust continues growing Grove
+- **Good case**: A small team maintains Grove as-is
+- **Okay case**: Grove freezes but stays online (Centennial sites remain accessible)
+- **Worst case**: Years-long managed transition to static archives
+
+Even the worst case honors the Centennial promise.
+
+---
+
+## Transparency
+
+This document isn't locked away in an investor deck. It's public. You can read it. You can hold me to it.
+
+I'll update this document every January with:
+
+- Current user count (ranges, not exact)
+- Reserve status (growing/stable/drawing)
+- Infrastructure costs (actual, not projected)
+- Any changes to the sustainability plan
+
+Updates will be announced on the Grove blog and emailed to Centennial members. This document's edit history is public on GitHub.
+
+No surprises. No hidden pivots. Just honesty about how we're doing.
+
+---
+
+## Why This Matters
+
+Most platforms make promises they can't keep. "We'll never sell your data." "We're not going anywhere." Then the VC funding dries up, the acqui-hire happens, and your content becomes someone else's problem.
+
+Grove is different because:
+
+1. **No VC funding** = No pressure to exit
+2. **Extreme margins** = Sustainability is achievable
+3. **The Reserve** = A structural guarantee, not just words
+4. **Transparency** = You can see if we're on track
+
+The 100-year promise isn't naive optimism. It's engineering. Financial engineering, legal engineering, organizational engineering—all designed so your words outlive me.
+
+---
+
+## The Covenant
+
+When you earn Centennial status, you're not just getting a feature. You're entering into a covenant:
+
+**Your words matter enough to me that I will build an organization capable of preserving them for a century.**
+
+That's what your support means. That's what we're building together.
+
+---
+
+*Some trees outlive the people who planted them.*
+
+*Grove is how I make sure yours can too.*
+
+---
+
+*Last updated: January 2026 · Status: Pre-launch planning*

--- a/docs/philosophy/grove-voice.md
+++ b/docs/philosophy/grove-voice.md
@@ -1,0 +1,219 @@
+# The Grove Voice
+
+> *Write with the warmth of a midnight tea shop and the clarity of good documentation.*
+
+This is how Grove speaks. Not a brand voice guide. Not corporate tone guidelines. Just how we actually sound when we're writing for each other.
+
+---
+
+## The Core Principles
+
+From the project's guiding philosophy:
+
+> This site is my authentic voice—warm, introspective, queer, unapologetically building something meaningful; write like you're helping me speak, not perform.
+
+### What Grove Sounds Like
+
+**Warm but not cutesy.** We're friendly, not performative. "Let's get started" feels right. "Let's gooo! 🚀" does not.
+
+**Direct and honest.** Say what you mean. Acknowledge limitations. Don't oversell. If something doesn't work yet, say so.
+
+**Conversational but not sloppy.** Contractions are fine (you're, it's, we're). Short paragraphs. Questions that invite readers in. But still clear, still structured.
+
+**Introspective.** Grove makes space for reflection. We don't rush. We ask "why" alongside "how."
+
+**Poetic in small doses.** Italicized one-liners at the end of sections can land beautifully. Use them sparingly, earn them.
+
+---
+
+## Sentence Rhythm
+
+Mix short sentences with longer ones. Vary your rhythm. Read it aloud—if it sounds monotonous, it is.
+
+**Good:**
+> Every new visitor asks the same question. "Is the music broken?" No. There is no music. There never has been.
+
+**Not good:**
+> Every new visitor asks a common question. The question is usually about whether the music system is functioning. The answer is that there is no music system. There has never been one.
+
+---
+
+## The Avoidance Checklist
+
+These patterns make text sound like AI wrote it. They're so common in generated text that they've become tells. Avoid them completely.
+
+### Em-Dashes (—)
+
+One tasteful use per thousand words, maximum. Use commas, periods, or parentheses instead.
+
+| Avoid | Better |
+|-------|--------|
+| The forest—our home—is where we gather. | The forest is our home. It's where we gather. |
+
+### The "Not X, But Y" Pattern
+
+This phrasing is deeply AI-coded. Avoid it entirely.
+
+**Never write:**
+- "It's not X, but Y"
+- "It's not just X, but Y"
+- "It's not merely X, but rather Y"
+- "Grove isn't just a platform, it's a home"
+
+**Instead, just say the thing:**
+- "Grove is a home for your words."
+- "This is where you belong."
+
+### Overused AI Words
+
+These words appear in AI text at rates far higher than human writing:
+
+| Category | Words to Avoid |
+|----------|---------------|
+| **Adjectives** | robust, seamless, innovative, cutting-edge, transformative, intricate, captivating, comprehensive |
+| **Nouns** | tapestry, camaraderie, realm, plethora, myriad, landscape, journey (when not literal) |
+| **Verbs** | delve, foster, leverage, navigate, empower, embark, unlock, harness |
+| **Phrases** | at the end of the day, in today's world, it goes without saying, needless to say |
+
+### Heavy Transition Words
+
+These make text feel stiff and robotic:
+
+- Furthermore, Moreover, Additionally
+- In conclusion, That being said
+- It's worth noting that, It's important to note
+
+**Instead:** Let ideas connect naturally. Use short transitions like "And," "But," "So," "Still." Or no transition at all—just start the next thought.
+
+### Semantic Echoes
+
+Don't repeat the same adjective or descriptor multiple times.
+
+**Bad:**
+> Grove provides a seamless experience. The seamless integration means you can seamlessly move between features.
+
+**Good:**
+> Grove gets out of your way. Move between features without friction.
+
+### Generic Safe Claims
+
+AI hedges. Humans commit.
+
+**Bad:** "This may help improve your workflow in many cases."
+**Good:** "This makes your workflow faster."
+
+---
+
+## Structural Guidelines
+
+### Paragraphs
+
+Keep them short. One idea per paragraph. Two to four sentences is usually right. White space is your friend. Dense walls of text don't feel like home.
+
+### Lists
+
+Use lists when they clarify. But don't turn everything into bullets. Sometimes prose flows better.
+
+**Good use of lists:**
+- Specific steps in a process
+- Features that are truly parallel
+- Quick reference information
+
+**Bad use of lists:**
+- Narrative content broken awkwardly
+- Things that would read better as a sentence
+
+### Headers
+
+Be specific. "Writing Guidelines" is better than "Guidelines." "What Grove Sounds Like" is better than "Voice."
+
+Action-oriented headers work well for help docs: "Add Your First Post" not "Posts."
+
+---
+
+## Closers
+
+Grove docs often end with an italicized line. This should feel earned, not forced.
+
+**Works:**
+> *Sometimes the most radical thing you can offer is nothing at all.*
+
+> *The path becomes clear by walking it.*
+
+**Doesn't work:**
+> *And that's how you configure your settings!*
+
+If you can't find a poetic closer that resonates, don't force one. A clean ending is fine.
+
+---
+
+## Queer-Friendly Language
+
+Grove is explicitly queer-friendly. This means:
+
+- No assumptions about users' identities or relationships
+- Welcoming, inclusive language throughout
+- Safe space messaging where appropriate
+- Pride in what we're building, not defensiveness
+
+We don't make a big deal of being queer-friendly. We just are. No rainbow-washing, no performative allyship. The inclusivity is baked in, not bolted on.
+
+---
+
+## Error Messages
+
+When things break, stay warm but be honest. Don't blame the user. Don't hide behind vague language.
+
+**Good:**
+```
+Couldn't save your post. Check your connection and try again.
+```
+
+```
+That page doesn't exist. It may have been moved or deleted.
+```
+
+```
+Something went wrong on our end. We're looking into it.
+Your draft is saved locally.
+```
+
+**Avoid:**
+```
+Oops! 😅 Looks like something went wrong! Don't worry though,
+these things happen! Please try again later!
+```
+
+---
+
+## Self-Review Checklist
+
+Before finalizing any Grove documentation:
+
+- [ ] Read it aloud. Does it sound human?
+- [ ] Check for em-dashes. Remove them.
+- [ ] Search for "not just" and "but rather." Rewrite.
+- [ ] Look for words from the avoid list. Replace them.
+- [ ] Vary sentence length. No monotone rhythm.
+- [ ] Cut unnecessary transitions. Ideas should flow naturally.
+- [ ] Is the closer earned? If forced, remove it.
+- [ ] Would you want to read this at 2 AM in a tea shop?
+
+---
+
+## Quick Reference
+
+| Do | Don't |
+|----|-------|
+| Write short paragraphs | Write walls of text |
+| Use "and," "but," "so" | Use "Furthermore," "Moreover" |
+| Say what you mean | Hedge with "may," "might," "could" |
+| Vary sentence rhythm | Write uniform sentence lengths |
+| Use commas or periods | Use em-dashes |
+| Let ideas connect naturally | Force transitions everywhere |
+| Earn poetic closers | Force poetic closers |
+| Acknowledge limitations | Oversell or overpromise |
+
+---
+
+*Write like you're explaining something to a friend at 2 AM. Clear, warm, honest.*

--- a/docs/philosophy/walking-through-the-grove.md
+++ b/docs/philosophy/walking-through-the-grove.md
@@ -1,0 +1,182 @@
+# Walking Through the Grove
+
+> *A naming ritual for the Grove ecosystem.*
+
+Finding the right name is a walk through the forest. Not a brainstorm session with sticky notes. Not a thesaurus dive. A genuine journey where you let the concept find where it naturally belongs among the trees.
+
+---
+
+## The Philosophy
+
+From the Grove naming document:
+
+> "These names share common ground: nature, shelter, things that grow. But none of them are *about* trees directly. They're about what happens in and around the forest."
+
+> "The Grove is the place. These are the things you find there."
+
+The name should feel *inevitable*. Like it was always there, waiting to be discovered.
+
+---
+
+## The Process
+
+This is a journey, not a checklist.
+
+### 1. Read the Naming Philosophy
+
+Start with `docs/grove-naming.md`. Read the entire document. Let it sink in:
+
+- "A forest of voices. Every user is a tree in the grove."
+- Names aren't branding—they're the language of an ecosystem
+- Things that grow, shelter, connect
+- Not about trees directly—about what happens *in and around* the forest
+
+### 2. Create a Scratchpad
+
+Create a markdown file for your journey: `docs/scratch/{concept}-naming-journey.md`
+
+This scratchpad is where you think out loud. Include:
+- ASCII art visualizations of the grove
+- Questions you're asking yourself
+- Rejected ideas and why
+- The moment when something clicks
+
+### 3. Visualize the Grove
+
+Draw the grove. ASCII art helps:
+
+```
+                          ☀️
+                       🌲   🌲   🌲
+                    🌲    🌳    🌲
+═══════════════════════════════════════════════
+           ROOTS CONNECT BENEATH
+              (mycelium network)
+```
+
+Place existing services in your visualization:
+- Where is Meadow? (the open social space)
+- Where is Heartwood? (the core identity)
+- Where is Ivy? (climbing, connecting)
+- Where is Pantry? (the warm kitchen cupboard)
+
+### 4. Ask "What IS This Thing?"
+
+Don't ask "where does it go?" first. Ask:
+
+**What is it, fundamentally?**
+- Is it a place? (Meadow, Nook, Clearing)
+- Is it an object/process? (Amber, Bloom, Patina)
+- Is it a feature of the tree? (Foliage, Heartwood, Rings)
+- Is it a connection? (Ivy, Mycelium, Reeds)
+
+**What does it DO in the user's life?**
+- Protect? (Shade, Patina)
+- Connect? (Ivy, Meadow, Reeds)
+- Store? (Amber, Trove)
+- Guide? (Waystone, Trails)
+- Create? (Terrarium, Foliage)
+
+**What emotion should it evoke?**
+- Warmth? Safety? Discovery? Community? Privacy?
+
+### 5. Walk Through the Forest
+
+Write this in your scratchpad:
+
+```markdown
+## Walking Through...
+
+I enter the grove. I see...
+I walk past the Meadow where others gather.
+I find my tree—my blog, my space.
+I check my Rings (private growth).
+I see my Foliage (how others see me).
+
+Now I need [THE NEW THING]. Where do I find it?
+What does it look like? Who's there? How does it feel?
+```
+
+Let the scene guide you to the name.
+
+### 6. Generate Candidates
+
+List 5-10 candidates. For each:
+
+- What it means in nature
+- Why it fits this concept
+- The vibe/feeling
+- Potential issues
+
+### 7. Test the Tagline
+
+A good Grove name should complete this sentence naturally:
+
+> "[Name] is where you _______________."
+
+Or:
+
+> "[Name] is the _______________."
+
+If you can't write a poetic one-liner, the name might not fit.
+
+### 8. Write the Entry
+
+Once you've found the name:
+
+```markdown
+## [Name]
+**[Tagline]** · `[domain].grove.place`
+
+[2-3 sentences explaining what this thing IS in the real world—
+the natural metaphor. Then 2-3 sentences explaining what it does
+in Grove. End with the feeling it should evoke.]
+
+*[A poetic one-liner in italics]*
+```
+
+---
+
+## Example: Finding "Porch"
+
+The problem: We need a name for support tickets.
+
+**First attempts (rejected):**
+- Echo → "echo chamber" feels like shouting into void
+- Feather, Flare, Dove → About *sending*, not *connecting*
+
+**The walk:**
+> I'm in the grove. Something's wrong with my tree. I need help.
+> Waystone gives me self-service guides. Clearing shows me status.
+> But I need to actually *talk* to someone.
+>
+> I walk to... a cabin. There's a porch. Someone's there.
+> I sit down. We talk about what's going on.
+
+**The realization:**
+Support isn't a ticket system. It's a porch conversation.
+
+**The name:** Porch
+
+> A porch on a cabin in the woods. You come up the steps. You sit down.
+> The grove keeper comes out. You talk.
+
+*"Have a seat on the porch. We'll figure it out together."*
+
+---
+
+## Keep Your Scratchpads
+
+They're documentation of how we think about Grove:
+
+```
+docs/scratch/
+  grove-journey.md         ← The original Porch discovery
+  {feature}-naming.md      ← Future naming journeys
+```
+
+These become part of Grove's story.
+
+---
+
+*The name you're looking for is already there. You just have to walk until you find it.*

--- a/landing/src/lib/data/knowledge-base.ts
+++ b/landing/src/lib/data/knowledge-base.ts
@@ -922,6 +922,135 @@ export const marketingDocs: Doc[] = [
   },
 ];
 
+// Philosophy Documents
+export const philosophyDocs: Doc[] = [
+  {
+    slug: "grove-naming",
+    title: "The Grove Naming System",
+    description:
+      "The complete philosophy and naming system for the Grove ecosystem",
+    excerpt:
+      "A forest of voices. Every user is a tree in the grove. These names aren't just branding—they're the language of an ecosystem. Each one draws from the same soil: forests, growth, shelter, connection.",
+    category: "philosophy",
+    lastUpdated: "2026-01-07",
+    readingTime: 15,
+  },
+  {
+    slug: "walking-through-the-grove",
+    title: "Walking Through the Grove",
+    description: "A naming ritual for new Grove services and features",
+    excerpt:
+      "Finding the right name is a walk through the forest. You create a visualization scratchpad, step into the metaphor, and let the concept find where it naturally belongs among the trees.",
+    category: "philosophy",
+    lastUpdated: "2026-01-12",
+    readingTime: 8,
+  },
+  {
+    slug: "grove-voice",
+    title: "The Grove Voice",
+    description:
+      "Writing guidelines for authentic, warm, human-sounding documentation",
+    excerpt:
+      "Write with the warmth of a midnight tea shop and the clarity of good documentation. Avoid AI patterns, em-dashes, and hollow encouragement. Say what you mean. Earn your poetic closers.",
+    category: "philosophy",
+    lastUpdated: "2026-01-12",
+    readingTime: 12,
+  },
+  {
+    slug: "grove-sustainability",
+    title: "Sustainability",
+    description: "Grove's approach to environmental and social sustainability",
+    excerpt:
+      "Technology in service of people, not the other way around. Community ownership over corporate extraction. Solarpunk-aligned infrastructure that respects both users and the planet.",
+    category: "philosophy",
+    lastUpdated: "2026-01-12",
+    readingTime: 6,
+  },
+];
+
+// Design Documents
+export const designDocs: Doc[] = [
+  {
+    slug: "grove-ui-patterns",
+    title: "Grove UI Patterns",
+    description:
+      "Glassmorphism, seasonal themes, and the visual language of Grove",
+    excerpt:
+      "Warm, nature-themed UI with glass surfaces, seasonal color palettes, randomized forests, and accessible design patterns. Every page should feel like a place you want to visit.",
+    category: "design",
+    lastUpdated: "2026-01-12",
+    readingTime: 18,
+  },
+  {
+    slug: "grove-product-standards",
+    title: "Product Standards",
+    description: "Design principles and product philosophy for Grove",
+    excerpt:
+      "Grove is intentionally focused. We don't add features for the sake of features. Every addition must serve the core mission: helping people own their words online.",
+    category: "design",
+    lastUpdated: "2026-01-12",
+    readingTime: 10,
+  },
+  {
+    slug: "icon-standards",
+    title: "Icon Standards",
+    description: "Comprehensive guide to icon usage and composition in Grove",
+    excerpt:
+      "Icons are visual shorthand. Grove uses Lucide icons with specific conventions for size, color, composition, and meaning. Consistency across the ecosystem.",
+    category: "design",
+    lastUpdated: "2026-01-12",
+    readingTime: 12,
+  },
+];
+
+// Developer Documents
+export const developerDocs: Doc[] = [
+  {
+    slug: "multi-tenant-architecture",
+    title: "Multi-Tenant Architecture",
+    description:
+      "How Grove handles multiple blogs on subdomains with shared infrastructure",
+    excerpt:
+      "Each user gets their own subdomain (username.grove.place) while sharing underlying infrastructure. Tenant isolation, data separation, and efficient resource sharing.",
+    category: "developer",
+    lastUpdated: "2026-01-12",
+    readingTime: 15,
+  },
+  {
+    slug: "ai-gateway-integration",
+    title: "AI Gateway Integration",
+    description:
+      "Cloudflare AI Gateway for per-tenant AI quotas and observability",
+    excerpt:
+      "Grove uses Cloudflare AI Gateway to manage AI features across tenants. Per-user quotas, request logging, cost tracking, and graceful degradation when limits are reached.",
+    category: "developer",
+    lastUpdated: "2026-01-12",
+    readingTime: 20,
+  },
+  {
+    slug: "cloudflare-infrastructure",
+    title: "Cloudflare Infrastructure",
+    description:
+      "Complete guide to Grove's Cloudflare-first architecture",
+    excerpt:
+      "Workers for compute, D1 for databases, KV for caching, R2 for storage. How Grove builds on Cloudflare's edge infrastructure for global performance and cost efficiency.",
+    category: "developer",
+    lastUpdated: "2026-01-12",
+    readingTime: 25,
+  },
+  {
+    slug: "ai-development-process",
+    title: "Building with AI: The Grove Development Process",
+    description:
+      "How Grove was built in 50 days using Claude Code, Kilo Code, and AI-assisted development",
+    excerpt:
+      "The complete workflow behind building Grove at speed. How to structure context, work across CLI and web interfaces, maintain quality while moving fast, and think alongside AI instead of just prompting it.",
+    category: "developer",
+    lastUpdated: "2026-01-12",
+    readingTime: 0, // Coming soon
+  },
+];
+
 // Combined export for convenience
 export const allDocs = [
   ...specs,
@@ -929,4 +1058,7 @@ export const allDocs = [
   ...legalDocs,
   ...marketingDocs,
   ...patterns,
+  ...philosophyDocs,
+  ...designDocs,
+  ...developerDocs,
 ];

--- a/landing/src/lib/types/docs.ts
+++ b/landing/src/lib/types/docs.ts
@@ -7,7 +7,15 @@
  */
 
 /** Document category */
-export type DocCategory = "specs" | "help" | "legal" | "marketing" | "patterns";
+export type DocCategory =
+  | "specs"
+  | "help"
+  | "legal"
+  | "marketing"
+  | "patterns"
+  | "philosophy"
+  | "design"
+  | "developer";
 
 /** Base document metadata (used for listings and static data) */
 export interface Doc extends Record<string, unknown> {

--- a/landing/src/lib/utils/docs-loader.ts
+++ b/landing/src/lib/utils/docs-loader.ts
@@ -194,16 +194,17 @@ export function loadDocBySlug(
     return null;
   }
 
-  const docsPath =
-    category === "specs"
-      ? join(DOCS_ROOT, "specs")
-      : category === "help"
-        ? join(DOCS_ROOT, "help-center/articles")
-        : category === "marketing"
-          ? join(DOCS_ROOT, "marketing")
-          : category === "patterns"
-            ? join(DOCS_ROOT, "patterns")
-            : join(DOCS_ROOT, "legal");
+  const categoryPaths: Record<DocCategory, string> = {
+    specs: join(DOCS_ROOT, "specs"),
+    help: join(DOCS_ROOT, "help-center/articles"),
+    marketing: join(DOCS_ROOT, "marketing"),
+    patterns: join(DOCS_ROOT, "patterns"),
+    legal: join(DOCS_ROOT, "legal"),
+    philosophy: join(DOCS_ROOT, "philosophy"),
+    design: join(DOCS_ROOT, "design"),
+    developer: join(DOCS_ROOT, "developer"),
+  };
+  const docsPath = categoryPaths[category];
 
   const docs = loadDocsFromDir(docsPath, category);
 

--- a/landing/src/lib/utils/icons.ts
+++ b/landing/src/lib/utils/icons.ts
@@ -486,6 +486,24 @@ export const pricingIcons = {
 } as const;
 
 // ============================================================================
+// KNOWLEDGE BASE CATEGORY ICONS
+// ============================================================================
+/** Icons for knowledge base categories */
+export const knowledgeCategoryIcons = {
+  specs: FileText,
+  help: HelpCircle,
+  legal: ShieldCheck,
+  marketing: Megaphone,
+  patterns: Layers,
+  philosophy: Trees,
+  design: PaintbrushVertical,
+  developer: Terminal,
+} as const;
+
+/** Type for knowledge category icon keys */
+export type KnowledgeCategoryIconKey = keyof typeof knowledgeCategoryIcons;
+
+// ============================================================================
 // UNIFIED EXPORT
 // ============================================================================
 /** All icons in one map (use specific maps above when possible) */

--- a/landing/src/routes/knowledge/+page.server.ts
+++ b/landing/src/routes/knowledge/+page.server.ts
@@ -1,4 +1,13 @@
-import { specs, helpArticles, legalDocs, marketingDocs, patterns } from "$lib/data/knowledge-base";
+import {
+  specs,
+  helpArticles,
+  legalDocs,
+  marketingDocs,
+  patterns,
+  philosophyDocs,
+  designDocs,
+  developerDocs,
+} from "$lib/data/knowledge-base";
 
 export async function load() {
   return {
@@ -7,5 +16,8 @@ export async function load() {
     legalDocs,
     marketingDocs,
     patterns,
+    philosophyDocs,
+    designDocs,
+    developerDocs,
   };
 }

--- a/landing/src/routes/knowledge/+page.svelte
+++ b/landing/src/routes/knowledge/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import SEO from '$lib/components/SEO.svelte';
   import { Header, Footer } from '@autumnsgrove/groveengine/ui/chrome';
-  import { toolIcons } from '$lib/utils/icons';
+  import { toolIcons, knowledgeCategoryIcons } from '$lib/utils/icons';
 
   let { data } = $props();
   const specs = $derived(data.specs);
@@ -10,6 +10,13 @@
   const legalDocs = $derived(data.legalDocs);
   const marketingDocs = $derived(data.marketingDocs);
   const patterns = $derived(data.patterns);
+  const philosophyDocs = $derived(data.philosophyDocs);
+  const designDocs = $derived(data.designDocs);
+  const developerDocs = $derived(data.developerDocs);
+
+  const PhilosophyIcon = knowledgeCategoryIcons.philosophy;
+  const DesignIcon = knowledgeCategoryIcons.design;
+  const DeveloperIcon = knowledgeCategoryIcons.developer;
 
   let searchQuery = $state('');
 
@@ -231,6 +238,100 @@
         </div>
         <a href="/knowledge/patterns" class="inline-flex items-center text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 font-medium transition-colors">
           View all patterns
+          <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </a>
+      </div>
+
+      <!-- Philosophy -->
+      <div class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+        <div class="flex items-center mb-4">
+          <div class="w-12 h-12 bg-green-100 dark:bg-green-900/30 rounded-lg flex items-center justify-center mr-4">
+            <PhilosophyIcon class="w-6 h-6 text-green-600 dark:text-green-400" />
+          </div>
+          <div>
+            <h2 class="text-xl font-semibold text-foreground">Philosophy</h2>
+            <p class="text-sm text-foreground-subtle">{philosophyDocs.length} documents</p>
+          </div>
+        </div>
+        <p class="text-foreground-muted mb-4">
+          The heart of Grove. Naming systems, voice guidelines, sustainability, and the principles that shape everything.
+        </p>
+        <div class="space-y-2 mb-4">
+          {#each philosophyDocs.slice(0, 3) as doc}
+            <div class="text-sm">
+              <a href="/knowledge/philosophy/{doc.slug}" class="text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 font-medium transition-colors">
+                {doc.title}
+              </a>
+            </div>
+          {/each}
+        </div>
+        <a href="/knowledge/philosophy" class="inline-flex items-center text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 font-medium transition-colors">
+          Explore philosophy
+          <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </a>
+      </div>
+
+      <!-- Design -->
+      <div class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+        <div class="flex items-center mb-4">
+          <div class="w-12 h-12 bg-rose-100 dark:bg-rose-900/30 rounded-lg flex items-center justify-center mr-4">
+            <DesignIcon class="w-6 h-6 text-rose-600 dark:text-rose-400" />
+          </div>
+          <div>
+            <h2 class="text-xl font-semibold text-foreground">Design</h2>
+            <p class="text-sm text-foreground-subtle">{designDocs.length} documents</p>
+          </div>
+        </div>
+        <p class="text-foreground-muted mb-4">
+          Visual language, UI patterns, icons, and the aesthetic that makes Grove feel like home.
+        </p>
+        <div class="space-y-2 mb-4">
+          {#each designDocs.slice(0, 3) as doc}
+            <div class="text-sm">
+              <a href="/knowledge/design/{doc.slug}" class="text-rose-600 dark:text-rose-400 hover:text-rose-700 dark:hover:text-rose-300 font-medium transition-colors">
+                {doc.title}
+              </a>
+            </div>
+          {/each}
+        </div>
+        <a href="/knowledge/design" class="inline-flex items-center text-rose-600 dark:text-rose-400 hover:text-rose-700 dark:hover:text-rose-300 font-medium transition-colors">
+          Browse design docs
+          <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </a>
+      </div>
+
+      <!-- Developer Guides -->
+      <div class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow md:col-span-2">
+        <div class="flex items-center mb-4">
+          <div class="w-12 h-12 bg-cyan-100 dark:bg-cyan-900/30 rounded-lg flex items-center justify-center mr-4">
+            <DeveloperIcon class="w-6 h-6 text-cyan-600 dark:text-cyan-400" />
+          </div>
+          <div>
+            <h2 class="text-xl font-semibold text-foreground">Developer Guides</h2>
+            <p class="text-sm text-foreground-subtle">{developerDocs.length} guides</p>
+          </div>
+        </div>
+        <p class="text-foreground-muted mb-4">
+          Technical deep-dives into Grove's architecture. Multi-tenant systems, Cloudflare infrastructure, AI integration.
+        </p>
+        <div class="grid md:grid-cols-3 gap-4 mb-4">
+          {#each developerDocs as doc}
+            <div class="text-sm p-3 bg-cyan-50 dark:bg-cyan-900/20 rounded-lg">
+              <a href="/knowledge/developer/{doc.slug}" class="text-cyan-600 dark:text-cyan-400 hover:text-cyan-700 dark:hover:text-cyan-300 font-medium transition-colors">
+                {doc.title}
+              </a>
+              <p class="text-foreground-subtle text-xs mt-1">{doc.description}</p>
+            </div>
+          {/each}
+        </div>
+        <a href="/knowledge/developer" class="inline-flex items-center text-cyan-600 dark:text-cyan-400 hover:text-cyan-700 dark:hover:text-cyan-300 font-medium transition-colors">
+          View all guides
           <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
           </svg>

--- a/landing/src/routes/knowledge/[category]/[slug]/+page.server.ts
+++ b/landing/src/routes/knowledge/[category]/[slug]/+page.server.ts
@@ -23,6 +23,9 @@ const validCategories: DocCategory[] = [
   "legal",
   "marketing",
   "patterns",
+  "philosophy",
+  "design",
+  "developer",
 ];
 
 export const load: PageServerLoad = async ({ params }) => {

--- a/landing/src/routes/knowledge/design/+page.server.ts
+++ b/landing/src/routes/knowledge/design/+page.server.ts
@@ -1,0 +1,7 @@
+import { designDocs } from "$lib/data/knowledge-base";
+
+export async function load() {
+  return {
+    designDocs,
+  };
+}

--- a/landing/src/routes/knowledge/design/+page.svelte
+++ b/landing/src/routes/knowledge/design/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import SEO from '$lib/components/SEO.svelte';
+  import { Header, Footer } from '@autumnsgrove/groveengine/ui/chrome';
+  import { knowledgeCategoryIcons } from '$lib/utils/icons';
+
+  let { data } = $props();
+  const docs = $derived(data.designDocs);
+
+  const DesignIcon = knowledgeCategoryIcons.design;
+</script>
+
+<SEO
+  title="Design - Grove Knowledge Base"
+  description="Visual language, UI patterns, icon standards, and the aesthetic principles that make Grove feel like home"
+  url="/knowledge/design"
+/>
+
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-6xl mx-auto">
+    <!-- Breadcrumb -->
+    <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
+      <a href="/knowledge" class="hover:text-accent transition-colors">Knowledge Base</a>
+      <span>/</span>
+      <span class="text-foreground">Design</span>
+    </nav>
+
+    <!-- Header -->
+    <div class="mb-12">
+      <div class="flex items-center gap-4 mb-4">
+        <div class="w-12 h-12 bg-rose-100 dark:bg-rose-900/30 rounded-lg flex items-center justify-center">
+          <DesignIcon class="w-6 h-6 text-rose-600 dark:text-rose-400" />
+        </div>
+        <h1 class="text-4xl font-bold text-foreground">Design</h1>
+      </div>
+      <p class="text-xl text-foreground-muted max-w-3xl">
+        How Grove looks and feels. Glassmorphism, seasonal themes, icon composition,
+        and the visual language that makes every page feel like a place you want to visit.
+      </p>
+    </div>
+
+    <!-- Documents List -->
+    <div class="grid gap-6">
+      {#each docs as doc}
+        <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+          <div class="flex items-start justify-between mb-4">
+            <div class="flex-1">
+              <h2 class="text-xl font-semibold text-foreground mb-2">
+                <a href="/knowledge/design/{doc.slug}" class="hover:text-rose-600 dark:hover:text-rose-400 transition-colors">
+                  {doc.title}
+                </a>
+              </h2>
+              {#if doc.description}
+                <p class="text-foreground-muted mb-3">{doc.description}</p>
+              {/if}
+              <p class="text-foreground-subtle text-sm">{doc.excerpt}</p>
+            </div>
+            <div class="ml-6 text-right">
+              <div class="text-sm text-foreground-subtle mb-1">{doc.readingTime} min read</div>
+              {#if doc.lastUpdated}
+                <div class="text-xs text-foreground-faint">Updated {doc.lastUpdated}</div>
+              {/if}
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <a
+              href="/knowledge/design/{doc.slug}"
+              class="inline-flex items-center text-rose-600 dark:text-rose-400 hover:text-rose-700 dark:hover:text-rose-300 font-medium transition-colors"
+            >
+              Read more
+              <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </a>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300">
+              Design
+            </span>
+          </div>
+        </article>
+      {/each}
+    </div>
+
+    <!-- About Section -->
+    <div class="mt-12 bg-rose-50 dark:bg-rose-900/20 rounded-lg p-8 border border-rose-200 dark:border-rose-800/30">
+      <h3 class="text-xl font-semibold text-foreground mb-2">Design as Hospitality</h3>
+      <p class="text-foreground-muted mb-4">
+        Every pixel is an invitation. Grove's design system isn't about looking pretty;
+        it's about making people feel welcome. Warm colors, soft edges, nature motifs.
+        A digital space that remembers what "cozy" means.
+      </p>
+      <p class="text-foreground-subtle text-sm italic">
+        The best interfaces disappear. What's left is home.
+      </p>
+    </div>
+    </div>
+  </article>
+
+  <Footer />
+</main>

--- a/landing/src/routes/knowledge/developer/+page.server.ts
+++ b/landing/src/routes/knowledge/developer/+page.server.ts
@@ -1,0 +1,7 @@
+import { developerDocs } from "$lib/data/knowledge-base";
+
+export async function load() {
+  return {
+    developerDocs,
+  };
+}

--- a/landing/src/routes/knowledge/developer/+page.svelte
+++ b/landing/src/routes/knowledge/developer/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import SEO from '$lib/components/SEO.svelte';
+  import { Header, Footer } from '@autumnsgrove/groveengine/ui/chrome';
+  import { knowledgeCategoryIcons } from '$lib/utils/icons';
+
+  let { data } = $props();
+  const docs = $derived(data.developerDocs);
+
+  const DeveloperIcon = knowledgeCategoryIcons.developer;
+</script>
+
+<SEO
+  title="Developer Guides - Grove Knowledge Base"
+  description="Technical architecture, infrastructure patterns, and implementation guides for building on Grove"
+  url="/knowledge/developer"
+/>
+
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-6xl mx-auto">
+    <!-- Breadcrumb -->
+    <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
+      <a href="/knowledge" class="hover:text-accent transition-colors">Knowledge Base</a>
+      <span>/</span>
+      <span class="text-foreground">Developer Guides</span>
+    </nav>
+
+    <!-- Header -->
+    <div class="mb-12">
+      <div class="flex items-center gap-4 mb-4">
+        <div class="w-12 h-12 bg-cyan-100 dark:bg-cyan-900/30 rounded-lg flex items-center justify-center">
+          <DeveloperIcon class="w-6 h-6 text-cyan-600 dark:text-cyan-400" />
+        </div>
+        <h1 class="text-4xl font-bold text-foreground">Developer Guides</h1>
+      </div>
+      <p class="text-xl text-foreground-muted max-w-3xl">
+        How Grove is built. Multi-tenant architecture, Cloudflare infrastructure,
+        AI integrations, and the technical decisions that hold everything together.
+      </p>
+    </div>
+
+    <!-- Documents List -->
+    <div class="grid gap-6">
+      {#each docs as doc}
+        <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+          <div class="flex items-start justify-between mb-4">
+            <div class="flex-1">
+              <h2 class="text-xl font-semibold text-foreground mb-2">
+                <a href="/knowledge/developer/{doc.slug}" class="hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors">
+                  {doc.title}
+                </a>
+              </h2>
+              {#if doc.description}
+                <p class="text-foreground-muted mb-3">{doc.description}</p>
+              {/if}
+              <p class="text-foreground-subtle text-sm">{doc.excerpt}</p>
+            </div>
+            <div class="ml-6 text-right">
+              <div class="text-sm text-foreground-subtle mb-1">{doc.readingTime} min read</div>
+              {#if doc.lastUpdated}
+                <div class="text-xs text-foreground-faint">Updated {doc.lastUpdated}</div>
+              {/if}
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <a
+              href="/knowledge/developer/{doc.slug}"
+              class="inline-flex items-center text-cyan-600 dark:text-cyan-400 hover:text-cyan-700 dark:hover:text-cyan-300 font-medium transition-colors"
+            >
+              Read guide
+              <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </a>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300">
+              Developer
+            </span>
+          </div>
+        </article>
+      {/each}
+    </div>
+
+    <!-- About Section -->
+    <div class="mt-12 bg-cyan-50 dark:bg-cyan-900/20 rounded-lg p-8 border border-cyan-200 dark:border-cyan-800/30">
+      <h3 class="text-xl font-semibold text-foreground mb-2">Built in the Open</h3>
+      <p class="text-foreground-muted mb-4">
+        Grove's architecture isn't a secret. These guides explain how we build multi-tenant systems on Cloudflare,
+        integrate AI responsibly, and scale without losing the personal touch.
+        Take what's useful. Build something good.
+      </p>
+      <p class="text-foreground-subtle text-sm italic">
+        The lattice holds everything up. Now you can see how.
+      </p>
+    </div>
+    </div>
+  </article>
+
+  <Footer />
+</main>

--- a/landing/src/routes/knowledge/philosophy/+page.server.ts
+++ b/landing/src/routes/knowledge/philosophy/+page.server.ts
@@ -1,0 +1,7 @@
+import { philosophyDocs } from "$lib/data/knowledge-base";
+
+export async function load() {
+  return {
+    philosophyDocs,
+  };
+}

--- a/landing/src/routes/knowledge/philosophy/+page.svelte
+++ b/landing/src/routes/knowledge/philosophy/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import SEO from '$lib/components/SEO.svelte';
+  import { Header, Footer } from '@autumnsgrove/groveengine/ui/chrome';
+  import { knowledgeCategoryIcons } from '$lib/utils/icons';
+
+  let { data } = $props();
+  const docs = $derived(data.philosophyDocs);
+
+  const PhilosophyIcon = knowledgeCategoryIcons.philosophy;
+</script>
+
+<SEO
+  title="Philosophy - Grove Knowledge Base"
+  description="The heart of Grove: naming systems, voice guidelines, sustainability, and the principles that shape everything we build"
+  url="/knowledge/philosophy"
+/>
+
+<main class="min-h-screen flex flex-col">
+  <Header />
+
+  <article class="flex-1 px-6 py-12">
+    <div class="max-w-6xl mx-auto">
+    <!-- Breadcrumb -->
+    <nav class="flex items-center space-x-2 text-sm text-foreground-muted mb-8">
+      <a href="/knowledge" class="hover:text-accent transition-colors">Knowledge Base</a>
+      <span>/</span>
+      <span class="text-foreground">Philosophy</span>
+    </nav>
+
+    <!-- Header -->
+    <div class="mb-12">
+      <div class="flex items-center gap-4 mb-4">
+        <div class="w-12 h-12 bg-green-100 dark:bg-green-900/30 rounded-lg flex items-center justify-center">
+          <PhilosophyIcon class="w-6 h-6 text-green-600 dark:text-green-400" />
+        </div>
+        <h1 class="text-4xl font-bold text-foreground">Philosophy</h1>
+      </div>
+      <p class="text-xl text-foreground-muted max-w-3xl">
+        The heart of Grove. How we name things, how we write, what we believe in.
+        These documents shape everything else.
+      </p>
+    </div>
+
+    <!-- Documents List -->
+    <div class="grid gap-6">
+      {#each docs as doc}
+        <article class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
+          <div class="flex items-start justify-between mb-4">
+            <div class="flex-1">
+              <h2 class="text-xl font-semibold text-foreground mb-2">
+                <a href="/knowledge/philosophy/{doc.slug}" class="hover:text-green-600 dark:hover:text-green-400 transition-colors">
+                  {doc.title}
+                </a>
+              </h2>
+              {#if doc.description}
+                <p class="text-foreground-muted mb-3">{doc.description}</p>
+              {/if}
+              <p class="text-foreground-subtle text-sm">{doc.excerpt}</p>
+            </div>
+            <div class="ml-6 text-right">
+              <div class="text-sm text-foreground-subtle mb-1">{doc.readingTime} min read</div>
+              {#if doc.lastUpdated}
+                <div class="text-xs text-foreground-faint">Updated {doc.lastUpdated}</div>
+              {/if}
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <a
+              href="/knowledge/philosophy/{doc.slug}"
+              class="inline-flex items-center text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 font-medium transition-colors"
+            >
+              Read more
+              <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </a>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300">
+              Philosophy
+            </span>
+          </div>
+        </article>
+      {/each}
+    </div>
+
+    <!-- About Section -->
+    <div class="mt-12 bg-green-50 dark:bg-green-900/20 rounded-lg p-8 border border-green-200 dark:border-green-800/30">
+      <h3 class="text-xl font-semibold text-foreground mb-2">Why Philosophy Matters</h3>
+      <p class="text-foreground-muted mb-4">
+        Grove isn't just software. It's a set of beliefs about how the internet should work,
+        how people should own their words, and how technology can serve communities instead of extracting from them.
+        These documents are where those beliefs take shape.
+      </p>
+      <p class="text-foreground-subtle text-sm italic">
+        The forest grows from its roots.
+      </p>
+    </div>
+    </div>
+  </article>
+
+  <Footer />
+</main>


### PR DESCRIPTION
Add three new knowledge base categories to surface internal docs:

Philosophy (4 docs):
- Grove Naming System (the holy grail)
- Walking Through the Grove (naming ritual)
- The Grove Voice (writing guidelines)
- Sustainability

Design (3 docs):
- Grove UI Patterns (glassmorphism, seasons, forests)
- Product Standards
- Icon Standards

Developer Guides (4 docs):
- Multi-Tenant Architecture
- AI Gateway Integration
- Cloudflare Infrastructure
- Building with AI (coming soon placeholder)

Includes:
- New category types in docs.ts
- Category icons in icons.ts (Trees, PaintbrushVertical, Terminal)
- Route folders for each category
- Condensed versions of long technical docs
- Updated main knowledge page with category cards
- Added AI development guide to TODOS.md