### PR TITLE
refactor: migrate marked to markdown-it

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -273,6 +273,7 @@
     "typescript": "^5.6.0",
     "vibe-kanban-web-companion": "^0.0.5",
     "vite": "^5.4.10",
+    "@types/markdown-it": "^14.1.2",
     "vitest": "^4.0.14"
   },
   "dependencies": {
@@ -286,7 +287,7 @@
     "esm-env": "^1.2.2",
     "gray-matter": "^4.0.3",
     "lucide-svelte": "^0.554.0",
-    "marked": "^17.0.1",
+    "markdown-it": "^14.1.0",
     "svelte-sonner": "^1.0.7",
     "tailwind-merge": "^3.4.0"
   }

--- a/packages/engine/src/lib/components/admin/GutterManager.svelte
+++ b/packages/engine/src/lib/components/admin/GutterManager.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { marked } from "marked";
   import { Input, Button } from '$lib/ui';
   import Dialog from "$lib/ui/components/ui/Dialog.svelte";
   import Select from "$lib/ui/components/ui/Select.svelte";

--- a/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
+++ b/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
@@ -1,7 +1,10 @@
 <script>
-  import { marked } from "marked";
+  import MarkdownIt from "markdown-it";
   import { onMount, tick } from "svelte";
   import { sanitizeMarkdown } from "$lib/utils/sanitize";
+
+  // Local instance for admin editor preview
+  const editorMd = new MarkdownIt({ html: false, linkify: true });
   import { extractHeaders } from "$lib/utils/markdown";
   import "$lib/styles/content.css";
   import { Button, Input, Logo } from '$lib/ui';
@@ -111,7 +114,7 @@
   let wordCount = $derived(content.trim() ? content.trim().split(/\s+/).length : 0);
   let charCount = $derived(content.length);
   let lineCount = $derived(content.split("\n").length);
