### PR TITLE
fix(ui): add Safari Reader Mode fallback for glass components

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -291,9 +291,9 @@ Created detailed implementation plans in `docs/plans/planned/`:
 ## Safari Reader Mode & Glass Cards
 > **Issue:** Safari Reader Mode strips `backdrop-blur`, making glass card content invisible
 > **Plan:** `docs/plans/planned/code-quality-optimizations.md` (§1)
-> **Status:** Fallback exists in `domains/src/app.css` but NOT in engine
+> **Status:** Fallback added to engine ✅
 
-- [ ] Add `@supports not (backdrop-filter: blur(1px))` fallback to engine
+- [x] Add `@supports not (backdrop-filter: blur(4px))` fallback to engine ✅ (Jan 18, 2026)
 - [ ] Wrap glass card content in semantic `<article>` or `<section>` elements
 - [ ] Test fix in Safari iOS and macOS
 

--- a/packages/engine/src/lib/ui/styles/grove.css
+++ b/packages/engine/src/lib/ui/styles/grove.css
@@ -862,4 +862,61 @@
       backdrop-filter: none;
     }
   }
+
+  /* Safari Reader Mode & older browser fallback
+     When backdrop-filter isn't supported, glass elements become invisible.
+     This provides solid backgrounds as a fallback for readability. */
+  @supports not (backdrop-filter: blur(4px)) {
+    /* Light mode fallbacks */
+    .glass {
+      background-color: rgb(255 255 255 / 0.95);
+    }
+    .glass-surface {
+      background-color: rgb(255 255 255 / 0.98);
+    }
+    .glass-overlay {
+      background-color: rgb(0 0 0 / 0.7);
+    }
+    .glass-accent {
+      background-color: rgb(34 197 94 / 0.25); /* grove-500 approximation */
+    }
+    .glass-muted {
+      background-color: rgb(255 255 255 / 0.85);
+    }
+    .glass-tint {
+      background-color: rgb(255 255 255 / 0.90);
+    }
+    .glass-dark {
+      background-color: rgb(15 23 42 / 0.95);
+    }
+    .glass-frosted {
+      background-color: rgb(255 255 255 / 0.97);
+    }
+
+    /* Dark mode fallbacks */
+    :is(.dark .glass) {
+      background-color: rgb(30 41 59 / 0.95);
+    }
+    :is(.dark .glass-surface) {
+      background-color: rgb(30 41 59 / 0.98);
+    }
+    :is(.dark .glass-overlay) {
+      background-color: rgb(0 0 0 / 0.8);
+    }
+    :is(.dark .glass-accent) {
+      background-color: rgb(34 197 94 / 0.20);
+    }
+    :is(.dark .glass-muted) {
+      background-color: rgb(15 23 42 / 0.85);
+    }
+    :is(.dark .glass-tint) {
+      background-color: rgb(15 23 42 / 0.90);
+    }
+    :is(.dark .glass-dark) {
+      background-color: rgb(2 6 23 / 0.95);
+    }
+    :is(.dark .glass-frosted) {
+      background-color: rgb(30 41 59 / 0.97);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds `@supports not (backdrop-filter)` fallback to glass components in the engine package. Safari Reader Mode (and some older browsers) strips backdrop-filter, making glass elements nearly invisible. This ensures content remains readable.

## Changes

- Add fallback backgrounds for all 8 glass variants in `grove.css`
- Cover both light and dark mode
- Update TODOS.md to mark task complete

## Type

fix

## Testing

- CSS-only change, all tests pass
- Pattern already validated in `domains/src/app.css`
- To manually test: Open any page with glass components in Safari, enable Reader Mode

## Visual Behavior

| Browser State | Before | After |
|--------------|--------|-------|
| Normal | Glass blur effect ✅ | Glass blur effect ✅ |
| Safari Reader / No backdrop-filter | Invisible content ❌ | Solid background ✅ |

🤖 Generated with [Claude Code](https://claude.ai/code)