### PR TITLE
feat(roadmap): move Petal to First Frost phase

### DIFF
--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -36,15 +36,6 @@ The groundwork laid in stillness. Foundations built when no one was watching.
   - Session management in D1
   - Cross-subdomain cookies
 
-- [ ] **Petal:** Image content moderation
-  - Privacy-first four-layer protection
-  - CSAM detection (Layer 1)
-  - Content classification (Layer 2)
-  - Sanity check (Layer 3)
-  - Output verification (Layer 4)
-  - Zero data retention for all user images
-  - See `docs/specs/petal-spec.md`
-
 - [x] **Landing Site:** grove.place welcomes visitors
   - Seasonal theme system
   - Randomized forest generation
@@ -63,6 +54,15 @@ The groundwork laid in stillness. Foundations built when no one was watching.
   - Vineyard: Asset & tool showcase pattern for Grove products
   - Vista (GroveMonitor): Infrastructure observability dashboard
   - See `docs/specs/bloom-spec.md`, `docs/specs/mycelium-spec.md`, `docs/specs/vineyard-spec.md`, `docs/specs/vista-spec.md`, and `docs/grove-mcp-guide.md`
+
+- [ ] **Petal:** Image content moderation
+  - Privacy-first four-layer protection
+  - CSAM detection (Layer 1)
+  - Content classification (Layer 2)
+  - Sanity check (Layer 3)
+  - Output verification (Layer 4)
+  - Zero data retention for all user images
+  - See `docs/specs/petal-spec.md`
 
 ---
 

--- a/packages/landing/src/routes/roadmap/+page.svelte
+++ b/packages/landing/src/routes/roadmap/+page.svelte
@@ -105,10 +105,10 @@
 			features: [
 				{ name: 'Lattice', description: 'Core engine — powers the grove', done: true, major: true },
 				{ name: 'Heartwood', description: 'Authentication — keeps you safe', done: true, major: true },
-				{ name: 'Petal', description: 'Image moderation — protection without surveillance', done: false, icon: 'petal', major: true },
 				{ name: 'Landing Site', description: 'grove.place welcomes visitors', done: true },
 				{ name: 'Clearing', description: 'Status page — transparent platform health', done: true, icon: 'clearing' },
 				{ name: 'Patina', description: 'Nightly backups — age as armor', done: true, icon: 'database', internal: true },
+				{ name: 'Petal', description: 'Image moderation — protection without surveillance', done: false, icon: 'petal', major: true },
 				{ name: 'Forage', description: 'Domain discovery — AI-powered name hunting', done: true, icon: 'forage' },
 				{ name: 'Email Waitlist', description: '70 seeds, waiting to sprout', done: true }
 			]


### PR DESCRIPTION
Move Petal (image content moderation) to First Frost phase as it needs to release when the platform launches. Petal provides privacy-first four-layer image moderation with CSAM detection, content classification, sanity checks, and output verification.