### PR TITLE
fix(kb): use Grove green and default vine background for help center

### DIFF
--- a/landing/src/routes/knowledge/+page.svelte
+++ b/landing/src/routes/knowledge/+page.svelte
@@ -75,8 +75,8 @@
       <!-- Help Center -->
       <div class="bg-surface-elevated rounded-lg shadow-sm border border-default p-6 hover:shadow-md transition-shadow">
         <div class="flex items-center mb-4">
-          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mr-4">
-            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-12 h-12 bg-emerald-100 dark:bg-emerald-900/30 rounded-lg flex items-center justify-center mr-4">
+            <svg class="w-6 h-6 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
@@ -91,13 +91,13 @@
         <div class="space-y-2 mb-4">
           {#each helpArticles.slice(0, 3) as article}
             <div class="text-sm">
-              <a href="/knowledge/help/{article.slug}" class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
+              <a href="/knowledge/help/{article.slug}" class="text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300 font-medium transition-colors">
                 {article.title}
               </a>
             </div>
           {/each}
         </div>
-        <a href="/knowledge/help" class="inline-flex items-center text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
+        <a href="/knowledge/help" class="inline-flex items-center text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300 font-medium transition-colors">
           Browse all articles
           <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />

--- a/landing/src/routes/knowledge/help/+page.svelte
+++ b/landing/src/routes/knowledge/help/+page.svelte
@@ -39,14 +39,14 @@
   url="/knowledge/help"
 />
 
-<main class="min-h-screen flex flex-col bg-slate-50 dark:bg-slate-900">
+<main class="min-h-screen flex flex-col">
   <Header />
 
   <!-- Hero -->
-  <section class="relative py-12 px-6 text-center bg-gradient-to-b from-blue-50 via-slate-50 to-white dark:from-blue-950/30 dark:via-slate-900 dark:to-slate-950">
+  <section class="relative py-12 px-6 text-center bg-gradient-to-b from-emerald-50/80 via-transparent to-transparent dark:from-emerald-950/20 dark:via-transparent dark:to-transparent">
     <div class="max-w-3xl mx-auto">
       <nav class="flex items-center justify-center space-x-2 text-sm text-foreground-muted mb-6">
-        <a href="/knowledge" class="hover:text-blue-600 dark:hover:text-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded transition-colors">Knowledge Base</a>
+        <a href="/knowledge" class="hover:text-emerald-600 dark:hover:text-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 rounded transition-colors">Knowledge Base</a>
         <span>/</span>
         <span class="text-foreground">Help Center</span>
       </nav>
@@ -69,16 +69,16 @@
         <div class="relative group">
           <a
             href="#{getSectionId(section.name)}"
-            class="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-slate-800 shadow-md border border-blue-200 dark:border-slate-700 hover:bg-blue-100 dark:hover:bg-blue-900/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-all duration-200 motion-reduce:transition-none"
+            class="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-slate-800 shadow-md border border-emerald-200 dark:border-slate-700 hover:bg-emerald-100 dark:hover:bg-emerald-900/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 transition-all duration-200 motion-reduce:transition-none"
             aria-label="Jump to {section.name}"
             title="{section.name} ({sectionArticles.length})"
           >
-            <SectionIcon class="w-5 h-5 text-blue-600 dark:text-blue-400 group-hover:scale-110 motion-reduce:group-hover:scale-100 transition-transform motion-reduce:transition-none" />
+            <SectionIcon class="w-5 h-5 text-emerald-600 dark:text-emerald-400 group-hover:scale-110 motion-reduce:group-hover:scale-100 transition-transform motion-reduce:transition-none" />
           </a>
 
           <!-- Section name tooltip on hover -->
           <div class="absolute right-full mr-3 top-1/2 -translate-y-1/2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 motion-reduce:transition-none">
-            <div class="px-3 py-1.5 rounded-lg bg-white dark:bg-slate-800 shadow-md border border-blue-200 dark:border-slate-700 text-sm font-medium text-foreground whitespace-nowrap">
+            <div class="px-3 py-1.5 rounded-lg bg-white dark:bg-slate-800 shadow-md border border-emerald-200 dark:border-slate-700 text-sm font-medium text-foreground whitespace-nowrap">
               {section.name}
               <span class="text-foreground-muted">({sectionArticles.length})</span>
             </div>
@@ -93,7 +93,7 @@
     <button
       type="button"
       onclick={() => isMobileTocOpen = !isMobileTocOpen}
-      class="w-12 h-12 rounded-full bg-blue-500 text-white shadow-lg flex items-center justify-center hover:bg-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none"
+      class="w-12 h-12 rounded-full bg-emerald-500 text-white shadow-lg flex items-center justify-center hover:bg-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none"
       aria-expanded={isMobileTocOpen}
       aria-label="Table of contents"
     >
@@ -103,10 +103,10 @@
     </button>
 
     {#if isMobileTocOpen}
-      <div class="absolute bottom-16 right-0 w-72 bg-white dark:bg-slate-800 rounded-xl shadow-xl border border-blue-200 dark:border-slate-700 overflow-hidden max-h-[70vh] overflow-y-auto">
-        <div class="px-4 py-3 border-b border-blue-200 dark:border-slate-700 flex items-center justify-between sticky top-0 bg-white dark:bg-slate-800">
+      <div class="absolute bottom-16 right-0 w-72 bg-white dark:bg-slate-800 rounded-xl shadow-xl border border-emerald-200 dark:border-slate-700 overflow-hidden max-h-[70vh] overflow-y-auto">
+        <div class="px-4 py-3 border-b border-emerald-200 dark:border-slate-700 flex items-center justify-between sticky top-0 bg-white dark:bg-slate-800">
           <span class="font-medium text-foreground">Sections</span>
-          <button type="button" onclick={() => isMobileTocOpen = false} class="text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded transition-colors motion-reduce:transition-none" aria-label="Close">
+          <button type="button" onclick={() => isMobileTocOpen = false} class="text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded transition-colors motion-reduce:transition-none" aria-label="Close">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -120,9 +120,9 @@
               <a
                 href="#{getSectionId(section.name)}"
                 onclick={() => isMobileTocOpen = false}
-                class="flex items-center gap-3 px-4 py-2 text-foreground-muted hover:text-foreground hover:bg-blue-50 dark:hover:bg-blue-900/20 focus-visible:outline-none focus-visible:bg-blue-50 dark:focus-visible:bg-blue-900/20 focus-visible:text-foreground transition-colors motion-reduce:transition-none"
+                class="flex items-center gap-3 px-4 py-2 text-foreground-muted hover:text-foreground hover:bg-emerald-50 dark:hover:bg-emerald-900/20 focus-visible:outline-none focus-visible:bg-emerald-50 dark:focus-visible:bg-emerald-900/20 focus-visible:text-foreground transition-colors motion-reduce:transition-none"
               >
-                <SectionIcon class="w-5 h-5 text-blue-500" />
+                <SectionIcon class="w-5 h-5 text-emerald-500" />
                 <span class="font-medium">{section.name}</span>
                 <span class="ml-auto text-xs text-foreground-faint">{sectionArticles.length}</span>
               </a>
@@ -144,7 +144,7 @@
           <div id={getSectionId(section.name)}>
             <!-- Section Header -->
             <div class="flex items-center gap-4 mb-8">
-              <div class="w-12 h-12 rounded-xl bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center text-blue-600 dark:text-blue-400">
+              <div class="w-12 h-12 rounded-xl bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center text-emerald-600 dark:text-emerald-400">
                 <SectionIcon class="w-6 h-6" />
               </div>
               <div>
@@ -156,15 +156,15 @@
             <!-- Articles Grid -->
             <div class="grid gap-4">
               {#each sectionArticles as article}
-                <article class="p-5 rounded-xl bg-white dark:bg-slate-800 shadow-sm border border-blue-200/50 dark:border-slate-700 hover:shadow-md hover:border-blue-300 dark:hover:border-blue-700/50 focus-within:shadow-md focus-within:border-blue-300 dark:focus-within:border-blue-700/50 transition-all motion-reduce:transition-none">
+                <article class="p-5 rounded-xl bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm shadow-sm border border-emerald-200/50 dark:border-slate-700 hover:shadow-md hover:border-emerald-300 dark:hover:border-emerald-700/50 focus-within:shadow-md focus-within:border-emerald-300 dark:focus-within:border-emerald-700/50 transition-all motion-reduce:transition-none">
                   <h3 class="text-lg font-semibold text-foreground mb-2">
-                    <a href="/knowledge/help/{article.slug}" class="hover:text-blue-600 dark:hover:text-blue-400 focus-visible:outline-none focus-visible:text-blue-600 dark:focus-visible:text-blue-400 transition-colors motion-reduce:transition-none">
+                    <a href="/knowledge/help/{article.slug}" class="hover:text-emerald-600 dark:hover:text-emerald-400 focus-visible:outline-none focus-visible:text-emerald-600 dark:focus-visible:text-emerald-400 transition-colors motion-reduce:transition-none">
                       {article.title}
                     </a>
                   </h3>
                   <p class="text-foreground-muted mb-3 line-clamp-2">{article.excerpt}</p>
                   <div class="flex items-center justify-between text-sm">
-                    <a href="/knowledge/help/{article.slug}" class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium transition-colors">
+                    <a href="/knowledge/help/{article.slug}" class="text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300 font-medium transition-colors">
                       Read more
                       <svg class="w-4 h-4 ml-1 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -180,12 +180,12 @@
       {/each}
 
       <!-- Contact Support CTA -->
-      <div class="text-center p-8 rounded-xl bg-blue-100/50 dark:bg-blue-950/25 backdrop-blur-md border border-dashed border-blue-300 dark:border-blue-800/30">
+      <div class="text-center p-8 rounded-xl bg-emerald-100/50 dark:bg-emerald-950/25 backdrop-blur-md border border-dashed border-emerald-300 dark:border-emerald-800/30">
         <h3 class="text-xl font-semibold text-foreground mb-2">Need more help?</h3>
         <p class="text-foreground-muted mb-4">
           Can't find what you're looking for? Contact our support team and we'll get back to you within 48 hours.
         </p>
-        <a href="mailto:autumnbrown23@pm.me" class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
+        <a href="mailto:autumnbrown23@pm.me" class="inline-flex items-center px-4 py-2 bg-emerald-600 dark:bg-emerald-500 text-white rounded-lg hover:bg-emerald-700 dark:hover:bg-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
           Contact Support
           <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
@@ -196,12 +196,12 @@
   </section>
 
   <!-- Links -->
-  <section class="py-8 px-6 bg-white/50 dark:bg-slate-900/50 border-t border-divider">
+  <section class="py-8 px-6 bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm border-t border-divider">
     <div class="max-w-4xl mx-auto flex flex-wrap justify-center gap-4">
-      <a href="/knowledge" class="px-4 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
+      <a href="/knowledge" class="px-4 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
         ← Knowledge Base
       </a>
-      <a href="/knowledge/specs" class="px-4 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
+      <a href="/knowledge/specs" class="px-4 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
         Technical Specs →
       </a>
     </div>


### PR DESCRIPTION
- Remove explicit bg-slate background from help page to show leaf-pattern
- Change all blue colors to emerald (Grove green) on help center page
- Update Help Center category on main KB page to use emerald
- Add backdrop-blur to article cards and bottom section for consistency