### PR TITLE
refactor(fonts): create single source of truth for font definitions

### DIFF
--- a/packages/engine/src/lib/config/presets.ts
+++ b/packages/engine/src/lib/config/presets.ts
@@ -52,113 +52,14 @@ export const COLOR_PRESETS: ColorPreset[] = [
 export const DEFAULT_ACCENT_COLOR = "#16a34a";
 
 /**
- * Font presets with display info
+ * Font presets - imported from the canonical source in fonts.ts
+ * This ensures consistency across the entire application
  */
-export interface FontPreset {
-  /** Internal ID used in database */
-  id: string;
-  /** Display name */
-  name: string;
-  /** CSS font-family stack */
-  family: string;
-  /** Description for settings UI */
-  description: string;
-  /** Category for grouping */
-  category: "accessibility" | "sans-serif" | "monospace" | "display";
-}
-
-export const FONT_PRESETS: FontPreset[] = [
-  // Accessibility fonts
-  {
-    id: "lexend",
-    name: "Lexend",
-    family:
-      "'Lexend', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-    description: "Modern accessibility font for reading fluency (default)",
-    category: "accessibility",
-  },
-  {
-    id: "atkinson",
-    name: "Atkinson Hyperlegible",
-    family:
-      "'Atkinson Hyperlegible', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-    description: "Accessibility font for low vision readers",
-    category: "accessibility",
-  },
-
-  // Sans-serif
-  {
-    id: "quicksand",
-    name: "Quicksand",
-    family:
-      "'Quicksand', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-    description: "Rounded, friendly geometric sans-serif",
-    category: "sans-serif",
-  },
-  {
-    id: "plus-jakarta-sans",
-    name: "Plus Jakarta Sans",
-    family:
-      "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-    description: "Contemporary geometric sans, balanced and versatile",
-    category: "sans-serif",
-  },
-
-  // Serifs
-  {
-    id: "lora",
-    name: "Lora",
-    family: "'Lora', Georgia, 'Times New Roman', serif",
-    description: "Highly readable serif for body text",
-    category: "sans-serif",
-  },
-  {
-    id: "merriweather",
-    name: "Merriweather",
-    family: "'Merriweather', Georgia, 'Times New Roman', serif",
-    description: "Elegant, professional serif for reading",
-    category: "sans-serif",
-  },
-  {
-    id: "eb-garamond",
-    name: "EB Garamond",
-    family: "'EB Garamond', Georgia, 'Times New Roman', serif",
-    description: "Classic high-elegance serif",
-    category: "sans-serif",
-  },
-
-  // Monospace
-  {
-    id: "ibm-plex-mono",
-    name: "IBM Plex Mono",
-    family: "'IBM Plex Mono', 'Courier New', Consolas, monospace",
-    description: "Clean, highly readable code font",
-    category: "monospace",
-  },
-
-  // Display/Special
-  {
-    id: "calistoga",
-    name: "Calistoga",
-    family: "'Calistoga', Georgia, serif",
-    description: "Casual brush serif, warm and friendly",
-    category: "display",
-  },
-  {
-    id: "caveat",
-    name: "Caveat",
-    family: "'Caveat', cursive, sans-serif",
-    description: "Handwritten script, personal and informal",
-    category: "display",
-  },
-];
-
-export const DEFAULT_FONT = "lexend";
-
-/**
- * Get font family by ID
- */
-export function getFontFamily(id: string): string {
-  const font = FONT_PRESETS.find((f) => f.id === id);
-  return font?.family ?? FONT_PRESETS[0].family;
-}
+export {
+  fontPresets as FONT_PRESETS,
+  DEFAULT_FONT,
+  fontMap,
+  validFontIds,
+  getFontStack as getFontFamily,
+  type FontPreset,
+} from "$lib/ui/tokens/fonts.js";

--- a/packages/engine/src/lib/ui/tokens/fonts.ts
+++ b/packages/engine/src/lib/ui/tokens/fonts.ts
@@ -270,3 +270,38 @@ export const fontCategoryLabels: Record<FontCategory, string> = {
   monospace: "Monospace",
   display: "Display & Special",
 };
+
+/**
+ * Array of valid font IDs for API validation
+ * Use this in server-side validation to ensure only valid fonts are accepted
+ */
+export const validFontIds: readonly string[] = fonts.map((f) => f.id);
+
+/**
+ * Font preset format for settings UI
+ * Compatible with the FONT_PRESETS format used in presets.ts
+ */
+export interface FontPreset {
+  /** Internal ID used in database */
+  id: string;
+  /** Display name */
+  name: string;
+  /** CSS font-family stack */
+  family: string;
+  /** Description for settings UI */
+  description: string;
+  /** Category for grouping */
+  category: FontCategory;
+}
+
+/**
+ * Font presets for settings UI
+ * Derived from the canonical fonts array - use this instead of maintaining a separate list
+ */
+export const fontPresets: readonly FontPreset[] = fonts.map((f) => ({
+  id: f.id,
+  name: f.name,
+  family: getFontStack(f.id as FontId),
+  description: f.description,
+  category: f.category,
+}));

--- a/packages/engine/src/routes/+layout.svelte
+++ b/packages/engine/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 	import { fade } from 'svelte/transition';
 	import { goto } from '$app/navigation';
 	import { Button, Input } from '$lib/ui';
+	import { fontMap, DEFAULT_FONT } from '$lib/ui/tokens/fonts.js';
 
 	/** @type {{ children: import('svelte').Snippet, data: any }} */
 	let { children, data } = $props();
@@ -29,30 +30,10 @@
 		'The Grove'
 	);
 
