### PR TITLE
feat(museum): scaffold all wing structure with placeholder exhibits

### DIFF
--- a/docs/museum/architecture/WING.md
+++ b/docs/museum/architecture/WING.md
@@ -1,0 +1,45 @@
+---
+title: The Architecture Wing
+description: How Grove is built at the infrastructure level
+category: exhibit
+exhibitWing: architecture
+icon: building
+lastUpdated: '2026-01-22'
+---
+# The Architecture Wing
+
+> *How Grove is built at the infrastructure level.*
+
+---
+
+## What You're Looking At
+
+This wing explains the structural decisions that make Grove work. One deployment serves unlimited blogs. One engine prevents duplication. Cloudflare primitives compose together like instruments in an orchestra.
+
+---
+
+## Exhibits
+
+### [The Foundation](./foundation.md)
+Multi-tenant architecture: one deployment, unlimited blogs.
+
+### [The Engine Room](./engine-room.md)
+Engine-first pattern: how we prevent 11,925 lines of duplication.
+
+### [The Loom](./loom.md)
+Durable Objects coordination layer.
+
+### [The Cloud Garden](./cloud-garden.md)
+Cloudflare Workers, D1, KV, R2 working together.
+
+---
+
+## Continue Your Tour
+
+- **[The Nature Wing](../nature/WING.md)** — How it looks and feels
+- **[The Trust Wing](../trust/WING.md)** — How it keeps you safe
+- **[Return to Entrance](../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/architecture/cloud-garden.md
+++ b/docs/museum/architecture/cloud-garden.md
@@ -1,0 +1,45 @@
+---
+title: The Cloud Garden
+description: Cloudflare Workers, D1, KV, and R2 working together
+category: exhibit
+exhibitWing: architecture
+icon: cloud
+lastUpdated: '2026-01-22'
+---
+# The Cloud Garden
+
+> *Cloudflare primitives composing like instruments in an orchestra.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains how Grove's Cloudflare infrastructure works together. Workers handle compute, D1 stores data, KV provides caching, and R2 stores media.
+
+---
+
+## The Composition
+
+| Primitive | Role | Analogy |
+|-----------|------|---------|
+| **Workers** | Compute | The musicians |
+| **D1** | Persistent storage | The sheet music |
+| **KV** | Fast cache | The rehearsal room |
+| **R2** | Object storage | The instrument cases |
+
+---
+
+## Why It Matters
+
+By building entirely on Cloudflare's primitives, Grove runs at the edge globally with minimal operational complexity. No VMs to maintain, no containers to orchestrate.
+
+---
+
+## Continue Your Tour
+
+- **[The Nature Wing](../nature/WING.md)** — Continue to next wing
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/architecture/engine-room.md
+++ b/docs/museum/architecture/engine-room.md
@@ -1,0 +1,49 @@
+---
+title: The Engine Room
+description: Engine-first pattern that prevented 11,925 lines of duplicate code
+category: exhibit
+exhibitWing: architecture
+icon: cog
+lastUpdated: '2026-01-22'
+---
+# The Engine Room
+
+> *The pattern that prevented 11,925 lines of duplicate code.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains the engine-first pattern. Before implementing any utility, component, or pattern in an app, check if the engine already has it. If not, add it to the engine first, then import it.
+
+---
+
+## The Rule
+
+```
+1. CHECK: Does the engine already have this?
+   └── YES → Import from @autumnsgrove/groveengine
+   └── NO  → Continue to step 2
+
+2. IMPLEMENT: Add it to the engine FIRST
+   └── packages/engine/src/lib/...
+
+3. IMPORT: Then use it from the engine in your app
+```
+
+---
+
+## Why It Matters
+
+Grove once accumulated 11,925 lines of duplicate code because apps implemented their own versions instead of using or extending the engine. The engine-first pattern prevents that from ever happening again.
+
+---
+
+## Continue Your Tour
+
+- **[The Loom](./loom.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/architecture/foundation.md
+++ b/docs/museum/architecture/foundation.md
@@ -1,0 +1,42 @@
+---
+title: The Foundation
+description: Multi-tenant architecture where one deployment serves unlimited blogs
+category: exhibit
+exhibitWing: architecture
+icon: layers
+lastUpdated: '2026-01-22'
+---
+# The Foundation
+
+> *One deployment, unlimited blogs.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grove's multi-tenant architecture. Rather than deploying a separate application for each blog, Grove runs a single SvelteKit application that serves every tenant through subdomain routing.
+
+---
+
+## The Pattern
+
+When a request arrives at `username.grove.place`, the routing layer extracts the subdomain and queries the appropriate tenant data. One codebase, one deployment, unlimited blogs.
+
+---
+
+## Why It Matters
+
+- **Cost efficiency**: Infrastructure costs don't scale linearly with users
+- **Consistency**: Every blog gets the same features and updates simultaneously
+- **Simplicity**: One deployment to manage, not thousands
+
+---
+
+## Continue Your Tour
+
+- **[The Engine Room](./engine-room.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/architecture/loom.md
+++ b/docs/museum/architecture/loom.md
@@ -1,0 +1,43 @@
+---
+title: The Loom
+description: Durable Objects coordination layer for real-time state
+category: exhibit
+exhibitWing: architecture
+icon: spool
+lastUpdated: '2026-01-22'
+---
+# The Loom
+
+> *Where threads of state come together.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Loom, Grove's Durable Objects coordination layer. Cloudflare Durable Objects provide stateful coordination primitives that enable real-time features, auth coordination, and D1 batching.
+
+---
+
+## The Pattern
+
+Loom weaves together:
+- **Auth coordination**: Sessions, tokens, device fingerprinting
+- **Real-time state**: WebSocket connections, live updates
+- **D1 batching**: Efficient database operations
+
+---
+
+## Why It Matters
+
+Traditional serverless is stateless. Durable Objects give Grove the coordination capabilities of traditional servers while maintaining the scaling benefits of serverless infrastructure.
+
+---
+
+## Continue Your Tour
+
+- **[The Cloud Garden](./cloud-garden.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/community/WING.md
+++ b/docs/museum/community/WING.md
@@ -1,0 +1,42 @@
+---
+title: The Community Wing
+description: The social layer and shared spaces
+category: exhibit
+exhibitWing: community
+icon: users
+lastUpdated: '2026-01-22'
+---
+# The Community Wing
+
+> *The social layer and shared spaces.*
+
+---
+
+## What You're Looking At
+
+This wing explains how Grove handles community. The Meadow is where blogs can share posts. The Landing welcomes visitors. The Clearing shows system health. Community is opt-in; your blog is yours first.
+
+---
+
+## Exhibits
+
+### [The Meadow](./meadow.md)
+Community feed where blogs share posts.
+
+### [The Landing](./landing.md)
+How grove.place welcomes visitors.
+
+### [The Clearing](./clearing.md)
+Status page and transparency.
+
+---
+
+## Continue Your Tour
+
+- **[The Personalization Wing](../personalization/WING.md)** — How you make it yours
+- **[The Naming Wing](../naming/WING.md)** — How Grove names things
+- **[Return to Entrance](../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/community/clearing.md
+++ b/docs/museum/community/clearing.md
@@ -1,0 +1,46 @@
+---
+title: The Clearing
+description: Status page and transparency
+category: exhibit
+exhibitWing: community
+icon: activity
+lastUpdated: '2026-01-22'
+---
+# The Clearing
+
+> *A gap in the forest where everything is visible.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains the Clearing, Grove's status page at status.grove.place. When something goes wrong, or when maintenance is planned, you can see exactly what's happening.
+
+---
+
+## The Transparency
+
+**Real-time Status**: Current health of all Grove services
+
+**Incident History**: Past issues and how they were resolved
+
+**Planned Maintenance**: Advance notice of scheduled work
+
+**Subscribe to Updates**: Get notified when status changes
+
+---
+
+## Why It Matters
+
+Transparency builds trust. When Grove has problems, we don't hide. The Clearing shows exactly what's happening, what we're doing about it, and when we expect it to be resolved.
+
+---
+
+## Continue Your Tour
+
+- **[The Naming Wing](../naming/WING.md)** — Continue to next wing
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/community/landing.md
+++ b/docs/museum/community/landing.md
@@ -1,0 +1,46 @@
+---
+title: The Landing
+description: How grove.place welcomes visitors
+category: exhibit
+exhibitWing: community
+icon: home
+lastUpdated: '2026-01-22'
+---
+# The Landing
+
+> *How grove.place welcomes visitors.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains the landing page at grove.place. Seasonal showcases, animated forests, and a warm welcome for anyone exploring what Grove offers.
+
+---
+
+## The Experience
+
+**Seasonal Forest**: The landing page changes with the seasons
+
+**Featured Blogs**: Showcase of community voices
+
+**Clear Value Prop**: What Grove is and why it matters
+
+**Easy Onboarding**: Start your journey with minimal friction
+
+---
+
+## Why It Matters
+
+First impressions matter. The landing page isn't just marketing; it's an invitation into the forest. Every visitor should feel they've found somewhere safe.
+
+---
+
+## Continue Your Tour
+
+- **[The Clearing](./clearing.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/community/meadow.md
+++ b/docs/museum/community/meadow.md
@@ -1,0 +1,46 @@
+---
+title: The Meadow
+description: Community feed where blogs share posts
+category: exhibit
+exhibitWing: community
+icon: flower
+lastUpdated: '2026-01-22'
+---
+# The Meadow
+
+> *An open space where the community gathers.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Meadow, Grove's community feed. Blogs can optionally share posts to a shared space where Wanderers can discover new voices, react with emojis, and find their next favorite writer.
+
+---
+
+## The Features
+
+**Opt-in Sharing**: Share posts to the feed if you want, or keep your blog private
+
+**Discovery**: Find new blogs through shared posts
+
+**Reactions**: Emoji reactions let readers respond without comments
+
+**Voting**: Surface the best content through community voting
+
+---
+
+## Why It Matters
+
+Community is opt-in. Your blog is yours first. Meadow exists for those who want to be discovered, but no one is forced into the spotlight.
+
+---
+
+## Continue Your Tour
+
+- **[The Landing](./landing.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/data/WING.md
+++ b/docs/museum/data/WING.md
@@ -1,0 +1,45 @@
+---
+title: The Data Wing
+description: How information flows and persists
+category: exhibit
+exhibitWing: data
+icon: database
+lastUpdated: '2026-01-22'
+---
+# The Data Wing
+
+> *How information flows and persists.*
+
+---
+
+## What You're Looking At
+
+This wing explains how Grove stores and retrieves data. Posts travel from editor to database to cache to browser. Tenant isolation keeps your data yours. Type-safe helpers prevent the scary stuff.
+
+---
+
+## Exhibits
+
+### [The Filing Cabinet](./filing-cabinet.md)
+D1 database patterns and storage.
+
+### [The Quick-Lookup Shelf](./quick-lookup.md)
+KV caching strategies for speed.
+
+### [The Media Vault](./media-vault.md)
+R2 storage for images and files.
+
+### [The Query Builders](./query-builders.md)
+Type-safe database helpers.
+
+---
+
+## Continue Your Tour
+
+- **[The Trust Wing](../trust/WING.md)** — How it keeps you safe
+- **[The Personalization Wing](../personalization/WING.md)** — How you make it yours
+- **[Return to Entrance](../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/data/filing-cabinet.md
+++ b/docs/museum/data/filing-cabinet.md
@@ -1,0 +1,44 @@
+---
+title: The Filing Cabinet
+description: D1 database patterns for persistent storage
+category: exhibit
+exhibitWing: data
+icon: folder
+lastUpdated: '2026-01-22'
+---
+# The Filing Cabinet
+
+> *D1 database patterns for persistent storage.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains how Grove uses Cloudflare D1 (SQLite at the edge) for persistent storage. Posts, comments, settings, and user data all live here.
+
+---
+
+## The Pattern
+
+**Tenant Isolation**: Every query is scoped to a tenant. Your data can't leak to other blogs.
+
+**Isolated Try/Catch**: One failing query doesn't block others. Each query has its own error handling.
+
+**Parallel Queries**: Independent queries run simultaneously to reduce latency.
+
+---
+
+## Why It Matters
+
+D1 puts your database at the edge, close to your readers. Combined with careful query patterns, this means fast, reliable data access worldwide.
+
+---
+
+## Continue Your Tour
+
+- **[The Quick-Lookup Shelf](./quick-lookup.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/data/media-vault.md
+++ b/docs/museum/data/media-vault.md
@@ -1,0 +1,46 @@
+---
+title: The Media Vault
+description: R2 storage for images and files
+category: exhibit
+exhibitWing: data
+icon: image
+lastUpdated: '2026-01-22'
+---
+# The Media Vault
+
+> *R2 storage for images and files.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains how Grove stores media using Cloudflare R2. Images, documents, and other files are stored securely with global distribution.
+
+---
+
+## The Pattern
+
+**Validation**: Images are validated before storage
+
+**Deduplication**: Content-hash prevents duplicate storage
+
+**CDN Delivery**: Files are served through Cloudflare's CDN
+
+**Tenant Isolation**: Each tenant's media is isolated
+
+---
+
+## Why It Matters
+
+R2 provides S3-compatible storage without egress fees. Your images load fast worldwide, and you're not charged for bandwidth.
+
+---
+
+## Continue Your Tour
+
+- **[The Query Builders](./query-builders.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/data/query-builders.md
+++ b/docs/museum/data/query-builders.md
@@ -1,0 +1,50 @@
+---
+title: The Query Builders
+description: Type-safe database helpers that prevent SQL injection
+category: exhibit
+exhibitWing: data
+icon: code
+lastUpdated: '2026-01-22'
+---
+# The Query Builders
+
+> *Type-safe helpers that prevent the scary stuff.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grove's typed query builders. Instead of raw SQL strings, Grove uses helper functions that validate inputs and provide type safety.
+
+---
+
+## The Helpers
+
+```typescript
+// Type-safe queries
+const user = await findById<User>(db, 'users', userId);
+const posts = await queryMany<Post>(db, 'posts', 'status = ?', ['published']);
+
+// Insert with auto-generated ID and timestamps
+const newId = await insert(db, 'posts', { title: 'Hello', content: '...' });
+
+// Tenant-scoped operations
+const tenantDb = getTenantDb(db, { tenantId: locals.tenant.id });
+```
+
+---
+
+## Why It Matters
+
+SQL injection is one of the most common security vulnerabilities. By using typed helpers instead of string concatenation, Grove prevents injection attacks at the API level.
+
+---
+
+## Continue Your Tour
+
+- **[The Personalization Wing](../personalization/WING.md)** — Continue to next wing
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/data/quick-lookup.md
+++ b/docs/museum/data/quick-lookup.md
@@ -1,0 +1,44 @@
+---
+title: The Quick-Lookup Shelf
+description: KV caching strategies for speed
+category: exhibit
+exhibitWing: data
+icon: zap
+lastUpdated: '2026-01-22'
+---
+# The Quick-Lookup Shelf
+
+> *KV caching for instant access.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grove's caching strategy using Cloudflare KV. Frequently accessed data is cached at the edge, making page loads feel instant.
+
+---
+
+## The Pattern
+
+**Cache First**: Check KV before hitting D1
+
+**Smart Invalidation**: Cache updates when data changes
+
+**TTL Strategy**: Different data types have different cache lifetimes
+
+---
+
+## Why It Matters
+
+Database queries have latency. KV is faster. By caching intelligently, Grove serves most requests from cache while keeping data fresh.
+
+---
+
+## Continue Your Tour
+
+- **[The Media Vault](./media-vault.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/naming/WING.md
+++ b/docs/museum/naming/WING.md
@@ -1,0 +1,47 @@
+---
+title: The Naming Wing
+description: How Grove names things, and why it matters
+category: exhibit
+exhibitWing: naming
+icon: tag
+lastUpdated: '2026-01-22'
+---
+# The Naming Wing
+
+> *How Grove names things, and why it matters.*
+
+---
+
+## What You're Looking At
+
+This wing explains Grove's naming philosophy. Names aren't branding; they're world-building. Every service has a nature metaphor that genuinely fits. Each name was discovered through a walk through the forest.
+
+---
+
+## Exhibits
+
+### [The Philosophy](./the-walk.md)
+The ritual of discovering names.
+
+### [The Journeys Gallery](./journeys/porch.md)
+50+ naming journeys with rejected ideas and realizations.
+
+### [The Ecosystem Map](./ecosystem.md)
+40+ services, each with its story.
+
+---
+
+## Featured Journey
+
+**Porch**: Support isn't a ticket system. It's a porch conversation. You come up the steps, have a seat, and the grove keeper comes out to chat. This journey created the naming ritual.
+
+---
+
+## Continue Your Tour
+
+- **[The Community Wing](../community/WING.md)** — How we gather
+- **[Return to Entrance](../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/naming/ecosystem.md
+++ b/docs/museum/naming/ecosystem.md
@@ -1,0 +1,50 @@
+---
+title: The Ecosystem Map
+description: 40+ services, each with its story
+category: exhibit
+exhibitWing: naming
+icon: map
+lastUpdated: '2026-01-22'
+---
+# The Ecosystem Map
+
+> *40+ services, each with its nature metaphor.*
+
+---
+
+## What You're Looking At
+
+This exhibit maps Grove's entire naming ecosystem. Every service, every feature, every concept has a name that fits naturally into the forest metaphor.
+
+---
+
+## The Map
+
+| Service | Role | Why This Name |
+|---------|------|---------------|
+| **Lattice** | Core framework | Structure that supports growth |
+| **Heartwood** | Authentication | Dense core where trust lives |
+| **Loom** | Durable Objects | Weaves threads together |
+| **Meadow** | Community feed | Open gathering space |
+| **Clearing** | Status page | Visibility and transparency |
+| **Porch** | Support system | Where conversations happen |
+| **Grafts** | Feature flags | Attaching new growth |
+| **Curios** | Personalization | Collected treasures |
+| **Foliage** | Theme system | The visible canopy |
+
+---
+
+## Why It Matters
+
+Consistent naming creates a world. When everything fits the metaphor, the platform feels coherent and intentional. Words create worlds.
+
+---
+
+## Continue Your Tour
+
+- **[Return to Wing](./WING.md)**
+- **[Return to Entrance](../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/naming/journeys/loom.md
+++ b/docs/museum/naming/journeys/loom.md
@@ -1,0 +1,54 @@
+---
+title: "Journey: Loom"
+description: A walk that returned home
+category: exhibit
+exhibitWing: naming
+icon: spool
+lastUpdated: '2026-01-22'
+---
+# Journey: Loom
+
+> *Sometimes you walk through the forest and realize the name you started with was right all along.*
+
+---
+
+## What You're Looking At
+
+This is the naming journey for Loom, Grove's Durable Objects coordination layer. A walk that explored many options before returning to where it started.
+
+---
+
+## The Concept
+
+A coordination layer using Cloudflare Durable Objects. Weaving together auth, state, and real-time features.
+
+---
+
+## The Walk
+
+*Coordination... threads... weaving...*
+
+The concept already had its name. Loom. A frame where threads come together. Where patterns emerge from individual strands.
+
+But I walked anyway, exploring:
+- **Web** — too Spider-Man
+- **Weave** — already used for something else
+- **Thread** — too generic
+- **Spindle** — too specific
+
+---
+
+## Returning Home
+
+After the walk, Loom was still the answer. The framework where Grove's threads come together. Sometimes the first instinct is right.
+
+---
+
+## Continue Your Tour
+
+- **[Return to Wing](../WING.md)**
+- **[Return to Entrance](../../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/naming/journeys/lumen.md
+++ b/docs/museum/naming/journeys/lumen.md
@@ -1,0 +1,57 @@
+---
+title: "Journey: Lumen"
+description: A difficult journey between light and void
+category: exhibit
+exhibitWing: naming
+icon: lamp-ceiling
+lastUpdated: '2026-01-22'
+---
+# Journey: Lumen
+
+> *A difficult journey between light and void.*
+
+---
+
+## What You're Looking At
+
+This is the naming journey for Lumen, Grove's AI gateway. A difficult journey that explored the tension between the hollow center (where everything flows) and illumination (what emerges).
+
+---
+
+## The Concept
+
+A unified AI routing layer. Every AI request passes through this center: moderation, generation, images. One interface, intelligent routing.
+
+---
+
+## The Walk
+
+*An AI gateway... what is this in the forest?*
+
+In anatomy, a lumen is the hollow center of a tube. The void through which everything flows.
+
+But lumen also means light. Illumination.
+
+Both meanings fit. The void through which requests pass, and the light that emerges from AI processing.
+
+---
+
+## The Decision
+
+It came down to trying names in sentences:
+
+"Lumen routed the request to the right model."
+"Check Lumen's logs for the AI call."
+
+Natural. Clean. The double meaning adds depth rather than confusion.
+
+---
+
+## Continue Your Tour
+
+- **[Journey: Loom](./loom.md)** — Returning home
+- **[Return to Wing](../WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/naming/journeys/porch.md
+++ b/docs/museum/naming/journeys/porch.md
@@ -1,0 +1,61 @@
+---
+title: "Journey: Porch"
+description: The origin story that created the naming ritual
+category: exhibit
+exhibitWing: naming
+icon: rocking-chair
+lastUpdated: '2026-01-22'
+---
+# Journey: Porch
+
+> *The origin story that created the naming ritual.*
+
+---
+
+## What You're Looking At
+
+This is the naming journey for Porch, Grove's support system. This journey created the naming ritual itself. Support isn't a ticket system. It's a porch conversation.
+
+---
+
+## The Concept
+
+A support system where conversations feel human. Not tickets and queues, but sitting down and talking through problems together.
+
+---
+
+## The Walk
+
+*Support... where does support happen in a grove?*
+
+Not inside the house. That's too formal. Not in the garden. That's work.
+
+The porch. You come up the steps. Have a seat. The grove keeper comes out to chat.
+
+---
+
+## Rejected Names
+
+- **Help Desk** — too corporate
+- **Support Center** — too clinical
+- **Grove Help** — doesn't fit the metaphor
+
+---
+
+## Why It Works
+
+"Come up to the Porch if you need help."
+"Autumn's on the Porch if you have questions."
+
+It sounds like home.
+
+---
+
+## Continue Your Tour
+
+- **[Journey: Lumen](./lumen.md)** — A difficult journey
+- **[Return to Wing](../WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/naming/the-walk.md
+++ b/docs/museum/naming/the-walk.md
@@ -1,0 +1,48 @@
+---
+title: The Walk
+description: The ritual of discovering Grove names
+category: exhibit
+exhibitWing: naming
+icon: footprints
+lastUpdated: '2026-01-22'
+---
+# The Walk
+
+> *Finding the right name is a walk through the forest.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains the naming ritual. You don't brainstorm Grove names in a conference room with sticky notes. You take a walk through the forest, visualize the concept, and let it find where it naturally belongs.
+
+---
+
+## The Ritual
+
+1. **Create a visualization scratchpad** — ASCII art of the forest
+2. **Step into the metaphor** — The Grove is the place, these are the things you find there
+3. **Walk through locations** — Where does this concept live?
+4. **Test the name** — Does it complete the tagline naturally?
+5. **Document the journey** — Rejected names teach as much as chosen ones
+
+---
+
+## The Test
+
+A name passes if it sounds natural in sentences:
+
+- "Check Heartwood to see if you're logged in" (natural)
+- "Heartwood verified your identity" (natural)
+- "The authentication module checked credentials" (doesn't fit Grove)
+
+---
+
+## Continue Your Tour
+
+- **[The Journeys Gallery](./journeys/porch.md)** — See naming journeys
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/nature/WING.md
+++ b/docs/museum/nature/WING.md
@@ -1,0 +1,45 @@
+---
+title: The Nature Wing
+description: The visual and emotional language of Grove
+category: exhibit
+exhibitWing: nature
+icon: tree-pine
+lastUpdated: '2026-01-22'
+---
+# The Nature Wing
+
+> *The visual and emotional language of Grove.*
+
+---
+
+## What You're Looking At
+
+This wing explains the design decisions that make Grove feel alive. 64 mathematically-driven SVG components create a living forest. Five seasons shift the mood. Glass surfaces layer over organic backgrounds.
+
+---
+
+## Exhibits
+
+### [The Forest](./forest.md)
+Trees, creatures, and weather effects that bring Grove to life.
+
+### [The Seasons](./seasons.md)
+Spring, Summer, Autumn, Winter, and Midnight.
+
+### [The Glass Garden](./glass-garden.md)
+Glassmorphism design that creates depth and warmth.
+
+### [The Typography Gallery](./typography.md)
+10 accessible fonts respecting every reader.
+
+---
+
+## Continue Your Tour
+
+- **[The Architecture Wing](../architecture/WING.md)** — How it's built
+- **[The Trust Wing](../trust/WING.md)** — How it keeps you safe
+- **[Return to Entrance](../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/nature/forest.md
+++ b/docs/museum/nature/forest.md
@@ -1,0 +1,44 @@
+---
+title: The Forest
+description: 64 SVG components that bring Grove to life
+category: exhibit
+exhibitWing: nature
+icon: trees
+lastUpdated: '2026-01-22'
+---
+# The Forest
+
+> *64 mathematically-driven SVG components with customizable Svelte props.*
+
+---
+
+## What You're Looking At
+
+This exhibit showcases Grove's nature component library. Every tree, creature, and weather effect is an SVG built with mathematical precision and customizable through Svelte props.
+
+---
+
+## The Components
+
+**Trees**: Cherry, Pine, Aspen, Oak, Birch, Maple, Willow, and more
+
+**Creatures**: Bee, Butterfly, Deer, Fox, Owl, Rabbit, Squirrel
+
+**Weather**: Rain, Snow, Falling Leaves, Falling Petals, Fireflies
+
+---
+
+## Why It Matters
+
+The nature system creates organic variety from precise parameters. Each component can be tuned through props, meaning no two forests are exactly alike while all maintain visual coherence.
+
+---
+
+## Continue Your Tour
+
+- **[The Seasons](./seasons.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/nature/glass-garden.md
+++ b/docs/museum/nature/glass-garden.md
@@ -1,0 +1,43 @@
+---
+title: The Glass Garden
+description: Glassmorphism design creating depth and warmth
+category: exhibit
+exhibitWing: nature
+icon: layout
+lastUpdated: '2026-01-22'
+---
+# The Glass Garden
+
+> *Glass surfaces layered over organic backgrounds.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grove's glassmorphism design system. Glass surfaces create hierarchy while hinting at beauty beneath. The effect is like looking through frosted windows at a forest.
+
+---
+
+## The Pattern
+
+- **Glass surfaces** with subtle blur and transparency
+- **Nature backgrounds** visible beneath the glass
+- **Soft shadows** that create depth without harshness
+- **Warm colors** that maintain Grove's cozy feeling
+
+---
+
+## Why It Matters
+
+Glassmorphism isn't just aesthetic. It creates visual hierarchy while preserving the nature elements that make Grove feel alive. Content floats above the forest without obscuring it.
+
+---
+
+## Continue Your Tour
+
+- **[The Typography Gallery](./typography.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/nature/seasons.md
+++ b/docs/museum/nature/seasons.md
@@ -1,0 +1,46 @@
+---
+title: The Seasons
+description: Five seasons including the Midnight easter egg
+category: exhibit
+exhibitWing: nature
+icon: sun
+lastUpdated: '2026-01-22'
+---
+# The Seasons
+
+> *Five palettes that shift the emotional tone.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grove's seasonal theming system. Four natural seasons plus a hidden fifth create distinct moods throughout the platform.
+
+---
+
+## The Seasons
+
+| Season | Mood | Colors |
+|--------|------|--------|
+| **Spring** | Renewal, fresh starts | Soft pastels, new greens |
+| **Summer** | Growth, vibrance | Bright greens, warm yellows |
+| **Autumn** | Harvest, reflection | Warm oranges, deep browns |
+| **Winter** | Rest, quiet | Cool blues, soft whites |
+| **Midnight** | Dreams, queerness | Deep purples, rose accents |
+
+---
+
+## Finding Midnight
+
+Cycle through seasons in the theme picker. Keep going past Winter. Midnight is Grove's queer aesthetic, a celebration of dreams and identity.
+
+---
+
+## Continue Your Tour
+
+- **[The Glass Garden](./glass-garden.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/nature/typography.md
+++ b/docs/museum/nature/typography.md
@@ -1,0 +1,46 @@
+---
+title: The Typography Gallery
+description: 10 accessible fonts respecting every reader
+category: exhibit
+exhibitWing: nature
+icon: type
+lastUpdated: '2026-01-22'
+---
+# The Typography Gallery
+
+> *10 fonts including accessible options for every reader.*
+
+---
+
+## What You're Looking At
+
+This exhibit showcases Grove's typography system. Every font was chosen with care, including accessibility options like OpenDyslexic and Atkinson Hyperlegible.
+
+---
+
+## The Collection
+
+**Default**: Lexend (optimized for readability)
+
+**Accessibility**: OpenDyslexic, Atkinson Hyperlegible
+
+**Serifs**: Lora, Merriweather, Playfair Display
+
+**Sans-serifs**: Inter, Work Sans, Source Sans Pro
+
+---
+
+## Why It Matters
+
+Typography affects readability, mood, and accessibility. By offering carefully curated options including fonts designed for dyslexia and low vision, Grove ensures every reader can find their comfortable reading experience.
+
+---
+
+## Continue Your Tour
+
+- **[The Trust Wing](../trust/WING.md)** — Continue to next wing
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/personalization/WING.md
+++ b/docs/museum/personalization/WING.md
@@ -1,0 +1,42 @@
+---
+title: The Personalization Wing
+description: Making each blog feel like home
+category: exhibit
+exhibitWing: personalization
+icon: palette
+lastUpdated: '2026-01-22'
+---
+# The Personalization Wing
+
+> *Making each blog feel like home.*
+
+---
+
+## What You're Looking At
+
+This wing explains how Grove lets you make your space yours. Feature flags have Grove vocabulary: Graft means enable, Prune means disable. Curios bring old-web energy. Your space should feel like yours.
+
+---
+
+## Exhibits
+
+### [The Grafts Exhibit](./grafts.md)
+Feature flags with Grove vocabulary.
+
+### [The Curios Collection](./curios.md)
+Old-web personalization features.
+
+### [The Theme Workshop](./themes.md)
+How blogs get customized.
+
+---
+
+## Continue Your Tour
+
+- **[The Data Wing](../data/WING.md)** — How information flows
+- **[The Community Wing](../community/WING.md)** — How we gather
+- **[Return to Entrance](../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/personalization/curios.md
+++ b/docs/museum/personalization/curios.md
@@ -1,0 +1,46 @@
+---
+title: The Curios Collection
+description: Old-web personalization features
+category: exhibit
+exhibitWing: personalization
+icon: sparkles
+lastUpdated: '2026-01-22'
+---
+# The Curios Collection
+
+> *Old-web energy meeting modern standards.*
+
+---
+
+## What You're Looking At
+
+This exhibit showcases Curios, Grove's collection of old-web personalization features. Guestbooks, hit counters, shrines, custom cursors. The nostalgic web, rebuilt with accessibility and security in mind.
+
+---
+
+## The Collection
+
+| Curio | What It Does | Old-Web Inspiration |
+|-------|--------------|---------------------|
+| **Guestbook** | Visitors leave signatures | GeoCities guestbooks |
+| **Hit Counter** | Shows visitor count | "You are visitor #12,847" |
+| **Shrine** | Dedication board | Fan shrines, memorial pages |
+| **Link Garden** | Curated links | Blogrolls, webrings |
+| **Custom Cursor** | Personalized pointer | Sparkle trails, themed cursors |
+
+---
+
+## Why It Matters
+
+The old web was personal in ways modern platforms aren't. Curios bring back that energy while respecting accessibility, security, and performance.
+
+---
+
+## Continue Your Tour
+
+- **[The Theme Workshop](./themes.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/personalization/grafts.md
+++ b/docs/museum/personalization/grafts.md
@@ -1,0 +1,47 @@
+---
+title: The Grafts Exhibit
+description: Feature flags with Grove vocabulary
+category: exhibit
+exhibitWing: personalization
+icon: flag
+lastUpdated: '2026-01-22'
+---
+# The Grafts Exhibit
+
+> *Feature flags with Grove vocabulary.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grafts, Grove's feature flag system. A graft makes your tree bear fruit no other can. Boolean flags, percentage rollouts, tier-gated features, and A/B variants.
+
+---
+
+## The Vocabulary
+
+| Term | Meaning | Standard Term |
+|------|---------|---------------|
+| **Graft** | Enable a feature | Feature flag ON |
+| **Prune** | Disable a feature | Feature flag OFF |
+| **Propagate** | Percentage rollout | Gradual rollout |
+| **Cultivate** | Full rollout | 100% enabled |
+| **Blight** | Emergency kill switch | Circuit breaker |
+| **Cultivar** | A/B test variant | Experiment variant |
+
+---
+
+## Why It Matters
+
+Feature flags let Grove customize experiences per tenant without code deploys. Want to beta test a feature with one blog? Graft it. Problem discovered? Blight it instantly.
+
+---
+
+## Continue Your Tour
+
+- **[The Curios Collection](./curios.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/personalization/themes.md
+++ b/docs/museum/personalization/themes.md
@@ -1,0 +1,46 @@
+---
+title: The Theme Workshop
+description: How blogs get customized
+category: exhibit
+exhibitWing: personalization
+icon: swatchbook
+lastUpdated: '2026-01-22'
+---
+# The Theme Workshop
+
+> *How blogs get customized.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grove's theming system. Fonts, colors, seasons, and layouts combine to make each blog unique while maintaining Grove's warm aesthetic foundation.
+
+---
+
+## The Layers
+
+**Fonts**: 10+ curated options including accessibility fonts
+
+**Colors**: Seasonal palettes that shift the mood
+
+**Layouts**: Content-first designs that adapt to your style
+
+**Decorations**: Nature elements and Curios that add personality
+
+---
+
+## Why It Matters
+
+Your blog should feel like yours. Grove's theming system gives you meaningful customization without requiring design expertise. Every choice contributes to a cohesive whole.
+
+---
+
+## Continue Your Tour
+
+- **[The Community Wing](../community/WING.md)** — Continue to next wing
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/trust/WING.md
+++ b/docs/museum/trust/WING.md
@@ -1,0 +1,42 @@
+---
+title: The Trust Wing
+description: Authentication, security, and identity
+category: exhibit
+exhibitWing: trust
+icon: shield
+lastUpdated: '2026-01-22'
+---
+# The Trust Wing
+
+> *Authentication, security, and identity.*
+
+---
+
+## What You're Looking At
+
+This wing explains how Grove keeps you safe without making you feel surveilled. Login should feel safe, not hostile. Sessions refresh quietly. Protection happens without frustration.
+
+---
+
+## Exhibits
+
+### [The Heartwood](./heartwood.md)
+OAuth and identity at Grove's core.
+
+### [The Session Gallery](./sessions.md)
+How Grove remembers who you are.
+
+### [The Security Checkpoint](./security.md)
+Protection patterns that work in the background.
+
+---
+
+## Continue Your Tour
+
+- **[The Nature Wing](../nature/WING.md)** — How it looks and feels
+- **[The Data Wing](../data/WING.md)** — How information flows
+- **[Return to Entrance](../MUSEUM.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/trust/heartwood.md
+++ b/docs/museum/trust/heartwood.md
@@ -1,0 +1,44 @@
+---
+title: The Heartwood
+description: OAuth flow and how login actually works
+category: exhibit
+exhibitWing: trust
+icon: key
+lastUpdated: '2026-01-22'
+---
+# The Heartwood
+
+> *The dense core of a tree, where trust lives.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Heartwood, Grove's authentication system. Named for the dense inner core of a tree, Heartwood handles Google OAuth, magic links, and everything that establishes your identity.
+
+---
+
+## The Flow
+
+1. You click "Sign in with Google"
+2. PKCE flow secures the OAuth handshake
+3. Your identity is verified
+4. A session is created
+5. You're in
+
+---
+
+## Why It Matters
+
+Authentication is the foundation of trust. Heartwood uses industry-standard security (PKCE, rate limiting, audit logging) while keeping the experience simple and non-threatening.
+
+---
+
+## Continue Your Tour
+
+- **[The Session Gallery](./sessions.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/trust/security.md
+++ b/docs/museum/trust/security.md
@@ -1,0 +1,46 @@
+---
+title: The Security Checkpoint
+description: Protection patterns that work in the background
+category: exhibit
+exhibitWing: trust
+icon: lock
+lastUpdated: '2026-01-22'
+---
+# The Security Checkpoint
+
+> *Protection that happens without frustration.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grove's security measures. Rate limiting prevents abuse. CAPTCHA appears only when necessary. Protection works in the background so you can focus on writing.
+
+---
+
+## The Layers
+
+**Rate Limiting**: Prevents abuse without blocking legitimate use
+
+**CAPTCHA**: Appears only when behavior looks suspicious
+
+**Input Validation**: Everything is sanitized before processing
+
+**Audit Logging**: Security events are tracked for investigation
+
+---
+
+## Why It Matters
+
+Security doesn't have to feel hostile. Grove protects without making visitors feel surveilled. The goal is safety that's invisible until you need it.
+
+---
+
+## Continue Your Tour
+
+- **[The Data Wing](../data/WING.md)** — Continue to next wing
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/docs/museum/trust/sessions.md
+++ b/docs/museum/trust/sessions.md
@@ -1,0 +1,42 @@
+---
+title: The Session Gallery
+description: How Grove remembers who you are
+category: exhibit
+exhibitWing: trust
+icon: user
+lastUpdated: '2026-01-22'
+---
+# The Session Gallery
+
+> *How Grove remembers who you are.*
+
+---
+
+## What You're Looking At
+
+This exhibit explains Grove's session management. Sessions refresh silently using the halfway pattern. Device fingerprinting coordinates multiple tabs. You stay logged in without thinking about it.
+
+---
+
+## The Pattern
+
+**Halfway Refresh**: Sessions extend when actively used, halfway through their lifetime. If you're active, you stay logged in. If you're away, you'll need to log in again.
+
+**Multi-Tab Coordination**: Open Grove in multiple tabs? They coordinate through Loom so you don't get logged out of one while using another.
+
+---
+
+## Why It Matters
+
+Good session management is invisible. You shouldn't have to think about authentication once you've logged in. Sessions should just work.
+
+---
+
+## Continue Your Tour
+
+- **[The Security Checkpoint](./security.md)** — Next exhibit
+- **[Return to Wing](./WING.md)**
+
+---
+
+*This exhibit is under construction. The full tour is coming soon.*

--- a/packages/landing/src/lib/data/knowledge-base.ts
+++ b/packages/landing/src/lib/data/knowledge-base.ts
@@ -1,4 +1,5 @@
 import type { Doc, SpecCategory, HelpSection, ExhibitWing } from "$lib/types/docs";
+import { scanDocsCategory } from "$lib/utils/docs-scanner";
 
 // Re-export for convenience
 export type { Doc, SpecCategory, HelpSection, ExhibitWing } from "$lib/types/docs";
@@ -1400,56 +1401,9 @@ export const designDocs: Doc[] = [
 ];
 
 // Art Exhibit Documents (Museum)
-export const exhibitDocs: Doc[] = [
-  {
-    slug: "MUSEUM",
-    title: "Welcome to the Lattice Museum",
-    description: "A guided tour through how this forest grows",
-    excerpt:
-      "This is the story of Grove, told through the systems that make it work. You're standing at the entrance to a museum—not the dusty kind with ropes and \"do not touch\" signs. This is the kind where you can peek behind every curtain.",
-    category: "exhibit",
-    exhibitWing: "entrance",
-    icon: "signpost",
-    lastUpdated: "2026-01-22",
-    readingTime: 8,
-  },
-  {
-    slug: "glossary",
-    title: "The Glossary Alcove",
-    description: "Grove speaks its own language. Here's the phrasebook.",
-    excerpt:
-      "Every community develops its own vocabulary. Grove's terminology isn't arbitrary. Each word was chosen to evoke feeling, not function. This glossary explains the terms you'll encounter throughout the museum.",
-    category: "exhibit",
-    exhibitWing: "entrance",
-    icon: "book",
-    lastUpdated: "2026-01-22",
-    readingTime: 6,
-  },
-  {
-    slug: "museum-layout-plan",
-    title: "Museum Layout Plan",
-    description: "The blueprint for the Lattice Museum",
-    excerpt:
-      "Traditional documentation answers \"how does this work?\" Museum documentation answers \"why does this exist, and why should I care?\" This document outlines the museum structure, exhibits, and agent orchestration model.",
-    category: "exhibit",
-    exhibitWing: "entrance",
-    icon: "layout",
-    lastUpdated: "2026-01-22",
-    readingTime: 15,
-  },
-  {
-    slug: "sister-museum",
-    title: "The Original AutumnsGrove Museum",
-    description: "A living archive of the original AutumnsGrove website",
-    excerpt:
-      "Walk through the source code of what was once a fully functional personal website. See how a real website gets built—not a tutorial's sanitized example, but actual working code that served real pages to real people.",
-    category: "exhibit",
-    exhibitWing: "entrance",
-    icon: "github",
-    lastUpdated: "2026-01-22",
-    readingTime: 10,
-  },
-];
+// Loaded from filesystem via docs-scanner.ts - no manual registry needed.
+// Just add .md files with proper frontmatter to docs/museum/ and they appear automatically.
+export const exhibitDocs: Doc[] = scanDocsCategory("exhibit");
 
 // Combined export for convenience
 export const allDocs = [

--- a/packages/landing/src/lib/utils/docs-loader.ts
+++ b/packages/landing/src/lib/utils/docs-loader.ts
@@ -167,9 +167,10 @@ function parseDoc(filePath: string, category: DocCategory): DocInternal {
 
 // Categories that should recursively include subdirectories.
 // - specs: includes completed specs in specs/completed/
+// - exhibit: museum wings organized in subdirectories (architecture/, nature/, etc.)
 // - Other categories (philosophy, design, etc.) may contain internal
 //   scratch/draft folders that shouldn't be exposed publicly.
-const RECURSIVE_CATEGORIES: DocCategory[] = ["specs"];
+const RECURSIVE_CATEGORIES: DocCategory[] = ["specs", "exhibit"];
 
 function loadDocsFromDir(
   dirPath: string,
@@ -234,6 +235,7 @@ export function loadAllDocs(): {
   legalDocs: Doc[];
   marketingDocs: Doc[];
   patterns: Doc[];
+  exhibitDocs: Doc[];
 } {
   const specs = loadDocsFromDir(join(DOCS_ROOT, "specs"), "specs");
   const helpArticles = loadDocsFromDir(
@@ -246,8 +248,9 @@ export function loadAllDocs(): {
     "marketing",
   );
   const patterns = loadDocsFromDir(join(DOCS_ROOT, "patterns"), "patterns");
+  const exhibitDocs = loadDocsFromDir(join(DOCS_ROOT, "museum"), "exhibit");
 
-  return { specs, helpArticles, legalDocs, marketingDocs, patterns };
+  return { specs, helpArticles, legalDocs, marketingDocs, patterns, exhibitDocs };
 }
 
 export function loadDocBySlug(

--- a/packages/landing/src/lib/utils/docs-scanner.ts
+++ b/packages/landing/src/lib/utils/docs-scanner.ts
@@ -42,9 +42,10 @@ const CATEGORY_PATHS: Record<DocCategory, string> = {
 /**
  * Categories that should recursively include subdirectories.
  * - specs: includes completed specs in specs/completed/
+ * - exhibit: museum wings organized in subdirectories (architecture/, nature/, etc.)
  * - Other categories may have internal scratch folders that shouldn't be public
  */
-const RECURSIVE_CATEGORIES: DocCategory[] = ["specs"];
+const RECURSIVE_CATEGORIES: DocCategory[] = ["specs", "exhibit"];
 
 /**
  * Valid values for category-specific fields.


### PR DESCRIPTION
Create the complete museum directory structure with basic filler files
for all wings and exhibits. Each file includes proper frontmatter for
knowledge base integration.

Wings created:
- Architecture (foundation, engine-room, loom, cloud-garden)
- Nature (forest, seasons, glass-garden, typography)
- Trust (heartwood, sessions, security)
- Data (filing-cabinet, quick-lookup, media-vault, query-builders)
- Personalization (grafts, curios, themes)
- Community (meadow, landing, clearing)
- Naming (the-walk, ecosystem, journeys/porch, journeys/lumen, journeys/loom)

Also:
- Update docs-loader and docs-scanner to recursively scan exhibit subdirectories
- Simplify knowledge-base.ts to use frontmatter-based discovery instead of manual registry