### PR TITLE
claude/update-personal-email-rAkEF

### DIFF
--- a/docs/help-center/articles/contact-support.md
+++ b/docs/help-center/articles/contact-support.md
@@ -15,7 +15,7 @@ When you need help with something the documentation doesn't cover, here's how to
 
 ## How to contact us
 
-**Email:** [autumnbrown23@pm.me](mailto:autumnbrown23@pm.me)
+**Email:** [hello@grove.place](mailto:hello@grove.place)
 
 That's it. No ticket system, no chatbot maze, no "press 1 for billing". Just send an email and a human will read it.
 
@@ -89,7 +89,7 @@ That said, don't hesitate to reach out if you're stuck. "I tried searching but c
 
 Want to suggest a feature or share feedback about Grove? Same email address:
 
-**[autumnbrown23@pm.me](mailto:autumnbrown23@pm.me)**
+**[hello@grove.place](mailto:hello@grove.place)**
 
 Feature requests are always welcome. Can't promise everything gets built, but everything gets read and considered.
 

--- a/docs/internal/business/grove-pricing.md
+++ b/docs/internal/business/grove-pricing.md
@@ -277,7 +277,7 @@ A professional email address for your blog—no extra cost, no separate service 
 
 Need something beyond Evergreen? Multiple domains, white-label options, team collaboration, dedicated support. Let's talk.
 
-**Contact:** autumnbrown23@pm.me
+**Contact:** hello@grove.place
 
 ---
 

--- a/docs/internal/pricing-discussions.md
+++ b/docs/internal/pricing-discussions.md
@@ -485,7 +485,7 @@ As product matures and Seedling users upgrade or churn:
 
 For users with special needs beyond Evergreen:
 
-> **Custom Plans:** Need something specific? Let's talk. Custom storage, multiple domains, white-label options, team collaboration, dedicated support. Contact autumnbrown23@pm.me.
+> **Custom Plans:** Need something specific? Let's talk. Custom storage, multiple domains, white-label options, team collaboration, dedicated support. Contact hello@grove.place.
 
 No public pricing. Handle case-by-case based on actual requirements.
 

--- a/docs/legal/acceptable-use-policy.md
+++ b/docs/legal/acceptable-use-policy.md
@@ -236,7 +236,7 @@ When we remove content:
 
 ### 5.4 Reporting Violations
 
-If you see content that violates this policy, please report it by emailing autumnbrown23@pm.me with:
+If you see content that violates this policy, please report it by emailing hello@grove.place with:
 - A link to the content
 - The specific rule you believe was violated
 - Any additional context
@@ -283,7 +283,7 @@ We may update this policy as our community grows and evolves. Significant change
 
 If you have questions about what's allowed, please ask before posting. We're happy to clarify.
 
-**Email:** autumnbrown23@pm.me
+**Email:** hello@grove.place
 
 ---
 

--- a/docs/legal/data-portability-separation.md
+++ b/docs/legal/data-portability-separation.md
@@ -88,7 +88,7 @@ grove-export-username-YYYY-MM-DD.zip
 ### How to Request an Export
 
 1. **Self-service:** Admin Panel → Settings → Export Data
-2. **Email:** autumnbrown23@pm.me
+2. **Email:** hello@grove.place
 3. **Automatic on cancellation:** Export link sent within 24 hours
 
 Exports are generated within 24 hours and available for download for 30 days.
@@ -117,7 +117,7 @@ When Grove registers a custom domain on your behalf (Evergreen tier), you are th
 4. **No fees:** Grove charges no transfer fees
 
 **To request a domain transfer:**
-- Email: autumnbrown23@pm.me
+- Email: hello@grove.place
 - Subject: "Domain Transfer Request - yourdomain.com"
 - We'll respond with your EPP/authorization code within 48 hours
 
@@ -186,13 +186,13 @@ Grove commits to the following:
 4. **No content held for ransom** under any circumstances
 5. **Standard formats** for all exports (Markdown, JSON, common image formats)
 