-  let previewHtml = $derived(content ? sanitizeMarkdown(/** @type {string} */ (marked.parse(content, { async: false }))) : "");
+  let previewHtml = $derived(content ? sanitizeMarkdown(editorMd.render(content)) : "");
   let previewHeaders = $derived(content ? extractHeaders(content) : []);
 
   let readingTime = $derived.by(() => {

--- a/packages/engine/src/lib/curios/timeline/Timeline.svelte
+++ b/packages/engine/src/lib/curios/timeline/Timeline.svelte
@@ -10,8 +10,11 @@
 	 * - Pagination with "Load More"
 	 */
 
-	import { marked } from 'marked';
+	import MarkdownIt from 'markdown-it';
 	import { sanitizeMarkdown } from '$lib/utils';
+
+	// Local instance with breaks: true for timeline rendering
+	const timelineMd = new MarkdownIt({ breaks: true, linkify: true });
 	import {
 		Calendar,
 		GitCommit,
@@ -76,8 +79,6 @@
 	let loadingMore = $state(false);
 	let expandedCards = $state(new Set<string>());
 
-	// Marked options for timeline rendering (breaks converts newlines to <br>)
-	const markedOptions = { breaks: true, async: false } as const;
 
 	// Fun rest day messages
 	const REST_DAY_MESSAGES = [
@@ -173,7 +174,7 @@
 		}
 
 		// Parse to HTML and sanitize
-		let html = sanitizeMarkdown(marked.parse(withRepoLinks, markedOptions) as string);
+		let html = sanitizeMarkdown(timelineMd.render(withRepoLinks));
 
 		// Inject gutter comments after headers
 		for (const [headerName, items] of Object.entries(gutterByHeader)) {

--- a/packages/engine/src/routes/+page.server.ts
+++ b/packages/engine/src/routes/+page.server.ts
@@ -2,10 +2,9 @@ import {
   getHomePage,
   getLatestPost,
   processAnchorTags,
+  renderMarkdown,
 } from "$lib/utils/markdown.js";
 import { error } from "@sveltejs/kit";
-import { marked } from "marked";
-import { sanitizeMarkdown } from "$lib/utils/sanitize.js";
 import type { PageServerLoad } from "./$types.js";
 
 // Disable prerendering - latest post is fetched from D1 at runtime
@@ -101,9 +100,7 @@ export const load: PageServerLoad = async ({ platform, locals }) => {
           pageData.markdown_content &&
           typeof pageData.markdown_content === "string"
         ) {
-          htmlContent = sanitizeMarkdown(
-            marked.parse(pageData.markdown_content, { async: false }) as string,
-          );
+          htmlContent = renderMarkdown(pageData.markdown_content);
         }
 
         // Extract headers from HTML for table of contents
@@ -125,9 +122,7 @@ export const load: PageServerLoad = async ({ platform, locals }) => {
               ) {
                 return {
                   ...item,
-                  content: sanitizeMarkdown(
-                    marked.parse(item.content, { async: false }) as string,
-                  ),
+                  content: renderMarkdown(item.content),
                 };
               }
               return item;
@@ -247,9 +242,7 @@ export const load: PageServerLoad = async ({ platform, locals }) => {
               ) {
                 return {
                   ...item,
-                  content: sanitizeMarkdown(
-                    marked.parse(item.content, { async: false }) as string,
-                  ),
+                  content: renderMarkdown(item.content),
                 };
               }
               return item;

--- a/packages/engine/src/routes/[slug]/+page.server.ts
+++ b/packages/engine/src/routes/[slug]/+page.server.ts
@@ -1,10 +1,9 @@
 import { error } from "@sveltejs/kit";
-import { marked } from "marked";
-import { sanitizeMarkdown } from "$lib/utils/sanitize.js";
 import {
   extractHeaders,
   type GutterItem,
   type Header,
+  renderMarkdown,
 } from "$lib/utils/markdown.js";
 import type { PageServerLoad } from "./$types.js";
 
@@ -85,9 +84,7 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
     let htmlContent = pageData.html_content;
     const rawMarkdown = pageData.markdown_content || "";
     if (!htmlContent && rawMarkdown && typeof rawMarkdown === "string") {
-      htmlContent = sanitizeMarkdown(
-        marked.parse(rawMarkdown, { async: false }) as string,
-      );
+      htmlContent = renderMarkdown(rawMarkdown);
     }
 
     // Extract headers from raw markdown for table of contents
@@ -112,9 +109,7 @@ export const load: PageServerLoad = async ({ params, platform, locals }) => {
           ) {
             return {
               ...item,
-              content: sanitizeMarkdown(
-                marked.parse(item.content, { async: false }) as string,
-              ),
+              content: renderMarkdown(item.content),
             };
           }
           return item;

--- a/packages/engine/src/routes/about/+page.server.ts
+++ b/packages/engine/src/routes/about/+page.server.ts
@@ -1,7 +1,9 @@
-import { getAboutPage, type GutterItem } from "$lib/utils/markdown.js";
+import {
+  getAboutPage,
+  type GutterItem,
+  renderMarkdown,
+} from "$lib/utils/markdown.js";
 import { error } from "@sveltejs/kit";
-import { marked } from "marked";
-import { sanitizeMarkdown } from "$lib/utils/sanitize.js";
 import type { PageServerLoad } from "./$types.js";
 
 // Disable prerendering - content is fetched from D1 at runtime for tenants
@@ -47,9 +49,7 @@ export const load: PageServerLoad = async ({ platform, locals }) => {
           pageData.markdown_content &&
           typeof pageData.markdown_content === "string"
         ) {
-          htmlContent = sanitizeMarkdown(
-            marked.parse(pageData.markdown_content, { async: false }) as string,
-          );
+          htmlContent = renderMarkdown(pageData.markdown_content);
         }
 
         // Extract headers from HTML for table of contents
@@ -73,9 +73,7 @@ export const load: PageServerLoad = async ({ platform, locals }) => {
               ) {
                 return {
                   ...item,
-                  content: sanitizeMarkdown(
-                    marked.parse(item.content, { async: false }) as string,
-                  ),
+                  content: renderMarkdown(item.content),
                 };
               }
               return item;

--- a/packages/engine/src/routes/api/pages/+server.ts
+++ b/packages/engine/src/routes/api/pages/+server.ts
@@ -1,8 +1,7 @@
 import { json, error } from "@sveltejs/kit";
-import { marked } from "marked";
 import { validateCSRF } from "$lib/utils/csrf.js";
 import { sanitizeObject } from "$lib/utils/validation.js";
-import { sanitizeMarkdown } from "$lib/utils/sanitize.js";
+import { renderMarkdown } from "$lib/utils/markdown.js";
 import { getTenantDb, now } from "$lib/server/services/database.js";
 import { getVerifiedTenantId } from "$lib/auth/session.js";
 import {
@@ -134,10 +133,8 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
       } as any);
     }
 
-    // Generate HTML from markdown and sanitize to prevent XSS
-    const html_content = sanitizeMarkdown(
-      marked.parse(data.markdown_content, { async: false }) as string,
-    );
+    // Generate HTML from markdown (renderMarkdown handles sanitization)
+    const html_content = renderMarkdown(data.markdown_content);
 
     const timestamp = now();
 

--- a/packages/engine/src/routes/api/pages/[slug]/+server.ts
+++ b/packages/engine/src/routes/api/pages/[slug]/+server.ts
@@ -1,8 +1,7 @@
 import { json, error } from "@sveltejs/kit";
-import { marked } from "marked";
 import { validateCSRF } from "$lib/utils/csrf.js";
 import { sanitizeObject } from "$lib/utils/validation.js";
-import { sanitizeMarkdown } from "$lib/utils/sanitize.js";
+import { renderMarkdown } from "$lib/utils/markdown.js";
 import { getVerifiedTenantId } from "$lib/auth/session.js";
 import type { RequestHandler } from "./$types.js";
 
@@ -99,10 +98,8 @@ export const PUT: RequestHandler = async ({
       throw error(404, "Page not found");
     }
 
-    // Generate HTML from markdown and sanitize to prevent XSS
-    const html_content = sanitizeMarkdown(
-      marked.parse(data.markdown_content, { async: false }) as string,
-    );
+    // Generate HTML from markdown (renderMarkdown handles sanitization)
+    const html_content = renderMarkdown(data.markdown_content);
 
     const now = new Date().toISOString();
 

--- a/packages/engine/src/routes/api/posts/+server.ts
+++ b/packages/engine/src/routes/api/posts/+server.ts
@@ -1,8 +1,7 @@
 import { json, error } from "@sveltejs/kit";
-import { marked } from "marked";
 import { validateCSRF } from "$lib/utils/csrf.js";
 import { sanitizeObject } from "$lib/utils/validation.js";
-import { sanitizeMarkdown } from "$lib/utils/sanitize.js";
+import { renderMarkdown } from "$lib/utils/markdown.js";
 import { getTenantDb, now } from "$lib/server/services/database.js";
 import { getVerifiedTenantId } from "$lib/auth/session.js";
 import {
@@ -220,10 +219,8 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
       throw error(409, "A post with this slug already exists");
     }
 
-    // Generate HTML from markdown and sanitize to prevent XSS
-    const html_content = sanitizeMarkdown(
-      marked.parse(data.markdown_content, { async: false }) as string,
-    );
+    // Generate HTML from markdown (renderMarkdown handles sanitization)
+    const html_content = renderMarkdown(data.markdown_content);
 
     const timestamp = now();
     const tags = JSON.stringify(data.tags || []);

--- a/packages/engine/src/routes/api/posts/[slug]/+server.ts
+++ b/packages/engine/src/routes/api/posts/[slug]/+server.ts
@@ -1,9 +1,7 @@
 import { json, error } from "@sveltejs/kit";
-import { marked } from "marked";
-import { getPostBySlug } from "$lib/utils/markdown.js";
+import { getPostBySlug, renderMarkdown } from "$lib/utils/markdown.js";
 import { validateCSRF } from "$lib/utils/csrf.js";
 import { sanitizeObject } from "$lib/utils/validation.js";
-import { sanitizeMarkdown } from "$lib/utils/sanitize.js";
 import { getTenantDb, now } from "$lib/server/services/database.js";
 import { getVerifiedTenantId } from "$lib/auth/session.js";
 import * as cache from "$lib/server/services/cache.js";
@@ -269,10 +267,8 @@ export const PUT: RequestHandler = async ({
       throw error(404, "Post not found");
     }
 
-    // Generate HTML from markdown and sanitize to prevent XSS
-    const html_content = sanitizeMarkdown(
-      marked.parse(data.markdown_content, { async: false }) as string,
-    );
+    // Generate HTML from markdown (renderMarkdown handles sanitization)
+    const html_content = renderMarkdown(data.markdown_content);
 
     // Generate a simple hash of the content
     const encoder = new TextEncoder();

--- a/packages/engine/tests/utils/markdown.test.ts
+++ b/packages/engine/tests/utils/markdown.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Markdown Rendering Tests
+ *
+ * Tests for the markdown-it based rendering pipeline.
+ * Focuses on user-facing behavior: heading IDs, code blocks with copy buttons,
+ * inline elements in headings, and the renderMarkdown() integration.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  renderMarkdown,
+  generateHeadingId,
+  extractHeaders,
+  parseMarkdownContent,
+} from "../../src/lib/utils/markdown.js";
+
+// ============================================================================
+// generateHeadingId — pure function, easy to unit test
+// ============================================================================
+
+describe("generateHeadingId", () => {
+  it("should convert text to lowercase kebab-case", () => {
+    expect(generateHeadingId("Hello World")).toBe("hello-world");
+  });
+
+  it("should strip special characters", () => {
+    expect(generateHeadingId("What's New?")).toBe("whats-new");
+  });
+
+  it("should collapse multiple spaces and hyphens", () => {
+    expect(generateHeadingId("Too   Many   Spaces")).toBe("too-many-spaces");
+    expect(generateHeadingId("too---many---dashes")).toBe("too-many-dashes");
+  });
+
+  it("should handle already-kebab text", () => {
+    expect(generateHeadingId("already-kebab")).toBe("already-kebab");
+  });
+
+  it("should handle leading/trailing whitespace gracefully", () => {
+    // Spaces become hyphens before trim runs, so edge spaces become edge hyphens
+    expect(generateHeadingId("  padded  ")).toBe("-padded-");
+    // But normal headings with trimmed input work perfectly
+    expect(generateHeadingId("Normal Heading")).toBe("normal-heading");
+  });
+});
+
+// ============================================================================
+// extractHeaders — header extraction from markdown source
+// ============================================================================
+
+describe("extractHeaders", () => {
+  it("should extract headings with correct levels", () => {
+    const md = "# Title\n\n## Section\n\n### Subsection";
+    const headers = extractHeaders(md);
+
+    expect(headers).toEqual([
+      { level: 1, text: "Title", id: "title" },
+      { level: 2, text: "Section", id: "section" },
+      { level: 3, text: "Subsection", id: "subsection" },
+    ]);
+  });
+
+  it("should ignore headings inside fenced code blocks", () => {
+    const md = "# Real Heading\n\n```\n# Not A Heading\n```\n\n## Another Real";
+    const headers = extractHeaders(md);
+
+    expect(headers).toHaveLength(2);
+    expect(headers[0].text).toBe("Real Heading");
+    expect(headers[1].text).toBe("Another Real");
+  });
+
+  it("should return empty array for content with no headings", () => {
+    expect(extractHeaders("Just a paragraph.")).toEqual([]);
+  });
+});
+
+// ============================================================================
+// renderMarkdown — the primary integration point
+// ============================================================================
+
+describe("renderMarkdown", () => {
+  it("should render basic paragraphs", () => {
+    const result = renderMarkdown("Hello world");
+    expect(result).toContain("<p>Hello world</p>");
+  });
+
+  it("should render bold and italic inline elements", () => {
+    const result = renderMarkdown("This is **bold** and *italic*");
+    expect(result).toContain("<strong>bold</strong>");
+    expect(result).toContain("<em>italic</em>");
+  });
+
+  it("should linkify URLs automatically", () => {
+    const result = renderMarkdown("Visit https://grove.place for more");
+    expect(result).toContain('href="https://grove.place"');
+  });
+
+  it("should NOT convert single newlines to <br> (breaks: false)", () => {
+    const result = renderMarkdown("Line one\nLine two");
+    expect(result).not.toContain("<br");
+  });
+
+  // ─── Heading ID generation ───────────────────────────────────────────
+
+  it("should add id attributes to headings", () => {
+    const result = renderMarkdown("## Getting Started");
+    expect(result).toContain('id="getting-started"');
+    expect(result).toContain("<h2");
+    expect(result).toContain("Getting Started");
+  });
+
+  it("should generate consistent IDs for TOC linking", () => {
+    const md = "## My Section\n\nSome content\n\n### Sub Section";
+    const result = renderMarkdown(md);
+
+    expect(result).toContain('id="my-section"');
+    expect(result).toContain('id="sub-section"');
+  });
+
+  // ─── THE HEADING BUG REGRESSION TEST ─────────────────────────────────
+  // This is the primary reason for the marked → markdown-it migration.
+  // In marked, inline elements inside headings could silently break if
+  // the renderer forgot to call parseInline(). In markdown-it, inline
+  // rendering is structurally separate — this bug is impossible.
+
+  it("should render links inside headings correctly", () => {
+    const result = renderMarkdown("## Check out [Grove](https://grove.place)");
+    expect(result).toContain("<h2");
+    expect(result).toContain('href="https://grove.place"');
+    expect(result).toContain("Grove");
+    // Should NOT contain raw markdown syntax
+    expect(result).not.toContain("[Grove]");
+  });
+
+  it("should render bold text inside headings", () => {
+    const result = renderMarkdown("## This is **important**");
+    expect(result).toContain("<h2");
+    expect(result).toContain("<strong>important</strong>");
+  });
+
+  it("should render inline code inside headings", () => {
+    const result = renderMarkdown("## Using `renderMarkdown()`");
+    expect(result).toContain("<h2");
+    expect(result).toContain("<code>renderMarkdown()</code>");
+  });
+
+  it("should render multiple inline elements inside headings", () => {
+    const result = renderMarkdown(
+      "## The **bold** and [linked](https://x.com) heading",
+    );
+    expect(result).toContain("<strong>bold</strong>");
+    expect(result).toContain('href="https://x.com"');
+    expect(result).toContain("<h2");
+  });
+
+  // ─── Code blocks ─────────────────────────────────────────────────────
+
+  it("should render code blocks with language label", () => {
+    const result = renderMarkdown("```typescript\nconst x = 1;\n```");
+    expect(result).toContain("code-block-wrapper");
+    expect(result).toContain("code-block-language");
+    expect(result).toContain("typescript");
+    expect(result).toContain('class="language-typescript"');
+  });
+
+  it("should render code block structure with language and escaped content", () => {
+    const result = renderMarkdown('```js\nconst x = "<div>";\n```');
+    // The code-block-wrapper and language survive sanitization
+    expect(result).toContain("code-block-wrapper");
+    expect(result).toContain("code-block-header");
+    expect(result).toContain("js");
+    expect(result).toContain("<pre>");
+    expect(result).toContain('class="language-js"');
+    // HTML special chars should be escaped in the code content
+    expect(result).toContain("&lt;div&gt;");
+    // Note: <button> elements are stripped by sanitizeMarkdown() on the server.
+    // Copy buttons are re-added client-side by JavaScript.
+  });
+
+  it("should render markdown code blocks as formatted content", () => {
+    const result = renderMarkdown("```markdown\n# Hello\n\nWorld\n```");
+    expect(result).toContain("rendered-markdown-block");
+    expect(result).toContain("rendered-markdown-content");
+    // The inner markdown should be rendered as HTML
+    expect(result).toContain("<h1");
+  });
+
+  it("should default to 'text' for code blocks without language", () => {
+    const result = renderMarkdown("```\nplain code\n```");
+    expect(result).toContain("text");
+  });
+
+  // ─── Sanitization ────────────────────────────────────────────────────
+
+  it("should sanitize dangerous HTML from output", () => {
+    // markdown-it with html:false won't render raw HTML, but test the
+    // sanitization layer handles any edge cases
+    const result = renderMarkdown("Normal content");
+    // Output should not contain script tags regardless of input
+    expect(result).not.toContain("<script");
+  });
+
+  // ─── GFM features ────────────────────────────────────────────────────
+
+  it("should render lists correctly", () => {
+    const result = renderMarkdown("- Item 1\n- Item 2\n- Item 3");
+    expect(result).toContain("<ul>");
+    expect(result).toContain("<li>Item 1</li>");
+  });
+
+  it("should render blockquotes", () => {
+    const result = renderMarkdown("> This is a quote");
+    expect(result).toContain("<blockquote>");
+    expect(result).toContain("This is a quote");
+  });
+});
+
+// ============================================================================
+// parseMarkdownContent — integration with gray-matter + rendering
+// ============================================================================
+
+describe("parseMarkdownContent", () => {
+  it("should extract frontmatter and render body", () => {
+    const input = `---
+title: My Post
+date: "2025-01-01"
+tags: [grove, test]
+---
+
+# Hello
+
+This is content.`;
+
+    const result = parseMarkdownContent(input);
+
+    expect(result.data.title).toBe("My Post");
+    expect(result.data.date).toBe("2025-01-01");
+    expect(result.data.tags).toEqual(["grove", "test"]);
+    expect(result.content).toContain("<h1");
+    expect(result.content).toContain("Hello");
+    expect(result.content).toContain("This is content.");
+    expect(result.headers).toEqual([{ level: 1, text: "Hello", id: "hello" }]);
+  });
+
+  it("should handle content with no frontmatter", () => {
+    const result = parseMarkdownContent("Just some markdown");
+    expect(result.data).toEqual({});
+    expect(result.content).toContain("Just some markdown");
+  });
+
+  it("should process anchor tags in HTML output", () => {
+    const input = "<!-- anchor:my-note -->\n\nSome content here.";
+    const result = parseMarkdownContent(input);
+    expect(result.content).toContain('data-anchor="my-note"');
+    expect(result.content).toContain("anchor-marker");
+  });
+
+  it("should preserve rawMarkdown in output", () => {
+    const input = `---
+title: Test
+---
+
+Body text here.`;
+
+    const result = parseMarkdownContent(input);
+    expect(result.rawMarkdown).toContain("Body text here.");
+    expect(result.rawMarkdown).not.toContain("title: Test");
+  });
+});

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -30,6 +30,7 @@
     "tailwindcss": "^3.4.15",
     "typescript": "^5.6.0",
     "vite": "^5.4.21",
+    "@types/markdown-it": "^14.1.2",
     "vitest": "^4.0.14",
     "wrangler": "^4.54.0"
   },
@@ -39,7 +40,7 @@
     "@tabler/icons-svelte": "^3.36.1",
     "gray-matter": "^4.0.3",
     "lucide-svelte": "^0.554.0",
-    "marked": "^17.0.1",
+    "markdown-it": "^14.1.0",
     "resend": "^4.0.0"
   }
 }

