### PR TITLE
fix: improve admin text legibility in dark mode (#659)

### DIFF
--- a/packages/engine/src/lib/styles/tokens.css
+++ b/packages/engine/src/lib/styles/tokens.css
@@ -176,6 +176,18 @@
 .dark {
 	color-scheme: dark;
 
+	/* ==========================================================================
+	   BASE VARIABLE REDEFINITIONS FOR DARK MODE
+	   These redefine the same variable names used in :root so that components
+	   using var(--color-text-muted) automatically get dark mode values.
+	   The -dark suffixed variants below are kept for backward compatibility.
+	   ========================================================================== */
+	--color-text: hsl(var(--foreground));
+	--color-text-muted: hsl(var(--muted-foreground));
+	--color-text-subtle: hsl(0 0% 72%);
+	--color-bg-secondary: hsl(var(--secondary));
+	--color-border: hsl(var(--border));
+
 	/* Dark mode tag colors */
 	--tag-bg: hsl(270 38% 55%);
 	--tag-bg-hover: hsl(270 38% 49%);

--- a/packages/engine/src/routes/admin/blog/+page.svelte
+++ b/packages/engine/src/routes/admin/blog/+page.svelte
@@ -62,8 +62,8 @@
 
   <header class="flex justify-between items-start mb-8 max-md:flex-col max-md:items-stretch max-md:gap-4">
     <div>
-      <h1 class="m-0 mb-1 text-3xl text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-colors">Blog Posts</h1>
-      <p class="m-0 text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] transition-colors">{data.posts.length} posts</p>
+      <h1 class="m-0 mb-1 text-3xl text-[#333] dark:text-[#f0f0f0] transition-colors">Blog Posts</h1>
+      <p class="m-0 text-[#555] dark:text-[#b0b0b0] transition-colors">{data.posts.length} posts</p>
     </div>
     <Button variant="primary" onclick={() => window.location.href = '/admin/blog/new'}>
       + New Post
@@ -74,24 +74,24 @@
     <table class="w-full border-collapse">
       <thead>
         <tr>
-          <th class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:px-2 max-md:py-3">Title</th>
-          <th class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden">Date</th>
-          <th class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden">Tags</th>
-          <th class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:px-2 max-md:py-3">Actions</th>
+          <th class="p-4 text-left border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:px-2 max-md:py-3">Title</th>
+          <th class="p-4 text-left border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden">Date</th>
+          <th class="p-4 text-left border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden">Tags</th>
+          <th class="p-4 text-left border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:px-2 max-md:py-3">Actions</th>
         </tr>
       </thead>
       <tbody>
         {#each data.posts as post (post.slug)}
           <tr>
-            <td class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] transition-[border-color] max-md:px-2 max-md:py-3">
-              <a href="/blog/{post.slug}" target="_blank" rel="noopener noreferrer" aria-label="{post.title} (opens in new tab)" class="font-medium text-[var(--color-primary)] dark:text-[var(--color-primary-light)] no-underline hover:underline transition-colors">
+            <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 transition-[border-color] max-md:px-2 max-md:py-3">
+              <a href="/blog/{post.slug}" target="_blank" rel="noopener noreferrer" aria-label="{post.title} (opens in new tab)" class="font-medium text-green-700 dark:text-green-400 no-underline hover:underline transition-colors">
                 {post.title}
               </a>
               {#if post.description}
-                <p class="mt-1 mb-0 text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] transition-colors">{post.description}</p>
+                <p class="mt-1 mb-0 text-xs text-[#555] dark:text-[#b0b0b0] transition-colors">{post.description}</p>
               {/if}
             </td>
-            <td class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] whitespace-nowrap text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] text-sm transition-[border-color,color] max-md:hidden">
+            <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 whitespace-nowrap text-[#555] dark:text-[#b0b0b0] text-sm transition-[border-color,color] max-md:hidden">
               {#if post.status === 'published' && post.date}
                 {formatDate(post.date)}
               {:else if post.status === 'draft'}
@@ -100,7 +100,7 @@
                 <span class="text-gray-400 dark:text-gray-500">—</span>
               {/if}
             </td>
-            <td class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] transition-[border-color] max-md:hidden">
+            <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 transition-[border-color] max-md:hidden">
               {#if post.tags.length > 0}
                 <div class="flex flex-wrap gap-1">
                   {#each post.tags as tag (tag)}
@@ -108,12 +108,12 @@
                   {/each}
                 </div>
               {:else}
-                <span class="text-[var(--color-text-subtle)] dark:text-[var(--color-text-subtle-dark)] transition-colors">-</span>
+                <span class="text-[#666] dark:text-[#9ca3af] transition-colors">-</span>
               {/if}
             </td>
-            <td class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] whitespace-nowrap transition-[border-color] max-md:px-2 max-md:py-3">
-              <a href="/blog/{post.slug}" target="_blank" rel="noopener noreferrer" aria-label="View {post.title} (opens in new tab)" class="text-[var(--color-primary)] dark:text-[var(--color-primary-light)] no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">View</a>
-              <a href="/admin/blog/edit/{post.slug}" class="text-[var(--color-primary)] dark:text-[var(--color-primary-light)] no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">Edit</a>
+            <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 whitespace-nowrap transition-[border-color] max-md:px-2 max-md:py-3">
+              <a href="/blog/{post.slug}" target="_blank" rel="noopener noreferrer" aria-label="View {post.title} (opens in new tab)" class="text-green-700 dark:text-green-400 no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">View</a>
+              <a href="/admin/blog/edit/{post.slug}" class="text-green-700 dark:text-green-400 no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">Edit</a>
               <button
                 onclick={() => confirmDelete({ slug: post.slug, title: post.title })}
                 disabled={deleting}
@@ -127,7 +127,7 @@
           </tr>
         {:else}
           <tr>
-            <td colspan="4" class="text-center text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] py-12 px-4 transition-colors">
+            <td colspan="4" class="text-center text-[#555] dark:text-[#b0b0b0] py-12 px-4 transition-colors">
               No blog posts yet. Create your first post!
             </td>
           </tr>

--- a/packages/engine/src/routes/admin/pages/+page.svelte
+++ b/packages/engine/src/routes/admin/pages/+page.svelte
@@ -69,8 +69,8 @@
 <div class="max-w-screen-xl">
   <header class="flex justify-between items-start mb-8 max-md:flex-col max-md:items-stretch max-md:gap-4">
     <div>
-      <h1 class="m-0 mb-1 text-3xl text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-colors">Site Pages</h1>
-      <p class="m-0 text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] transition-colors">
+      <h1 class="m-0 mb-1 text-3xl text-[#333] dark:text-[#f0f0f0] transition-colors">Site Pages</h1>
+      <p class="m-0 text-[#555] dark:text-[#b0b0b0] transition-colors">
         {data.pages.length} pages
         <span class="mx-2">·</span>
         <span class:text-amber-600={atLimit} class:dark:text-amber-400={atLimit}>
@@ -100,11 +100,11 @@
     <table class="w-full border-collapse">
       <thead>
         <tr>
-          <th class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:px-2 max-md:py-3">Page</th>
-          <th class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden">Type</th>
-          <th class="p-4 text-center border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden" title="Show in navigation menu">Nav</th>
-          <th class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden">Updated</th>
-          <th class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:px-2 max-md:py-3">Actions</th>
+          <th class="p-4 text-left border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:px-2 max-md:py-3">Page</th>
+          <th class="p-4 text-left border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden">Type</th>
+          <th class="p-4 text-center border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden" title="Show in navigation menu">Nav</th>
+          <th class="p-4 text-left border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:hidden">Updated</th>
+          <th class="p-4 text-left border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm font-semibold text-xs text-[#333] dark:text-[#f0f0f0] transition-[background-color,color,border-color] sticky top-0 z-10 max-md:px-2 max-md:py-3">Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -112,18 +112,18 @@
           {@const isInNav = page.show_in_nav === 1}
           {@const canToggle = isInNav || !atLimit}
           <tr>
-            <td class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] transition-[border-color] max-md:px-2 max-md:py-3">
-              <a href="/{page.slug === 'home' ? '' : page.slug}" target="_blank" class="font-medium text-[var(--color-primary)] dark:text-[var(--color-primary-light)] no-underline hover:underline transition-colors">
+            <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 transition-[border-color] max-md:px-2 max-md:py-3">
+              <a href="/{page.slug === 'home' ? '' : page.slug}" target="_blank" class="font-medium text-green-700 dark:text-green-400 no-underline hover:underline transition-colors">
                 {page.title}
               </a>
               {#if page.description}
-                <p class="mt-1 mb-0 text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] transition-colors">{page.description}</p>
+                <p class="mt-1 mb-0 text-xs text-[#555] dark:text-[#b0b0b0] transition-colors">{page.description}</p>
               {/if}
             </td>
-            <td class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] whitespace-nowrap transition-[border-color] max-md:hidden">
+            <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 whitespace-nowrap transition-[border-color] max-md:hidden">
               <Badge variant="tag">{page.type}</Badge>
             </td>
-            <td class="p-4 text-center border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] whitespace-nowrap transition-[border-color] max-md:hidden">
+            <td class="p-4 text-center border-b border-gray-200 dark:border-gray-700 whitespace-nowrap transition-[border-color] max-md:hidden">
               <input
                 type="checkbox"
                 checked={isInNav}
@@ -137,15 +137,15 @@
                 aria-label={`Toggle navigation visibility for ${page.title}`}
               />
             </td>
-            <td class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] whitespace-nowrap text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] text-sm transition-[border-color,color] max-md:hidden">{formatDate(page.updated_at)}</td>
-            <td class="p-4 text-left border-b border-[var(--color-border)] dark:border-[var(--color-border-dark)] whitespace-nowrap transition-[border-color] max-md:px-2 max-md:py-3">
-              <a href="/{page.slug === 'home' ? '' : page.slug}" target="_blank" class="text-[var(--color-primary)] dark:text-[var(--color-primary-light)] no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">View</a>
-              <a href="/admin/pages/edit/{page.slug}" class="text-[var(--color-primary)] dark:text-[var(--color-primary-light)] no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">Edit</a>
+            <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 whitespace-nowrap text-[#555] dark:text-[#b0b0b0] text-sm transition-[border-color,color] max-md:hidden">{formatDate(page.updated_at)}</td>
+            <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 whitespace-nowrap transition-[border-color] max-md:px-2 max-md:py-3">
+              <a href="/{page.slug === 'home' ? '' : page.slug}" target="_blank" class="text-green-700 dark:text-green-400 no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">View</a>
+              <a href="/admin/pages/edit/{page.slug}" class="text-green-700 dark:text-green-400 no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">Edit</a>
             </td>
           </tr>
         {:else}
           <tr>
-            <td colspan="5" class="text-center text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] py-12 px-4 transition-colors">
+            <td colspan="5" class="text-center text-[#555] dark:text-[#b0b0b0] py-12 px-4 transition-colors">
               No pages yet. Click "Create Page" to get started.
             </td>
           </tr>
@@ -156,11 +156,11 @@
 
   <GlassCard variant="muted">
     <h3>About Pages</h3>
-    <p class="text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)]">
+    <p class="text-[#555] dark:text-[#b0b0b0]">
       Pages are standalone content like About, Contact, or custom landing pages.
       Unlike blog posts, pages can appear in your site navigation and are designed for timeless content.
     </p>
-    <p class="text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] text-sm mt-2">
+    <p class="text-[#555] dark:text-[#b0b0b0] text-sm mt-2">
       <strong>Navigation limits:</strong> Your plan allows up to {navLimit} custom navigation pages.
       Home, Blog, and About are always included in navigation automatically.
     </p>

--- a/packages/engine/src/routes/admin/pages/create/+page.svelte
+++ b/packages/engine/src/routes/admin/pages/create/+page.svelte
@@ -158,10 +158,10 @@
 <div class="max-w-screen-2xl mx-auto">
   <header class="flex justify-between items-start mb-6 max-md:flex-col max-md:items-stretch max-md:gap-4">
     <div>
-      <h1 class="m-0 mb-1 text-3xl text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-colors">
+      <h1 class="m-0 mb-1 text-3xl text-[#333] dark:text-[#f0f0f0] transition-colors">
         Create New Page
       </h1>
-      <p class="m-0 text-sm text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] transition-colors">
+      <p class="m-0 text-sm text-[#555] dark:text-[#b0b0b0] transition-colors">
         Add a new page to your site
       </p>
     </div>
@@ -179,7 +179,7 @@
     <!-- Page Details Section -->
     <GlassCard variant="default" class="details-section">
       <div class="details-content">
-        <h2 class="m-0 mb-4 text-xl text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-colors">
+        <h2 class="m-0 mb-4 text-xl text-[#333] dark:text-[#f0f0f0] transition-colors">
           Page Details
         </h2>
 
@@ -196,7 +196,7 @@
         <div class="form-group">
           <label for="slug">
             URL Slug
-            <span class="text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] ml-2">
+            <span class="text-xs text-[#555] dark:text-[#b0b0b0] ml-2">
               (Auto-generated from title)
             </span>
           </label>
@@ -220,7 +220,7 @@
           {#if slugError}
             <p class="text-sm text-red-500 mt-1">{slugError}</p>
           {:else}
-            <p class="text-xs text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] mt-1">
+            <p class="text-xs text-[#555] dark:text-[#b0b0b0] mt-1">
               Preview: /{slug || 'your-page-slug'}
             </p>
           {/if}
@@ -295,7 +295,7 @@
 
     <!-- Markdown Editor -->
     <GlassCard variant="default" class="editor-section">
-      <h2 class="m-0 mb-4 text-xl text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-colors">
+      <h2 class="m-0 mb-4 text-xl text-[#333] dark:text-[#f0f0f0] transition-colors">
         Content <span class="text-red-500">*</span>
       </h2>
       <MarkdownEditor

--- a/packages/engine/src/routes/admin/pages/edit/[slug]/+page.svelte
+++ b/packages/engine/src/routes/admin/pages/edit/[slug]/+page.svelte
@@ -172,10 +172,10 @@
 <div class="max-w-screen-2xl mx-auto">
   <header class="flex justify-between items-start mb-6 max-md:flex-col max-md:items-stretch max-md:gap-4">
     <div>
-      <h1 class="m-0 mb-1 text-3xl text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-colors">
+      <h1 class="m-0 mb-1 text-3xl text-[#333] dark:text-[#f0f0f0] transition-colors">
         Edit Page: {data.page.title}
       </h1>
-      <p class="m-0 text-sm text-[var(--color-text-muted)] dark:text-[var(--color-text-subtle-dark)] transition-colors">
+      <p class="m-0 text-sm text-[#555] dark:text-[#b0b0b0] transition-colors">
         Slug: {slug}
         {#if hasUnsavedChanges}
           <span class="unsaved-indicator">• Unsaved changes</span>
@@ -196,7 +196,7 @@
     <!-- Page Details Section -->
     <GlassCard variant="default" class="details-section">
       <button class="details-header" onclick={toggleDetailsCollapsed}>
-        <h2 class="m-0 text-xl text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-colors">
+        <h2 class="m-0 text-xl text-[#333] dark:text-[#f0f0f0] transition-colors">
           Page Details
         </h2>
         <span class="collapse-icon">{detailsCollapsed ? '▼' : '▲'}</span>
@@ -284,7 +284,7 @@
 
     <!-- Markdown Editor -->
     <GlassCard variant="default" class="editor-section">
-      <h2 class="m-0 mb-4 text-xl text-[var(--color-text)] dark:text-[var(--color-text-dark)] transition-colors">
+      <h2 class="m-0 mb-4 text-xl text-[#333] dark:text-[#f0f0f0] transition-colors">
         Content
       </h2>
       <MarkdownEditor


### PR DESCRIPTION
## Summary
- Fix root cause of dark mode text legibility issues: token system defined separate `-dark` suffixed variables instead of redefining base variables
- Add base variable redefinitions (`--color-text`, `--color-text-muted`, etc.) to `.dark` selector in tokens.css
- Migrate Tailwind arbitrary values in blog/pages admin routes to semantic hex values

## Root Cause
The token system in `tokens.css` defined **separate `-dark` suffixed variables** instead of redefining base variables:

```css
/* Before (broken) */
:root { --color-text-muted: hsl(var(--muted-foreground)); }
.dark { --color-text-muted-dark: hsl(var(--muted-foreground)); }  /* Different name! */
```

Components using `var(--color-text-muted)` always got the light value because `.dark` never redefined it.

## Changes
| File | Change |
|------|--------|
| `tokens.css` | Add base variable redefinitions to `.dark` (architectural fix) |
| `blog/+page.svelte` | Migrate Tailwind arbitrary values to hex |
| `pages/+page.svelte` | Migrate Tailwind arbitrary values to hex |
| `pages/create/+page.svelte` | Migrate Tailwind arbitrary values to hex |
| `pages/edit/[slug]/+page.svelte` | Migrate Tailwind arbitrary values to hex |

## Test plan
- [ ] Light mode - all admin pages render with correct text colors
- [ ] Dark mode - all admin pages render with legible text (no dark-on-dark)
- [ ] Toggle between modes mid-session works correctly
- [ ] Mobile viewport - both light & dark modes

Fixes #659

🤖 Generated with [Claude Code](https://claude.ai/code)