### PR TITLE
fix(ci): ensure svelte-kit sync runs before tests and build engine types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Sync SvelteKit (generate tsconfig)
+        run: |
+          for config in packages/*/svelte.config.*; do
+            (cd "$(dirname "$config")" && pnpm exec svelte-kit sync) || true
+          done
+
       - name: Run all tests
         run: pnpm test
 
@@ -59,6 +65,10 @@ jobs:
 
       - name: Type check engine
         run: pnpm check
+        working-directory: packages/engine
+
+      - name: Build engine package (for types)
+        run: pnpm package
         working-directory: packages/engine
 
       - name: Type check landing

--- a/packages/landing/src/app.d.ts
+++ b/packages/landing/src/app.d.ts
@@ -4,7 +4,9 @@ declare global {
   namespace App {
     interface Locals {
       user: {
+        id: string;
         email: string;
+        name: string | null;
         is_admin: boolean;
       } | null;
       /** D1 database session for consistent reads within a request */

--- a/packages/landing/src/hooks.server.ts
+++ b/packages/landing/src/hooks.server.ts
@@ -76,7 +76,9 @@ export const handle: Handle = async ({ event, resolve }) => {
 
         if (data.valid && data.user) {
           event.locals.user = {
+            id: data.user.id,
             email: data.user.email,
+            name: data.user.name || null,
             is_admin: data.user.isAdmin,
           };
           return resolve(event);
@@ -124,7 +126,9 @@ export const handle: Handle = async ({ event, resolve }) => {
 
     if (user) {
       event.locals.user = {
+        id: user.id,
         email: user.email,
+        name: null, // Legacy D1 sessions don't store name
         is_admin: user.is_admin === 1,
       };
     }

--- a/packages/landing/src/routes/porch/+page.svelte
+++ b/packages/landing/src/routes/porch/+page.svelte
@@ -36,7 +36,7 @@
 				<p class="text-foreground-muted font-sans mb-6 max-w-md mx-auto">
 					Tell me what's going on. I read everything personally and respond as quickly as I can.
 				</p>
-				<GlassButton href="/porch/new" variant="primary" class="inline-flex items-center gap-2">
+				<GlassButton href="/porch/new" variant="accent" class="inline-flex items-center gap-2">
 					Start a conversation
 					<ArrowRight class="w-4 h-4" />
 				</GlassButton>


### PR DESCRIPTION
The CI workflow was failing because:
1. Tests require .svelte-kit/tsconfig.json which is generated by svelte-kit sync
2. Landing typecheck needs engine dist/ with type definitions

Also fixes type errors in landing package:
- Add missing id and name properties to locals.user type
- Use correct GlassButton variant (accent instead of primary)

https://claude.ai/code/session_012FUSwrPPbksKrJR2S53bQv