### PR TITLE
feat(landing): implement segmented vine physics animation v3

### DIFF
--- a/packages/landing/src/app.html
+++ b/packages/landing/src/app.html
@@ -939,11 +939,11 @@
           if (o && !o.classList.contains('grove-parting')) {
             o.classList.add('grove-parting');
           }
-          // ALWAYS remove overlay after animation completes (~3s for segmented animation)
-          // This ensures cleanup even if Svelte hydration is delayed
+          // ALWAYS remove overlay after animation completes
+          // Max delay (820ms) + duration (2500ms) = 3320ms; use 3500ms for safety buffer
           setTimeout(function() {
             if (o) o.remove();
-          }, 3000);
+          }, 3500);
         }, 100);
       });
     </script>

--- a/packages/landing/src/lib/utils/loading-overlay.test.ts
+++ b/packages/landing/src/lib/utils/loading-overlay.test.ts
@@ -141,8 +141,13 @@ describe("Grove Entrance Animation", () => {
     });
 
     it("should disable segment transforms for reduced motion", () => {
-      expect(appHtml).toContain(".vine-seg");
-      // Reduced motion should disable transforms on segments
+      // Verify that reduced motion CSS disables transforms on .vine-seg
+      const reducedMotionMatch = appHtml.match(
+        /@media \(prefers-reduced-motion: reduce\)[^@]+/,
+      );
+      expect(reducedMotionMatch).not.toBeNull();
+      expect(reducedMotionMatch![0]).toContain(".vine-seg");
+      expect(reducedMotionMatch![0]).toContain("transform: none !important");
     });
 
     it("should have noscript fallback for users without JavaScript", () => {

--- a/packages/landing/src/routes/+layout.svelte
+++ b/packages/landing/src/routes/+layout.svelte
@@ -24,7 +24,7 @@
 				// Trigger the parting animation
 				overlay.classList.add('grove-parting');
 				// Remove after animation completes (~3s for segmented animation)
-				setTimeout(() => overlay.remove(), 3000);
+				setTimeout(() => overlay.remove(), 3500);
 			}
 		}
 	});


### PR DESCRIPTION
## Summary
- Replace monolithic vine rotation with nested 8-segment architecture for natural "rope physics" cascading animation
- Split each of the 12 vines into 8 nested DOM segments (125px each, 96 total animated elements)
- Add 16 dampened keyframes with progressive amplitude (top segments 18-30°, tip segments 3-6°)
- 60ms cascading delays between segments creates wave propagation down each vine
- Increase animation duration to 2.5s (was 1.4s) so it's slow enough to appreciate

## Why Nested Segments?
When a parent DOM element rotates, all children rotate with it. By nesting segment 2 inside segment 1, segment 2's own rotation *adds* to segment 1's rotation—creating natural cascading "rope physics" with pure CSS, no JavaScript needed.

## Test plan
- [x] All 44 loading-overlay tests pass
- [x] Full test suite passes (175 tests)
- [ ] Manual test: Each segment rotates from its top attachment point
- [ ] Manual test: Movement cascades naturally from top to bottom
- [ ] Manual test: Dampening is visible (top moves more than tip)
- [ ] Manual test: Animation is slow enough to appreciate (~2.5s)
- [ ] Manual test: Left vines part leftward, right vines part rightward
- [ ] Manual test: Glass backdrop fades correctly
- [ ] Manual test: Reduced motion still works (instant fade)
- [ ] Manual test: No performance issues (96 elements animating)

🤖 Generated with [Claude Code](https://claude.ai/code)