### PR TITLE
Update arbor panel nav slots to curios

### DIFF
--- a/packages/engine/src/routes/admin/pages/+page.svelte
+++ b/packages/engine/src/routes/admin/pages/+page.svelte
@@ -74,7 +74,7 @@
         {data.pages.length} pages
         <span class="mx-2">·</span>
         <span class:text-amber-600={atLimit} class:dark:text-amber-400={atLimit}>
-          {navPagesUsed}/{navLimit} nav slots used
+          {navPagesUsed}/{navLimit} curios used
         </span>
       </p>
     </div>


### PR DESCRIPTION
Updated the navigation page counter display in the Arbor panel from "nav slots" to "curios" to align with new terminology.