### PR TITLE
fix(routing): correct data portability policy links

### DIFF
--- a/docs/internal/business/grove-pricing.md
+++ b/docs/internal/business/grove-pricing.md
@@ -196,7 +196,7 @@ When we register a domain for you, **you own it**. If you ever leave Grove:
 - We provide authorization codes within 48 hours
 - No transfer fees, no hostage situations
 
-See our [Data Portability & Separation Policy](https://grove.place/legal/data-portability) for full details.
+See our [Data Portability & Separation Policy](https://grove.place/knowledge/legal/data-portability-separation) for full details.
 
 ---
 

--- a/packages/landing/src/routes/pricing/+page.svelte
+++ b/packages/landing/src/routes/pricing/+page.svelte
@@ -505,7 +505,7 @@
               Grove is designed around portability. Export everything at any
               time. If we ever register a domain for you, you own it — transfer
               it whenever you want, no fees, no questions. See our <a
-                href="/legal/data-portability"
+                href="/knowledge/legal/data-portability-separation"
                 class="text-accent-muted hover:text-primary underline"
                 >Data Portability Policy</a
               > for details.


### PR DESCRIPTION
The pricing page and internal docs linked to /legal/data-portability
which doesn't exist as a SvelteKit route. Updated to use the correct
path /knowledge/legal/data-portability-separation that matches the
knowledge base routing pattern.