### PR TITLE
fix: add Contact link to mobile menu Connect section

### DIFF
--- a/packages/engine/src/lib/ui/components/chrome/defaults.ts
+++ b/packages/engine/src/lib/ui/components/chrome/defaults.ts
@@ -135,9 +135,11 @@ export const DEFAULT_MOBILE_RESOURCE_LINKS: FooterLink[] = [
 ];
 
 // Connect section (mobile menu)
-// Excludes: Contact, Blog (already in mobile nav)
+// Note: Contact appears in both main nav and here for discoverability
+// (matches desktop footer placement)
 export const DEFAULT_MOBILE_CONNECT_LINKS: FooterLink[] = [
   { href: "/hello", label: "Hello", icon: HeartHandshake },
+  { href: "/contact", label: "Contact", icon: Mail },
   {
     href: "https://github.com/AutumnsGrove/GroveEngine",
     label: "GitHub",


### PR DESCRIPTION
Contact was only showing in the main mobile nav items but was missing
from the Connect section, making it inconsistent with the desktop footer
where Contact appears in the Connect column. Now Contact shows in both
locations on mobile for better discoverability.