### PR TITLE
fix(docs): move midnight bloom article to philosophy category

### DIFF
--- a/docs/philosophy/what-is-midnight-bloom.md
+++ b/docs/philosophy/what-is-midnight-bloom.md
@@ -1,8 +1,7 @@
 ---
 title: What is the Midnight Bloom?
 description: The dream at the end of Grove's roadmap — a late-night tea shop where digital and physical community intertwine
-category: help
-section: philosophy-vision
+category: philosophy
 lastUpdated: '2026-01-23'
 keywords:
   - midnight bloom


### PR DESCRIPTION
The article was placed in docs/help-center/articles/ with category: help,
which meant the automatic scanner picked it up as a help center article
instead of a philosophy doc. Moved to docs/philosophy/ and updated
frontmatter to category: philosophy so it appears in the correct section.

https://claude.ai/code/session_01WaCxaeL4qrtV3Cvcfkposc