### PR TITLE
fix(kb): replace broken /support links with /contact

### DIFF
--- a/docs/help-center/articles/account-deletion.md
+++ b/docs/help-center/articles/account-deletion.md
@@ -95,4 +95,4 @@ If something about Grove drove you away, we'd genuinely appreciate knowing what.
 
 ---
 
-*Need help with the deletion process? [Contact support](/support) and we'll walk you through it.*
+*Need help with the deletion process? [Contact support](/contact) and we'll walk you through it.*

--- a/docs/help-center/articles/browser-compatibility.md
+++ b/docs/help-center/articles/browser-compatibility.md
@@ -97,7 +97,7 @@ If an extension is the problem, you can usually whitelist Grove rather than disa
 
 ### Step 5: Contact support
 
-If you've tried the above and things still aren't working, [contact us](/support) with:
+If you've tried the above and things still aren't working, [contact us](/contact) with:
 
 - Your browser and version
 - What you're trying to do
@@ -129,4 +129,4 @@ If you use assistive technology and encounter barriers, please let us know. Acce
 
 ---
 
-*Having browser issues we haven't covered? [Reach out](/support)—we want to know about edge cases.*
+*Having browser issues we haven't covered? [Reach out](/contact)—we want to know about edge cases.*

--- a/docs/help-center/articles/checking-grove-status.md
+++ b/docs/help-center/articles/checking-grove-status.md
@@ -97,4 +97,4 @@ The status page shows the past 30 days of incidents. You can see what happened, 
 
 ---
 
-*If something's broken and the status page doesn't mention it, [let us know](/support). We want to know about issues we haven't caught yet.*
+*If something's broken and the status page doesn't mention it, [let us know](/contact). We want to know about issues we haven't caught yet.*

--- a/docs/help-center/articles/choosing-your-plan.md
+++ b/docs/help-center/articles/choosing-your-plan.md
@@ -120,4 +120,4 @@ All plans include:
 
 ---
 
-*Questions about which plan fits? [Ask us](/support). We'll give you an honest answer, even if it's "Seedling is probably enough."*
+*Questions about which plan fits? [Ask us](/contact). We'll give you an honest answer, even if it's "Seedling is probably enough."*

--- a/docs/help-center/articles/creating-your-account.md
+++ b/docs/help-center/articles/creating-your-account.md
@@ -82,4 +82,4 @@ Your Grove account is tied to a specific Google account. You can't merge account
 
 ---
 
-*Questions about signing up? Something not working? [Reach out](/support). We'll help you get sorted.*
+*Questions about signing up? Something not working? [Reach out](/contact). We'll help you get sorted.*

--- a/docs/help-center/articles/gdpr-and-privacy-rights.md
+++ b/docs/help-center/articles/gdpr-and-privacy-rights.md
@@ -134,7 +134,7 @@ Grove is built on Cloudflare's global network. Your data may be processed in dif
 - Correct: Edit your content directly in the admin panel
 
 **Email** (for anything else):
-- Contact: [support](/support)
+- Contact: [support](/contact)
 - Response time: Within 30 days (usually much faster)
 
 ## For blog readers

--- a/docs/help-center/articles/my-site-isnt-loading.md
+++ b/docs/help-center/articles/my-site-isnt-loading.md
@@ -46,7 +46,7 @@ If you see an incident listed, we're already aware and working on it. Status upd
 This usually means the domain isn't pointing to Grove correctly.
 
 **If you're using a grove.place subdomain:**
-This shouldn't happen. [Contact us](/support) with your blog URL—something's wrong on our end.
+This shouldn't happen. [Contact us](/contact) with your blog URL—something's wrong on our end.
 
 **If you're using a custom domain:**
 Check that your DNS records are still configured correctly:
@@ -68,7 +68,7 @@ Something went wrong on our end.
 
 - Refresh the page and try again
 - If it persists, check **status.grove.place** for known issues
-- If there's no incident posted, [contact us](/support): this is something we need to fix
+- If there's no incident posted, [contact us](/contact): this is something we need to fix
 
 ### Slow loading or timing out
 
@@ -76,7 +76,7 @@ If your site loads but takes forever:
 
 - Large images can slow things down. Consider compressing them before uploading.
 - If it's only slow sometimes, we might be experiencing high traffic. It should resolve on its own.
-- Persistent slowness? [Let us know](/support). We want your blog to be fast.
+- Persistent slowness? [Let us know](/contact). We want your blog to be fast.
 
 ## If you have a custom domain
 
@@ -86,7 +86,7 @@ Custom domain issues have their own quirks. Common culprits:
 - **Domain expired:** Check that your domain registration is current with your registrar.
 - **DNS provider issues:** Sometimes the problem is upstream. Try checking your registrar's status page.
 
-If you're still having trouble with your custom domain, [contact us](/support) with your domain name and we'll help you troubleshoot.
+If you're still having trouble with your custom domain, [contact us](/contact) with your domain name and we'll help you troubleshoot.
 
 ## Still stuck?
 
@@ -94,7 +94,7 @@ If you've tried the above and your site is still down:
 
 1. **Note the exact error message** you're seeing (screenshot if possible)
 2. **Note your blog URL** (subdomain or custom domain)
-3. **Contact us at [/support](/support)**
+3. **Contact us at [/contact](/contact)**
 
 Include those details in your message. We'll prioritize site-down issues and get back to you as quickly as we can.
 

--- a/docs/help-center/articles/the-markdown-editor.md
+++ b/docs/help-center/articles/the-markdown-editor.md
@@ -79,4 +79,4 @@ Line numbers appear on the left side of the editor. The current line is highligh
 
 ---
 
-*The editor should feel natural after a few posts. If something's confusing or not working as expected, [let us know](/support).*
+*The editor should feel natural after a few posts. If something's confusing or not working as expected, [let us know](/contact).*

--- a/docs/help-center/articles/upgrading-or-downgrading.md
+++ b/docs/help-center/articles/upgrading-or-downgrading.md
@@ -85,4 +85,4 @@ Downgrades don't trigger refunds for the current period. You keep access to your
 
 ---
 
-*Questions about which plan fits? [Ask us](/support)—we'll give you an honest recommendation.*
+*Questions about which plan fits? [Ask us](/contact)—we'll give you an honest recommendation.*

--- a/docs/help-center/articles/what-is-grove.md
+++ b/docs/help-center/articles/what-is-grove.md
@@ -88,4 +88,4 @@ Grove is built on a few principles:
 
 ---
 
-*Questions about whether Grove is right for you? [Reach out](/support)—we're happy to chat.*
+*Questions about whether Grove is right for you? [Reach out](/contact)—we're happy to chat.*

--- a/docs/help-center/articles/writing-your-first-post.md
+++ b/docs/help-center/articles/writing-your-first-post.md
@@ -86,4 +86,4 @@ That's it. You're a blogger now.
 
 ---
 
-*Stuck on something? The writing experience should be smooth. If it's not, [let us know](/support).*
+*Stuck on something? The writing experience should be smooth. If it's not, [let us know](/contact).*


### PR DESCRIPTION
The /support route redirects to the knowledge base, making these links
circular and unhelpful. Updated all 11 help center articles to use
/contact instead, which is the correct page for reaching support.