### PR TITLE
fix(logo): increase hero logo size from w-24 to w-32

### DIFF
--- a/packages/landing/src/routes/+page.svelte
+++ b/packages/landing/src/routes/+page.svelte
@@ -62,7 +62,7 @@
 			aria-label="Toggle season theme"
 			title="Click to change season"
 		>
-			<Logo class="w-24 h-24" season={$seasonStore} />
+			<Logo class="w-32 h-32" season={$seasonStore} />
 		</button>
 	</div>
 


### PR DESCRIPTION
The circular glass logo treatment added in #538 rendered too small
on the landing page hero. Bumps from 96px to 128px (~33% increase).

Fixes #539