### PR TITLE
fix(arbor): use hardcoded colors for admin dashboard text contrast

### DIFF
--- a/packages/engine/src/routes/admin/+page.svelte
+++ b/packages/engine/src/routes/admin/+page.svelte
@@ -83,8 +83,7 @@
         href="https://grove.place/knowledge/help/wanderers-and-pathfinders"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-colors"
-        style="background: rgba(34, 197, 94, 0.15); color: var(--color-primary);"
+        class="rooted-badge inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-colors"
         title="You've planted your tree in the grove"
         aria-label="Learn about being Rooted in Grove"
       >
@@ -378,7 +377,11 @@
     border-radius: 9999px;
     font-size: 0.875rem;
     font-weight: 500;
-    color: var(--color-primary);
+    color: #166534;
+  }
+
+  :global(.dark) .roadmap-badge {
+    color: #4ade80;
   }
 
   .roadmap-content {
@@ -416,8 +419,22 @@
 
   .progress-fill {
     height: 100%;
-    background: var(--color-primary);
+    background: #16a34a;
     border-radius: 9999px;
     transition: width 0.5s ease;
+  }
+
+  :global(.dark) .progress-fill {
+    background: #22c55e;
+  }
+
+  /* Rooted badge in header */
+  .rooted-badge {
+    background: rgba(34, 197, 94, 0.15);
+    color: #166534;
+  }
+
+  :global(.dark) .rooted-badge {
+    color: #4ade80;
   }
 </style>


### PR DESCRIPTION
## Summary

Fixes text legibility issues in the Arbor admin dashboard where text was nearly invisible in both light and dark modes. The root cause was that CSS custom property cascading through `var(--color-text-muted)` → `hsl(var(--muted-foreground))` wasn't working correctly with Svelte scoped styles and the `:global(.dark)` selector pattern.

**Solution:** Replace CSS variable references with direct hex colors for reliable contrast.

## Changes

- Dashboard heading and welcome message: `text-[#333] dark:text-[#f0f0f0]`
- Stat card labels: `#555` light / `#b0b0b0` dark
- Stat card values: `#333` light / `#f0f0f0` dark
- Quick Actions heading and cards
- Roadmap preview card

## Why Hardcoded Colors?

We tried two previous approaches that didn't work:
1. Adding `--foreground-muted` and `--foreground-subtle` to Tailwind config (PR #639)
2. Adjusting `--muted-foreground` values in app.css

Both failed because the admin dashboard uses a different variable chain (`--color-text-muted` defined in tokens.css) that wasn't cascading through Svelte's scoped style boundaries. Hardcoding the colors bypasses this complexity and ensures reliable contrast.

## Test Plan

- [ ] Verify text is readable in light mode on dashboard
- [ ] Verify text is readable in dark mode on dashboard
- [ ] Check stat cards (Blog Posts, Words Written, Top Tags, Account Age)
- [ ] Check Quick Actions buttons
- [ ] Check Roadmap preview section
- [ ] Test on mobile viewport

Fixes #618

🤖 Generated with [Claude Code](https://claude.ai/code)