### PR TITLE
docs: add support page announcement email draft

### DIFF
--- a/docs/internal/grove-email-v6-support-announcement.md
+++ b/docs/internal/grove-email-v6-support-announcement.md
@@ -1,0 +1,60 @@
+# Grove Email: Version 6 (Support Announcement)
+
+*Created: January 21, 2026*
+
+---
+
+## Context
+
+First email sent from autumn@grove.place (previous emails came from Autumn's personal address). Announces the support page at grove.place/support. Keeps it brief, no pressure, just making people aware the option exists.
+
+**The tone:** Quiet, honest, not salesy. "Here's a thing, if you want it."
+
+---
+
+## Final Email Draft
+
+**Subject:** A way to support the grove
+
+---
+
+Quick one.
+
+I set up a support page: [grove.place/support](https://grove.place/support)
+
+No pressure, no pitch. If Grove means something to you and you want to help keep it running, the option is there. One-time, no account needed.
+
+Also: this is the first email from my new Grove address. autumn@grove.place is officially home now.
+
+\- Autumn
+
+---
+
+![Grove]({{LOGO_URL}})
+
+*A place to be.*
+
+[grove.place](https://grove.place) · [step away (unsubscribe)]({{{RESEND_UNSUBSCRIBE_URL}}})
+
+---
+
+## Subject Line Options
+
+1. **A way to support the grove** ← selected
+2. Something small
+3. If you want to help
+
+---
+
+## Voice Notes
+
+- Opens with "Quick one." to signal brevity
+- No pressure framing: "If Grove means something to you"
+- Mentions the new email address naturally, not as the main event
+- "One-time, no account needed" removes friction anxiety
+- Doesn't linger on asking for money
+- Respects their inbox
+
+---
+
+*This email is a quiet announcement. It exists. That's all.*


### PR DESCRIPTION
First email from autumn@grove.place announcing the Ko-fi
support page at grove.place/support. Brief, no pressure,
matches existing email voice.