-	/** @type {Record<string, string>} */
-	// Font family mapping - maps database values to CSS font stacks
-	const fontMap = {
-		// Default
-		lexend: "'Lexend', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		// Accessibility
-		atkinson: "'Atkinson Hyperlegible', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		opendyslexic: "'OpenDyslexic', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		// Sans-serif
-		quicksand: "'Quicksand', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		'plus-jakarta-sans': "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		// Monospace
-		'ibm-plex-mono': "'IBM Plex Mono', 'Courier New', Consolas, monospace",
-		cozette: "'Cozette', 'Courier New', Consolas, monospace",
-		// Display/Special
-		alagard: "'Alagard', fantasy, cursive",
-		calistoga: "'Calistoga', Georgia, serif",
-		caveat: "'Caveat', cursive, sans-serif"
-	};
-
-	// Apply font from server-loaded settings
+	// Apply font from server-loaded settings (fontMap imported from canonical source)
 	$effect(() => {
 		if (typeof document !== 'undefined' && data?.siteSettings?.font_family) {
-			const fontValue = fontMap[data.siteSettings.font_family] || fontMap.lexend;
+			const fontValue = fontMap[data.siteSettings.font_family] || fontMap[DEFAULT_FONT];
 			document.documentElement.style.setProperty('--font-family-main', fontValue);
 		}
 	});

--- a/packages/engine/src/routes/api/admin/settings/+server.ts
+++ b/packages/engine/src/routes/api/admin/settings/+server.ts
@@ -3,6 +3,7 @@ import { validateCSRF } from "$lib/utils/csrf.js";
 import { sanitizeObject } from "$lib/utils/validation.js";
 import type { RequestHandler } from "./$types";
 import { getVerifiedTenantId } from "$lib/auth/session.js";
+import { validFontIds } from "$lib/ui/tokens/fonts.js";
 
 export const prerender = false;
 
@@ -71,26 +72,9 @@ export const PUT: RequestHandler = async ({ request, platform, locals }) => {
       }
     }
 
-    // Validate font_family value specifically
+    // Validate font_family value against canonical font list
     if (setting_key === "font_family") {
-      const validFonts = [
-        // Default
-        "lexend",
-        // Accessibility
-        "atkinson",
-        "opendyslexic",
-        // Sans-serif
-        "quicksand",
-        "plus-jakarta-sans",
-        // Monospace
-        "ibm-plex-mono",
-        "cozette",
-        // Display/Special
-        "alagard",
-        "calistoga",
-        "caveat",
-      ];
-      if (!validFonts.includes(setting_value)) {
+      if (!validFontIds.includes(setting_value)) {
         throw error(400, "Invalid font value");
       }
     }

--- a/packages/engine/src/routes/blog/[slug]/+page.svelte
+++ b/packages/engine/src/routes/blog/[slug]/+page.svelte
@@ -1,33 +1,15 @@
 <script>
 	import ContentWithGutter from '$lib/components/custom/ContentWithGutter.svelte';
 	import { Button, Badge } from '$lib/ui';
+	import { fontMap } from '$lib/ui/tokens/fonts.js';
 
 	let { data } = $props();
 
 	// Get accent color from site settings (falls back to default if not set)
 	const accentColor = $derived(data.siteSettings?.accent_color || null);
 
-	/** @type {Record<string, string>} */
-	// Font family mapping - curated selection of 10 high-quality fonts
-	const fontMap = {
-		// Accessibility
-		lexend: "'Lexend', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		atkinson: "'Atkinson Hyperlegible', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		// Modern Sans
-		quicksand: "'Quicksand', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		'plus-jakarta-sans': "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-		// Serifs
-		lora: "'Lora', Georgia, 'Times New Roman', serif",
-		merriweather: "'Merriweather', Georgia, 'Times New Roman', serif",
-		'eb-garamond': "'EB Garamond', Georgia, 'Times New Roman', serif",
-		// Monospace
-		'ibm-plex-mono': "'IBM Plex Mono', 'Courier New', Consolas, monospace",
-		// Display/Special
-		calistoga: "'Calistoga', Georgia, serif",
-		caveat: "'Caveat', cursive, sans-serif"
-	};
-
 	// Get the font stack for this post (null if default)
+	// Uses canonical fontMap imported from fonts.ts
 	const postFont = $derived(
 		data.post.font && data.post.font !== 'default'
 			? fontMap[data.post.font]


### PR DESCRIPTION
## Summary

- **Consolidates 4 duplicate font definitions into one canonical source** in `fonts.ts`
- Removes ~120 lines of redundant code
- Fixes font list mismatches that caused settings to show fonts that wouldn't actually work

## Problem

Font definitions were duplicated in 4 places with **different font lists**:

| Location | Issue |
|----------|-------|
| `fonts.ts` | Had 10 fonts (canonical) |
| `presets.ts` | Different 10 fonts (had serifs, missing cozette/alagard) |
| `+layout.svelte` | Matched fonts.ts |
| `blog/[slug]/+page.svelte` | Yet another list (serifs, no cozette) |
| API validation | Hardcoded array |

This caused bugs like:
- Settings UI showing fonts that would fail API validation
- Per-post font selector missing fonts that exist in site settings
- Adding a new font required changes in 4+ files

## Changes

- Add `validFontIds` and `fontPresets` exports to `fonts.ts`
- Update `presets.ts` to re-export from fonts.ts (removes ~100 lines)
- Update `+layout.svelte` to import `fontMap` from fonts.ts
- Update `blog/[slug]/+page.svelte` to import `fontMap` from fonts.ts  
- Update API validation to import `validFontIds` from fonts.ts

## Test plan

- [x] svelte-check passes with 0 errors
- [x] All existing tests pass
- [ ] Verify font settings page loads correctly
- [ ] Verify font selection saves and applies
- [ ] Verify per-post font override works

Related to #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)