-If you ever feel Grove is not honoring this commitment, contact autumnbrown23@pm.me directly.
+If you ever feel Grove is not honoring this commitment, contact hello@grove.place directly.
 
 ---
 
 ## Questions?
 
-**Email:** autumnbrown23@pm.me
+**Email:** hello@grove.place
 **Response time:** Within 48 hours
 
 ---

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -207,7 +207,7 @@ You can update your account information at any time through your settings.
 
 ### 5.4 Delete Your Data
 
-You can request deletion of your account and all associated data by contacting us at autumnbrown23@pm.me. Deletion will be processed within 30 days.
+You can request deletion of your account and all associated data by contacting us at hello@grove.place. Deletion will be processed within 30 days.
 
 ### 5.5 Opt Out of Communications
 
@@ -235,7 +235,7 @@ We take security seriously and implement industry-standard measures to protect y
 - Minimal data access on a need-to-know basis
 - No third-party access to raw user data
 
-While we implement strong security measures, no system is 100% secure. If you discover a security vulnerability, please report it to autumnbrown23@pm.me.
+While we implement strong security measures, no system is 100% secure. If you discover a security vulnerability, please report it to hello@grove.place.
 
 ---
 
@@ -265,7 +265,7 @@ You can configure your browser to block cookies, but this may prevent you from u
 
 Grove is not intended for users under 18 years of age. We do not knowingly collect personal information from anyone under 18. If we learn that we have collected data from someone under 18, we will delete it promptly.
 
-If you believe a child under 18 has provided us with personal information, please contact us at autumnbrown23@pm.me.
+If you believe a child under 18 has provided us with personal information, please contact us at hello@grove.place.
 
 ---
 
@@ -298,7 +298,7 @@ We encourage you to review this policy periodically.
 
 If you have questions about this Privacy Policy or your personal data, please contact us:
 
-**Email:** autumnbrown23@pm.me
+**Email:** hello@grove.place
 
 We will respond to privacy-related inquiries within 30 days.
 

--- a/docs/legal/refund-policy.md
+++ b/docs/legal/refund-policy.md
@@ -32,7 +32,7 @@ After the 14-day period, you may still request a refund. We will provide a **pro
 
 To request a refund, email us at:
 
-**Email:** autumnbrown23@pm.me
+**Email:** hello@grove.place
 **Subject:** Refund Request
 
 Please include:
@@ -50,7 +50,7 @@ We will process your request within **3 business days**.
 You can cancel your subscription at any time:
 
 1. **Through your account settings** - Go to Settings → Billing → Cancel Subscription
-2. **By contacting us** - Email autumnbrown23@pm.me
+2. **By contacting us** - Email hello@grove.place
 
 ### 2.2 What Happens When You Cancel
 
@@ -166,7 +166,7 @@ When you downgrade to a lower plan:
 
 If you have questions about refunds, cancellations, or billing:
 
-**Email:** autumnbrown23@pm.me
+**Email:** hello@grove.place
 
 We respond to all billing inquiries within **24 hours**.
 

--- a/docs/legal/terms-of-service.md
+++ b/docs/legal/terms-of-service.md
@@ -234,7 +234,7 @@ Upon termination:
 These Terms are governed by the laws of the State of Georgia, United States, without regard to conflict of law principles.
 
 ### 17.2 Informal Resolution
-Before filing any legal claim, you agree to contact us at autumnbrown23@pm.me to attempt to resolve the dispute informally. We will work in good faith to resolve issues within 30 days.
+Before filing any legal claim, you agree to contact us at hello@grove.place to attempt to resolve the dispute informally. We will work in good faith to resolve issues within 30 days.
 
 ### 17.3 Jurisdiction
 Any legal action arising from these Terms shall be brought exclusively in the state or federal courts located in Georgia, and you consent to the jurisdiction of such courts.
@@ -271,7 +271,7 @@ You may not assign your rights under these Terms without our consent. We may ass
 
 If you have questions about these Terms, please contact us at:
 
-**Email:** autumnbrown23@pm.me
+**Email:** hello@grove.place
 
 ---
 

