### PR TITLE
docs: update README logo to high-resolution variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1><img src="docs/internal/email-assets/logo-summer-32.png" alt="Lattice logo" width="32" height="32" valign="middle">&nbsp;Lattice</h1>
+<h1><img src="docs/internal/email-assets/logo-summer-1024-social.png" alt="Lattice logo" width="32" height="32" valign="middle">&nbsp;Lattice</h1>
 
 [![npm version](https://img.shields.io/npm/v/@autumnsgrove/groveengine.svg?style=flat-square&color=4a7c59)](https://www.npmjs.com/package/@autumnsgrove/groveengine)
 [![license](https://img.shields.io/npm/l/@autumnsgrove/groveengine.svg?style=flat-square&color=8b5a2b)](LICENSE)


### PR DESCRIPTION
Use logo-summer-1024-social.png instead of logo-summer-32.png for better
quality while maintaining the 32x32 display size.