### PR TITLE
fix(roadmap): set tree rotation to 0 degrees

### DIFF
--- a/landing/src/routes/roadmap/+page.svelte
+++ b/landing/src/routes/roadmap/+page.svelte
@@ -404,7 +404,7 @@
 
 			<!-- Single tree - the beginning (positioned at 25% to not block waitlist card) -->
 			<div class="absolute bottom-0 left-[25%] -translate-x-1/2 w-32 h-40 opacity-60" aria-hidden="true">
-				<Logo class="w-full h-full" season="winter" />
+				<Logo class="w-full h-full" season="winter" rotation={0} />
 			</div>
 
 			<div class="max-w-3xl mx-auto relative z-10">
@@ -461,7 +461,7 @@
 					aria-hidden="true"
 				>
 					{#if tree.treeType === 'logo'}
-						<Logo class="w-full h-full" season="winter" />
+						<Logo class="w-full h-full" season="winter" rotation={0} />
 					{:else if tree.treeType === 'pine'}
 						<TreePine class="w-full h-full" season="winter" animate color={winter.frostedPine} />
 					{:else if tree.treeType === 'birch'}
@@ -542,7 +542,7 @@
 					aria-hidden="true"
 				>
 					{#if tree.treeType === 'logo'}
-						<Logo class="w-full h-full" season="spring" />
+						<Logo class="w-full h-full" season="spring" rotation={0} />
 					{:else if tree.treeType === 'pine'}
 						<TreePine class="w-full h-full" season="spring" animate color={greens.grove} />
 					{:else if tree.treeType === 'cherry'}
@@ -657,7 +657,7 @@
 					aria-hidden="true"
 				>
 					{#if tree.treeType === 'logo'}
-						<Logo class="w-full h-full" season="summer" />
+						<Logo class="w-full h-full" season="summer" rotation={0} />
 					{:else if tree.treeType === 'pine'}
 						<TreePine class="w-full h-full" season="summer" animate color={greens.deepGreen} />
 					{:else if tree.treeType === 'cherry'}
@@ -779,7 +779,7 @@
 					aria-hidden="true"
 				>
 					{#if tree.treeType === 'logo'}
-						<Logo class="w-full h-full" season="autumn" />
+						<Logo class="w-full h-full" season="autumn" rotation={0} />
 					{:else if tree.treeType === 'pine'}
 						<TreePine class="w-full h-full" season="autumn" animate color={autumn.gold} />
 					{:else if tree.treeType === 'cherry'}
@@ -878,7 +878,7 @@
 					aria-hidden="true"
 				>
 					{#if tree.treeType === 'logo'}
-						<Logo class="w-full h-full" season="midnight" />
+						<Logo class="w-full h-full" season="midnight" rotation={0} />
 					{:else if tree.treeType === 'pine'}
 						<TreePine class="w-full h-full" season="winter" color={nightColor} />
 					{:else if tree.treeType === 'cherry'}


### PR DESCRIPTION
Explicitly set rotation={0} on all Logo components in the roadmap page
to ensure trees display upright, matching the forest page fix.