--- a/docs/specs/waystone-spec.md
+++ b/docs/specs/waystone-spec.md
@@ -448,7 +448,7 @@ When users can't find what they need:
 │                                                                 │
 │  Can't find what you're looking for?                            │
 │                                                                 │
-│  Email: autumnbrown23@pm.me                                     │
+│  Email: hello@grove.place                                     │
 │  Response time: Within 48 hours                                 │
 │                                                                 │
 │  Or describe your issue below and we'll get back to you:        │

--- a/packages/engine/src/lib/config/contact.ts
+++ b/packages/engine/src/lib/config/contact.ts
@@ -6,10 +6,10 @@
 
 export const CONTACT = {
   /** Support email for billing, account issues, and general inquiries */
-  supportEmail: "autumnbrown23@pm.me",
+  supportEmail: "hello@grove.place",
 
   /** Display-friendly support email (same as above, but explicitly for UI display) */
-  supportEmailDisplay: "autumnbrown23@pm.me",
+  supportEmailDisplay: "hello@grove.place",
 } as const;
 
 export type ContactConfig = typeof CONTACT;

--- a/packages/engine/src/routes/api/feed/+server.ts
+++ b/packages/engine/src/routes/api/feed/+server.ts
@@ -25,7 +25,7 @@ export const GET: RequestHandler = (event) => {
     siteConfig.site?.description ||
     "A personal website for blogging, demonstrating projects, and sharing articles";
   const feedAuthor = siteConfig.owner?.name || "Autumn";
-  const feedEmail = siteConfig.owner?.email || "autumnbrown23@pm.me";
+  const feedEmail = siteConfig.owner?.email || "autumn@grove.place";
 
   const items = sortedPosts
     .map((post) => {

--- a/packages/landing/src/routes/contact/+page.svelte
+++ b/packages/landing/src/routes/contact/+page.svelte
@@ -65,7 +65,7 @@
 
 			<!-- Email -->
 			<a
-				href="mailto:autumnbrown23@pm.me"
+				href="mailto:autumn@grove.place"
 				class="flex items-center gap-4 p-4 rounded-xl border border-default bg-surface hover:bg-surface-hover transition-colors group"
 			>
 				<div class="p-3 rounded-lg bg-accent-subtle/20">
@@ -73,7 +73,7 @@
 				</div>
 				<div class="flex-1">
 					<p class="font-sans font-medium text-foreground group-hover:text-accent-muted transition-colors">Email me</p>
-					<p class="text-sm text-foreground-subtle">autumnbrown23@pm.me</p>
+					<p class="text-sm text-foreground-subtle">autumn@grove.place</p>
 				</div>
 			</a>
 

--- a/packages/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
+++ b/packages/landing/src/routes/knowledge/[category]/[slug]/+page.svelte
@@ -175,7 +175,7 @@
 
             <div class="flex gap-4">
               <a
-                href="mailto:autumnbrown23@pm.me"
+                href="mailto:hello@grove.place"
                 class="text-foreground-muted hover:text-foreground transition-colors"
                 aria-label="Contact support via email"
               >

--- a/packages/landing/src/routes/knowledge/help/+page.svelte
+++ b/packages/landing/src/routes/knowledge/help/+page.svelte
@@ -185,7 +185,7 @@
         <p class="text-foreground-muted mb-4">
           Can't find what you're looking for? Contact our support team and we'll get back to you within 48 hours.
         </p>
-        <a href="mailto:autumnbrown23@pm.me" class="inline-flex items-center px-4 py-2 bg-emerald-600 dark:bg-emerald-500 text-white rounded-lg hover:bg-emerald-700 dark:hover:bg-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
+        <a href="mailto:hello@grove.place" class="inline-flex items-center px-4 py-2 bg-emerald-600 dark:bg-emerald-500 text-white rounded-lg hover:bg-emerald-700 dark:hover:bg-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
           Contact Support
           <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />

--- a/packages/landing/src/routes/knowledge/legal/+page.svelte
+++ b/packages/landing/src/routes/knowledge/legal/+page.svelte
@@ -83,7 +83,7 @@
       <p class="text-foreground-muted mb-4">
         If you have questions about our terms or policies, or need clarification on anything, please reach out.
       </p>
-      <a href="mailto:autumnbrown23@pm.me" class="inline-flex items-center px-4 py-2 {colors.buttonBg} text-white rounded-lg {colors.buttonHover} transition-colors">
+      <a href="mailto:hello@grove.place" class="inline-flex items-center px-4 py-2 {colors.buttonBg} text-white rounded-lg {colors.buttonHover} transition-colors">
         Contact Us
         <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />

--- a/packages/landing/src/routes/knowledge/specs/+page.svelte
+++ b/packages/landing/src/routes/knowledge/specs/+page.svelte
@@ -226,7 +226,7 @@
         <p class="text-foreground-muted mb-4">
           If you need clarification on any technical specification or want to suggest improvements, we'd love to hear from you.
         </p>
-        <a href="mailto:autumnbrown23@pm.me" class="inline-flex items-center px-4 py-2 {colors.buttonBg} text-white rounded-lg {colors.buttonHover} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
+        <a href="mailto:hello@grove.place" class="inline-flex items-center px-4 py-2 {colors.buttonBg} text-white rounded-lg {colors.buttonHover} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 transition-colors motion-reduce:transition-none">
           Contact Us
           <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />

--- a/packages/landing/src/routes/legal/+page.svelte
+++ b/packages/landing/src/routes/legal/+page.svelte
@@ -91,8 +91,8 @@
 					Questions about our policies?
 				</p>
 				<p class="font-sans">
-					<a href="mailto:autumnbrown23@pm.me" class="text-accent-muted hover:text-primary underline">
-						autumnbrown23@pm.me
+					<a href="mailto:hello@grove.place" class="text-accent-muted hover:text-primary underline">
+						hello@grove.place
 					</a>
 				</p>
 			</div>

--- a/packages/landing/src/routes/pricing/+page.svelte
+++ b/packages/landing/src/routes/pricing/+page.svelte
@@ -522,7 +522,7 @@
         </p>
         <p class="font-sans">
           <a
-            href="mailto:autumnbrown23@pm.me"
+            href="mailto:hello@grove.place"
             class="text-accent-muted hover:text-primary underline"
           >
             Let's talk.

--- a/packages/landing/src/routes/roadmap/workshop/+page.svelte
+++ b/packages/landing/src/routes/roadmap/workshop/+page.svelte
@@ -882,7 +882,7 @@
 					More tools are always being dreamed up in the workshop.
 				</p>
 				<p class="text-sm text-foreground-faint mt-2">
-					Have an idea? <a href="mailto:autumnbrown23@pm.me" class="text-accent hover:underline">Let's talk</a>
+					Have an idea? <a href="mailto:hello@grove.place" class="text-accent hover:underline">Let's talk</a>
 				</p>
 			</div>
 		</div>

--- a/packages/landing/src/routes/shade/+page.svelte
+++ b/packages/landing/src/routes/shade/+page.svelte
@@ -139,8 +139,8 @@
 					Questions or concerns?
 				</p>
 				<p>
-					<a href="mailto:autumnbrown23@pm.me" class="text-accent-muted hover:text-accent transition-colors">
-						autumnbrown23@pm.me
+					<a href="mailto:hello@grove.place" class="text-accent-muted hover:text-accent transition-colors">
+						hello@grove.place
 					</a>
 				</p>
 				<p class="text-foreground-faint text-sm mt-4">


### PR DESCRIPTION
## Summary

Update all contact emails from personal email (`autumnbrown23@pm.me`) to the new `@grove.place` domain:

- **`hello@grove.place`** — Professional/support contacts (legal docs, pricing, help center, support inquiries)
- **`autumn@grove.place`** — Personal contacts (contact page, RSS feed author)

## Changes

- Updated 20 files across legal docs, landing pages, help center, engine config, and internal docs
- No functional changes, just email address replacements

## Test plan

- [ ] Verify mailto links work on contact page
- [ ] Verify mailto links work on pricing page
- [ ] Confirm RSS feed shows correct author email
