### PR TITLE
fix: remove stale @jsquash/jxl entry from root lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,10 +14,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      '@jsquash/jxl':
-        specifier: ^1.3.0
-        version: 1.3.0
     devDependencies:
       wrangler:
         specifier: ^4.54.0


### PR DESCRIPTION
The lockfile had a dependency entry for @jsquash/jxl in the root
workspace that didn't exist in package.json, causing pnpm install
to fail during CI deployments.

This dependency correctly exists in packages/engine/package.json
but was erroneously recorded in the root workspace section.