### PR TITLE
fix(logo): extend trunk to viewBox bottom for proper ground anchoring

### DIFF
--- a/packages/engine/src/lib/ui/components/ui/GlassLogo.svelte
+++ b/packages/engine/src/lib/ui/components/ui/GlassLogo.svelte
@@ -324,9 +324,9 @@
 	const tier3DarkPath = "M50 38 L18 68 L50 54 Z";
 	const tier3LightPath = "M50 38 L50 54 L82 68 Z";
 
-	// Trunk
-	const trunkDarkPath = "M50 54 L42 58 L46 92 L50 92 Z";
-	const trunkLightPath = "M50 54 L58 58 L54 92 L50 92 Z";
+	// Trunk (extends to y=100 to match viewBox bottom, ensuring tree "sticks" to ground properly)
+	const trunkDarkPath = "M50 54 L42 58 L46 100 L50 100 Z";
+	const trunkLightPath = "M50 54 L58 58 L54 100 L50 100 Z";
 </script>
 
 <svg

--- a/packages/engine/src/lib/ui/components/ui/Logo.svelte
+++ b/packages/engine/src/lib/ui/components/ui/Logo.svelte
@@ -311,8 +311,9 @@
 	const tier3LightPath = "M50 38 L50 54 L82 68 Z";
 
 	// Trunk (two-tone for depth)
-	const trunkDarkPath = "M50 54 L42 58 L46 92 L50 92 Z";
-	const trunkLightPath = "M50 54 L58 58 L54 92 L50 92 Z";
+	// Trunk extends to y=100 to match viewBox bottom, ensuring tree "sticks" to ground properly
+	const trunkDarkPath = "M50 54 L42 58 L46 100 L50 100 Z";
+	const trunkLightPath = "M50 54 L58 58 L54 100 L50 100 Z";
 </script>
 
 <svg


### PR DESCRIPTION
The Logo tree trunk previously ended at y=92 in a 100-unit viewBox,
leaving 8% empty space at the bottom. This caused the logo tree to
"float" above hills in forest scenes, as the translateY(-97%) positioning
assumed the visual bottom aligned with the viewBox bottom.

Extended trunk paths from y=92 to y=100 in both Logo.svelte and
GlassLogo.svelte, matching the behavior of other tree components
(e.g., TreePine) where the visual bottom reaches the viewBox edge.