### PR TITLE
Fix table of contents links not clickable

### DIFF
--- a/packages/engine/src/lib/utils/markdown.ts
+++ b/packages/engine/src/lib/utils/markdown.ts
@@ -13,6 +13,20 @@ export interface Header {
   id: string;
 }
 
+/**
+ * Generate a URL-safe ID from header text.
+ * This is used both by extractHeaders and heading renderers to ensure
+ * the IDs in the TOC match the IDs in the generated HTML.
+ */
+export function generateHeadingId(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .trim();
+}
+
 /** Frontmatter data from markdown files */
 export interface Frontmatter {
   title?: string;
@@ -275,13 +289,8 @@ export function extractHeaders(markdown: string): Header[] {
   while ((match = headerRegex.exec(markdownWithoutCodeBlocks)) !== null) {
     const level = match[1].length;
     const text = match[2].trim();
-    // Create a slug-style ID from the header text
-    const id = text
-      .toLowerCase()
-      .replace(/[^\w\s-]/g, "")
-      .replace(/\s+/g, "-")
-      .replace(/-+/g, "-")
-      .trim();
+    // Use shared helper to generate ID - ensures consistency with heading renderers
+    const id = generateHeadingId(text);
 
     headers.push({
       level,


### PR DESCRIPTION
In marked v17+, the heading renderer receives `text` with already-rendered HTML (e.g., `Hello <strong>World</strong>`) instead of raw markdown. This caused IDs generated in the renderer to differ from those generated by extractHeaders (which processes raw markdown), making TOC navigation fail since document.getElementById() couldn't find matching elements.

- Add stripHtmlTags helper to strip HTML before ID generation
- Add shared generateHeadingId helper for consistency
- Update all heading renderers and extractHeaders to use shared logic