--- a/packages/landing/src/lib/utils/markdown-parser.ts
+++ b/packages/landing/src/lib/utils/markdown-parser.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import matter from "gray-matter";
-import { marked } from "marked";
+import MarkdownIt from "markdown-it";
+
+const md = new MarkdownIt({ html: false, linkify: true });
 
 export interface MarkdownDoc {
   slug: string;
@@ -24,9 +26,7 @@ export function parseMarkdownFile(filePath: string): ParsedDoc {
   const content = readFileSync(filePath, "utf-8");
   const { data, content: markdownContent } = matter(content);
 
-  const htmlPromise = marked(markdownContent);
-  const htmlResult =
-    typeof htmlPromise === "string" ? htmlPromise : htmlPromise.toString();
+  const htmlResult = md.render(markdownContent);
   const slug = filePath.split("/").pop()?.replace(".md", "") || "";
 
   // Generate excerpt (first paragraph or first 200 chars)

--- a/packages/landing/src/routes/credits/+page.svelte
+++ b/packages/landing/src/routes/credits/+page.svelte
@@ -329,10 +329,10 @@
 				</p>
 
 				<div class="grid gap-3">
-					<a href="https://github.com/markedjs/marked" target="_blank" rel="noopener noreferrer" class="card p-4 hover:border-accent transition-colors group">
+					<a href="https://github.com/markdown-it/markdown-it" target="_blank" rel="noopener noreferrer" class="card p-4 hover:border-accent transition-colors group">
 						<div class="flex items-center justify-between">
 							<div>
-								<span class="font-serif text-foreground group-hover:text-accent-muted transition-colors">Marked</span>
+								<span class="font-serif text-foreground group-hover:text-accent-muted transition-colors">markdown-it</span>
 								<span class="text-foreground-subtle font-sans text-sm ml-2">— Markdown parser</span>
 							</div>
 							<span class="text-foreground-faint text-xs font-sans">MIT</span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,9 @@ importers:
       lucide-svelte:
         specifier: ^0.554.0
         version: 0.554.0(svelte@5.46.1)
-      marked:
-        specifier: ^17.0.1
-        version: 17.0.1
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
       svelte-sonner:
         specifier: ^1.0.7
         version: 1.0.7(svelte@5.46.1)
@@ -201,6 +201,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.2.9
         version: 5.3.1(svelte@5.46.1)(vite@5.4.21(@types/node@22.19.3))(vitest@4.0.16)
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
@@ -291,9 +294,9 @@ importers:
       lucide-svelte:
         specifier: ^0.554.0
         version: 0.554.0(svelte@5.46.1)
-      marked:
-        specifier: ^17.0.1
-        version: 17.0.1
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
       resend:
         specifier: ^4.0.0
         version: 4.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -316,6 +319,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.2.9
         version: 5.3.1(svelte@5.46.1)(vite@5.4.21(@types/node@22.19.3))(vitest@4.0.16)
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -1413,6 +1419,15 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node@20.19.25':
     resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
 
@@ -1543,6 +1558,9 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
@@ -2090,6 +2108,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -2119,9 +2140,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  marked@17.0.1:
-    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
-    engines: {node: '>= 20'}
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -2130,6 +2150,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2308,6 +2331,10 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2643,6 +2670,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3664,6 +3694,15 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/node@20.19.25':
     dependencies:
       undici-types: 6.21.0
@@ -3818,6 +3857,8 @@ snapshots:
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+
+  argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
     dependencies:
@@ -4365,6 +4406,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-character@3.0.0: {}
 
   loupe@3.2.1: {}
@@ -4391,11 +4436,20 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  marked@17.0.1: {}
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.12.2: {}
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -4557,6 +4611,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -4988,6 +5044,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary

- Replace `marked` (v17) with `markdown-it` (v14) across engine + landing packages
- Fix the heading inline-rendering bug: links/bold/code inside headings now render correctly (structurally impossible to break in markdown-it's token architecture)
- New `renderMarkdown()` export centralizes render + sanitize pattern for route files
- 29 new tests covering heading IDs, inline elements, code blocks, and the heading bug regression

## Why

`marked` has broken its API across v4→v5→v12→v14→v17 (token-based renderers, async defaults, singleton globals). `markdown-it` has a stable per-instance API that hasn't had breaking renderer changes since 2017.

## Changes

| Area | Files | What changed |
|------|-------|-------------|
| Dependencies | 2 | `marked` → `markdown-it` + `@types/markdown-it` |
| Core utility | 1 | Per-instance MarkdownIt with heading_open + fence rules |
| Engine routes | 8 | `sanitizeMarkdown(marked.parse(...))` → `renderMarkdown(...)` |
| Components | 3 | Own instances (Timeline: breaks:true, Editor: preview, GutterManager: dead import removed) |
| Landing | 4 | Local instances with heading/link/fence rules, credits updated |
| Tests | 1 | 29 new tests for markdown rendering pipeline |

## Test plan

- [x] All 3,577 engine tests pass
- [x] All 131 landing tests pass
- [x] 29 new markdown-specific tests pass
- [x] TypeScript: 0 errors (both packages)
- [x] No remaining `marked` imports in packages/
- [ ] Manual: verify heading IDs in table of contents on a blog post
- [ ] Manual: verify code blocks render with copy buttons on the site
- [ ] Manual: verify timeline entries render line breaks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)