### PR TITLE
feat(kb): add related content section to knowledge base articles

### DIFF
--- a/landing/src/lib/components/RelatedArticles.svelte
+++ b/landing/src/lib/components/RelatedArticles.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { FileText, ArrowRight } from 'lucide-svelte';
+  import type { Doc } from '$lib/types/docs';
+  import { kbCategoryColors } from '$lib/utils/kb-colors';
+
+  interface Props {
+    articles: Doc[];
+  }
+
+  let { articles }: Props = $props();
+
+  // Get colors for article category with fallback
+  function getColors(article: Doc) {
+    return kbCategoryColors[article.category] || kbCategoryColors.help;
+  }
+</script>
+
+{#if articles.length > 0}
+  <aside class="mt-12 pt-8 border-t border-divider">
+    <h2 class="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+      <FileText class="w-5 h-5 text-foreground-muted" />
+      Related Content
+    </h2>
+
+    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {#each articles as article}
+        {@const colors = getColors(article)}
+        <a
+          href="/knowledge/{article.category}/{article.slug}"
+          class="group p-4 rounded-xl bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border border-slate-200/50 dark:border-slate-700/50 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-grove-green focus-visible:ring-offset-2 transition-all motion-reduce:transition-none"
+        >
+          <div class="flex items-start gap-3">
+            <div class="w-8 h-8 rounded-lg {colors.iconBg} {colors.iconBgDark} flex items-center justify-center flex-shrink-0">
+              <FileText class="w-4 h-4 {colors.text} {colors.textDark}" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <h3 class="text-sm font-medium text-foreground group-hover:text-grove-green dark:group-hover:text-emerald-400 transition-colors line-clamp-2">
+                {article.title}
+              </h3>
+              <p class="text-xs text-foreground-muted mt-1 line-clamp-2">
+                {article.excerpt}
+              </p>
+              <span class="inline-flex items-center text-xs {colors.text} {colors.textDark} mt-2 group-hover:gap-1.5 transition-all">
+                Read article
+                <ArrowRight class="w-3 h-3 ml-1 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </span>
+            </div>
+          </div>
+        </a>
+      {/each}
+    </div>
+  </aside>
+{/if}

--- a/landing/src/lib/types/docs.ts
+++ b/landing/src/lib/types/docs.ts
@@ -54,6 +54,8 @@ export interface Doc extends Record<string, unknown> {
   specCategory?: SpecCategory;
   /** Optional help section for grouping help articles */
   section?: HelpSection;
+  /** Optional array of related article slugs */
+  related?: string[];
 }
 
 /** Header extracted from markdown for table of contents */

--- a/landing/src/lib/utils/docs-loader.ts
+++ b/landing/src/lib/utils/docs-loader.ts
@@ -159,6 +159,7 @@ function parseDoc(filePath: string, category: DocCategory): DocInternal {
     category,
     lastUpdated: data.lastUpdated || new Date().toISOString().split("T")[0],
     readingTime: calculateReadingTime(markdownContent),
+    related: Array.isArray(data.related) ? data.related : undefined,
     _filePath: filePath,
   };
 }

--- a/landing/src/routes/knowledge/[category]/[slug]/+page.server.ts
+++ b/landing/src/routes/knowledge/[category]/[slug]/+page.server.ts
@@ -1,6 +1,6 @@
 import { loadDocBySlug } from "$lib/utils/docs-loader";
 import { allDocs } from "$lib/data/knowledge-base";
-import type { DocCategory } from "$lib/types/docs";
+import type { Doc, DocCategory } from "$lib/types/docs";
 import { error } from "@sveltejs/kit";
 import type { PageServerLoad, EntryGenerator } from "./$types";
 
@@ -42,7 +42,17 @@ export const load: PageServerLoad = async ({ params }) => {
     throw error(404, "Document not found");
   }
 
+  // Resolve related articles by slug (limit to 3 for clean presentation)
+  let relatedArticles: Doc[] = [];
+  if (doc.related && doc.related.length > 0) {
+    relatedArticles = doc.related
+      .slice(0, 3)
+      .map((relatedSlug) => allDocs.find((d) => d.slug === relatedSlug))
+      .filter((d): d is Doc => d !== undefined);
+  }
+
   return {
     doc,
+    relatedArticles,
   };
 };

--- a/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
+++ b/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
@@ -5,6 +5,7 @@
   import { Header, Footer } from '@autumnsgrove/groveengine/ui/chrome';
   import SEO from '$lib/components/SEO.svelte';
   import TableOfContents from '$lib/components/TableOfContents.svelte';
+  import RelatedArticles from '$lib/components/RelatedArticles.svelte';
   import { kbCategoryColors, categoryLabels } from '$lib/utils/kb-colors';
   import type { DocCategory } from '$lib/types/docs';
   import '$lib/styles/content.css';
@@ -12,6 +13,7 @@
   let { data } = $props();
 
   let doc = $derived(data.doc);
+  let relatedArticles = $derived(data.relatedArticles || []);
   let category = $derived($page.params.category as DocCategory);
   let slug = $derived($page.params.slug);
   let headers = $derived(doc?.headers || []);
@@ -154,6 +156,9 @@
           <article class="content-body prose prose-slate dark:prose-invert max-w-none">
             {@html doc.html || `<p class="text-foreground-muted leading-relaxed">${doc.excerpt}</p>`}
           </article>
+
+          <!-- Related Articles -->
+          <RelatedArticles articles={relatedArticles} />
 
           <!-- Article Footer -->
           <footer class="flex items-center justify-between mt-12">


### PR DESCRIPTION
Display related articles at the bottom of knowledge base pages using
the existing `related` field from markdown front matter. Changes:

- Add `related?: string[]` to Doc type
- Extract related field in docs-loader parseDoc function
- Resolve related slugs to full article metadata in server loader
- Create RelatedArticles.svelte component with glass styling
- Integrate component into article page layout

Related articles are limited to 3 for clean presentation and use
seasonal category colors consistent with Prism design system.