### PR TITLE
feat(forest): add glass overlay content sections (#512)

### DIFF
--- a/packages/landing/src/routes/forest/+page.svelte
+++ b/packages/landing/src/routes/forest/+page.svelte
@@ -874,6 +874,7 @@
 			<a
 				href="/pricing"
 				class="inline-block text-accent-muted hover:text-accent-foreground transition-colors font-sans font-medium py-3 px-6"
+				aria-label="See Grove pricing plans"
 			>
 				See Plans →
 			</a>


### PR DESCRIPTION
## Summary

- Adds glass-treated content sections below the forest visualization on `/forest`
- Introduces the Forests feature concept: themed communities for blog discovery without algorithms
- Three sections: community intro (Glass), feature callout grid (4x GlassCard), and a "Coming Soon" CTA linking to `/pricing`

## Details

The Forests feature is Grove's community discovery system — themed neighborhoods (like GeoCities) where blogs grow together. This PR adds the marketing/explanatory content while the feature is in development.

**Components used:** `Glass` (tint + accent variants) and `GlassCard` from `@autumnsgrove/groveengine/ui`

**Heading hierarchy:** h1 (hero) → h2 (section titles) → h3 (card headings)

**Responsive:** Grid collapses to single column on mobile via `sm:grid-cols-2`

**Season/theme compatible:** Uses CSS variable-driven colors (`text-foreground`, `text-accent-muted`, etc.) — works across all 5 seasons and dark mode automatically.

## Test plan

- [ ] Visit `/forest` — glass sections render below the forest visualization
- [ ] Content is readable over the page background
- [ ] Toggle all 5 seasons (Spring, Summer, Autumn, Winter, Midnight)
- [ ] Dark mode looks warm, not washed out
- [ ] Mobile: grid collapses to single column, text remains readable
- [ ] CTA link navigates to `/pricing`
- [ ] DevTools → `prefers-reduced-motion: reduce` → blur disabled, opacity fallback active

🤖 Generated with [Claude Code](https://claude.ai/code)