### PR TITLE
fix(chrome): allow clearing nav links in mobile menu

### DIFF
--- a/packages/clearing/src/routes/+page.svelte
+++ b/packages/clearing/src/routes/+page.svelte
@@ -24,10 +24,12 @@
 		Trees
 	} from 'lucide-svelte';
 
-	// Status page navigation - just a way home
+	// Status page navigation - just a way home (no grove.place footer sections)
 	const navItems: NavItem[] = [
 		{ href: 'https://grove.place', label: 'Grove', icon: Trees, external: true }
 	];
+	const resourceLinks: never[] = [];
+	const connectLinks: never[] = [];
 
 	let { data } = $props();
 
@@ -58,7 +60,7 @@
 </svelte:head>
 
 <div class="min-h-screen flex flex-col">
-	<Header {navItems} brandTitle="Status" />
+	<Header {navItems} {resourceLinks} {connectLinks} brandTitle="Status" />
 
 	<main class="flex-1 py-8 px-4 sm:px-6" aria-label="Status page content">
 		<div class="max-w-4xl mx-auto space-y-8">

--- a/packages/engine/src/lib/ui/components/chrome/Header.svelte
+++ b/packages/engine/src/lib/ui/components/chrome/Header.svelte
@@ -5,7 +5,7 @@
 	import MobileMenu from './MobileMenu.svelte';
 	import { seasonStore } from '../../stores/season.svelte';
 	import { Menu } from 'lucide-svelte';
-	import type { NavItem, MaxWidth } from './types';
+	import type { NavItem, MaxWidth, FooterLink } from './types';
 	import type { Season } from '../../types/season';
 	import { isActivePath } from './types';
 	import { DEFAULT_NAV_ITEMS } from './defaults';
@@ -15,6 +15,8 @@
 
 	interface Props {
 		navItems?: NavItem[];
+		resourceLinks?: FooterLink[];
+		connectLinks?: FooterLink[];
 		maxWidth?: MaxWidth;
 		brandTitle?: string;
 		season?: Season;
@@ -22,6 +24,8 @@
 
 	let {
 		navItems,
+		resourceLinks,
+		connectLinks,
 		maxWidth = 'default',
 		brandTitle,
 		season
@@ -105,4 +109,4 @@
 </header>
 
 <!-- Mobile menu overlay -->
-<MobileMenu bind:open={mobileMenuOpen} onClose={() => (mobileMenuOpen = false)} {navItems} />
+<MobileMenu bind:open={mobileMenuOpen} onClose={() => (mobileMenuOpen = false)} {navItems} {resourceLinks} {connectLinks} />


### PR DESCRIPTION
Header component now accepts resourceLinks and connectLinks props,
forwarding them to MobileMenu. Clearing passes empty arrays to hide
the grove.place footer sections (Resources/Connect) in its sidebar.