### PR TITLE
fix: correct import path for GlassLegend component

### DIFF
--- a/landing/src/routes/knowledge/specs/+page.svelte
+++ b/landing/src/routes/knowledge/specs/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import SEO from '$lib/components/SEO.svelte';
   import { Header, Footer } from '@autumnsgrove/groveengine/ui/chrome';
-  import { GlassLegend } from '@autumnsgrove/groveengine/ui/ui';
+  import { GlassLegend } from '@autumnsgrove/groveengine/ui';
   import { toolIcons, stateIcons, type ToolIconKey } from '$lib/utils/icons';
   import type { SpecCategory } from '$lib/types/docs';
 


### PR DESCRIPTION
The import was using '@autumnsgrove/groveengine/ui/ui' which doesn't exist in the package exports. Changed to '@autumnsgrove/groveengine/ui' which is the correct export path.