### PR TITLE
revert: restore original vine animation timing

### DIFF
--- a/packages/landing/src/app.html
+++ b/packages/landing/src/app.html
@@ -367,160 +367,160 @@
          Parting State (triggered by adding .grove-parting class)
          ─────────────────────────────────────────────────────────────
 
-         SEGMENTED ANIMATION (v3 - optimized):
+         SEGMENTED ANIMATION (v3):
          - Each segment has its own keyframes with dampening
-         - 40ms delay between segments creates wave propagation
-         - 50ms delay between adjacent vines for visual separation
-         - Total duration: 1.8s (snappier while still appreciable)
+         - 60ms delay between segments creates wave propagation
+         - 80ms delay between adjacent vines for visual separation
+         - Total duration: 2.5s (slow enough to appreciate)
          ───────────────────────────────────────────────────────────── */
 
       /* ═══ LEFT VINES swing RIGHT (positive rotation = outward) ═══ */
       /* Vine 8 (center-most) starts first */
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-1 { animation: vine-swing-r-1 1.8s ease-out 0ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-2 { animation: vine-swing-r-2 1.8s ease-out 40ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-3 { animation: vine-swing-r-3 1.8s ease-out 80ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-4 { animation: vine-swing-r-4 1.8s ease-out 120ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-5 { animation: vine-swing-r-5 1.8s ease-out 160ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-6 { animation: vine-swing-r-6 1.8s ease-out 200ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-7 { animation: vine-swing-r-7 1.8s ease-out 240ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-8 { animation: vine-swing-r-8 1.8s ease-out 280ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-1 { animation: vine-swing-r-1 2.5s ease-out 0ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-2 { animation: vine-swing-r-2 2.5s ease-out 60ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-3 { animation: vine-swing-r-3 2.5s ease-out 120ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-4 { animation: vine-swing-r-4 2.5s ease-out 180ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-5 { animation: vine-swing-r-5 2.5s ease-out 240ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-6 { animation: vine-swing-r-6 2.5s ease-out 300ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-7 { animation: vine-swing-r-7 2.5s ease-out 360ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(8) .vine-seg-8 { animation: vine-swing-r-8 2.5s ease-out 420ms forwards; }
 
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-1 { animation: vine-swing-r-1 1.8s ease-out 50ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-2 { animation: vine-swing-r-2 1.8s ease-out 90ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-3 { animation: vine-swing-r-3 1.8s ease-out 130ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-4 { animation: vine-swing-r-4 1.8s ease-out 170ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-5 { animation: vine-swing-r-5 1.8s ease-out 210ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-6 { animation: vine-swing-r-6 1.8s ease-out 250ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-7 { animation: vine-swing-r-7 1.8s ease-out 290ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-8 { animation: vine-swing-r-8 1.8s ease-out 330ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-1 { animation: vine-swing-r-1 2.5s ease-out 80ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-2 { animation: vine-swing-r-2 2.5s ease-out 140ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-3 { animation: vine-swing-r-3 2.5s ease-out 200ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-4 { animation: vine-swing-r-4 2.5s ease-out 260ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-5 { animation: vine-swing-r-5 2.5s ease-out 320ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-6 { animation: vine-swing-r-6 2.5s ease-out 380ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-7 { animation: vine-swing-r-7 2.5s ease-out 440ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(7) .vine-seg-8 { animation: vine-swing-r-8 2.5s ease-out 500ms forwards; }
 
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-1 { animation: vine-swing-r-1 1.8s ease-out 100ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-2 { animation: vine-swing-r-2 1.8s ease-out 140ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-3 { animation: vine-swing-r-3 1.8s ease-out 180ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-4 { animation: vine-swing-r-4 1.8s ease-out 220ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-5 { animation: vine-swing-r-5 1.8s ease-out 260ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-6 { animation: vine-swing-r-6 1.8s ease-out 300ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-7 { animation: vine-swing-r-7 1.8s ease-out 340ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-8 { animation: vine-swing-r-8 1.8s ease-out 380ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-1 { animation: vine-swing-r-1 2.5s ease-out 160ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-2 { animation: vine-swing-r-2 2.5s ease-out 220ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-3 { animation: vine-swing-r-3 2.5s ease-out 280ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-4 { animation: vine-swing-r-4 2.5s ease-out 340ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-5 { animation: vine-swing-r-5 2.5s ease-out 400ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-6 { animation: vine-swing-r-6 2.5s ease-out 460ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-7 { animation: vine-swing-r-7 2.5s ease-out 520ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(6) .vine-seg-8 { animation: vine-swing-r-8 2.5s ease-out 580ms forwards; }
 
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-1 { animation: vine-swing-r-1 1.8s ease-out 150ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-2 { animation: vine-swing-r-2 1.8s ease-out 190ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-3 { animation: vine-swing-r-3 1.8s ease-out 230ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-4 { animation: vine-swing-r-4 1.8s ease-out 270ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-5 { animation: vine-swing-r-5 1.8s ease-out 310ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-6 { animation: vine-swing-r-6 1.8s ease-out 350ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-7 { animation: vine-swing-r-7 1.8s ease-out 390ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-8 { animation: vine-swing-r-8 1.8s ease-out 430ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-1 { animation: vine-swing-r-1 2.5s ease-out 240ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-2 { animation: vine-swing-r-2 2.5s ease-out 300ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-3 { animation: vine-swing-r-3 2.5s ease-out 360ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-4 { animation: vine-swing-r-4 2.5s ease-out 420ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-5 { animation: vine-swing-r-5 2.5s ease-out 480ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-6 { animation: vine-swing-r-6 2.5s ease-out 540ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-7 { animation: vine-swing-r-7 2.5s ease-out 600ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(5) .vine-seg-8 { animation: vine-swing-r-8 2.5s ease-out 660ms forwards; }
 
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-1 { animation: vine-swing-r-1 1.8s ease-out 200ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-2 { animation: vine-swing-r-2 1.8s ease-out 240ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-3 { animation: vine-swing-r-3 1.8s ease-out 280ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-4 { animation: vine-swing-r-4 1.8s ease-out 320ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-5 { animation: vine-swing-r-5 1.8s ease-out 360ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-6 { animation: vine-swing-r-6 1.8s ease-out 400ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-7 { animation: vine-swing-r-7 1.8s ease-out 440ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-8 { animation: vine-swing-r-8 1.8s ease-out 480ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-1 { animation: vine-swing-r-1 2.5s ease-out 320ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-2 { animation: vine-swing-r-2 2.5s ease-out 380ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-3 { animation: vine-swing-r-3 2.5s ease-out 440ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-4 { animation: vine-swing-r-4 2.5s ease-out 500ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-5 { animation: vine-swing-r-5 2.5s ease-out 560ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-6 { animation: vine-swing-r-6 2.5s ease-out 620ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-7 { animation: vine-swing-r-7 2.5s ease-out 680ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(4) .vine-seg-8 { animation: vine-swing-r-8 2.5s ease-out 740ms forwards; }
 
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-1 { animation: vine-swing-r-1 1.8s ease-out 250ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-2 { animation: vine-swing-r-2 1.8s ease-out 290ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-3 { animation: vine-swing-r-3 1.8s ease-out 330ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-4 { animation: vine-swing-r-4 1.8s ease-out 370ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-5 { animation: vine-swing-r-5 1.8s ease-out 410ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-6 { animation: vine-swing-r-6 1.8s ease-out 450ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-7 { animation: vine-swing-r-7 1.8s ease-out 490ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-8 { animation: vine-swing-r-8 1.8s ease-out 530ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-1 { animation: vine-swing-r-1 2.5s ease-out 400ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-2 { animation: vine-swing-r-2 2.5s ease-out 460ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-3 { animation: vine-swing-r-3 2.5s ease-out 520ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-4 { animation: vine-swing-r-4 2.5s ease-out 580ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-5 { animation: vine-swing-r-5 2.5s ease-out 640ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-6 { animation: vine-swing-r-6 2.5s ease-out 700ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-7 { animation: vine-swing-r-7 2.5s ease-out 760ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(3) .vine-seg-8 { animation: vine-swing-r-8 2.5s ease-out 820ms forwards; }
 
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-1 { animation: vine-swing-r-1 1.8s ease-out 300ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-2 { animation: vine-swing-r-2 1.8s ease-out 340ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-3 { animation: vine-swing-r-3 1.8s ease-out 380ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-4 { animation: vine-swing-r-4 1.8s ease-out 420ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-5 { animation: vine-swing-r-5 1.8s ease-out 460ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-6 { animation: vine-swing-r-6 1.8s ease-out 500ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-7 { animation: vine-swing-r-7 1.8s ease-out 540ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-8 { animation: vine-swing-r-8 1.8s ease-out 580ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-1 { animation: vine-swing-r-1 2.5s ease-out 480ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-2 { animation: vine-swing-r-2 2.5s ease-out 540ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-3 { animation: vine-swing-r-3 2.5s ease-out 600ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-4 { animation: vine-swing-r-4 2.5s ease-out 660ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-5 { animation: vine-swing-r-5 2.5s ease-out 720ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-6 { animation: vine-swing-r-6 2.5s ease-out 780ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-7 { animation: vine-swing-r-7 2.5s ease-out 840ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(2) .vine-seg-8 { animation: vine-swing-r-8 2.5s ease-out 900ms forwards; }
 
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-1 { animation: vine-swing-r-1 1.8s ease-out 350ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-2 { animation: vine-swing-r-2 1.8s ease-out 390ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-3 { animation: vine-swing-r-3 1.8s ease-out 430ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-4 { animation: vine-swing-r-4 1.8s ease-out 470ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-5 { animation: vine-swing-r-5 1.8s ease-out 510ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-6 { animation: vine-swing-r-6 1.8s ease-out 550ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-7 { animation: vine-swing-r-7 1.8s ease-out 590ms forwards; }
-      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-8 { animation: vine-swing-r-8 1.8s ease-out 630ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-1 { animation: vine-swing-r-1 2.5s ease-out 560ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-2 { animation: vine-swing-r-2 2.5s ease-out 620ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-3 { animation: vine-swing-r-3 2.5s ease-out 680ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-4 { animation: vine-swing-r-4 2.5s ease-out 740ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-5 { animation: vine-swing-r-5 2.5s ease-out 800ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-6 { animation: vine-swing-r-6 2.5s ease-out 860ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-7 { animation: vine-swing-r-7 2.5s ease-out 920ms forwards; }
+      .grove-parting .grove-vine-left .grove-vine-strip:nth-child(1) .vine-seg-8 { animation: vine-swing-r-8 2.5s ease-out 980ms forwards; }
 
       /* ═══ RIGHT VINES swing LEFT (negative rotation = outward) ═══ */
       /* Vine 1 (center-most) starts first */
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-1 { animation: vine-swing-l-1 1.8s ease-out 0ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-2 { animation: vine-swing-l-2 1.8s ease-out 40ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-3 { animation: vine-swing-l-3 1.8s ease-out 80ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-4 { animation: vine-swing-l-4 1.8s ease-out 120ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-5 { animation: vine-swing-l-5 1.8s ease-out 160ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-6 { animation: vine-swing-l-6 1.8s ease-out 200ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-7 { animation: vine-swing-l-7 1.8s ease-out 240ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-8 { animation: vine-swing-l-8 1.8s ease-out 280ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-1 { animation: vine-swing-l-1 2.5s ease-out 0ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-2 { animation: vine-swing-l-2 2.5s ease-out 60ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-3 { animation: vine-swing-l-3 2.5s ease-out 120ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-4 { animation: vine-swing-l-4 2.5s ease-out 180ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-5 { animation: vine-swing-l-5 2.5s ease-out 240ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-6 { animation: vine-swing-l-6 2.5s ease-out 300ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-7 { animation: vine-swing-l-7 2.5s ease-out 360ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(1) .vine-seg-8 { animation: vine-swing-l-8 2.5s ease-out 420ms forwards; }
 
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-1 { animation: vine-swing-l-1 1.8s ease-out 50ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-2 { animation: vine-swing-l-2 1.8s ease-out 90ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-3 { animation: vine-swing-l-3 1.8s ease-out 130ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-4 { animation: vine-swing-l-4 1.8s ease-out 170ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-5 { animation: vine-swing-l-5 1.8s ease-out 210ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-6 { animation: vine-swing-l-6 1.8s ease-out 250ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-7 { animation: vine-swing-l-7 1.8s ease-out 290ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-8 { animation: vine-swing-l-8 1.8s ease-out 330ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-1 { animation: vine-swing-l-1 2.5s ease-out 80ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-2 { animation: vine-swing-l-2 2.5s ease-out 140ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-3 { animation: vine-swing-l-3 2.5s ease-out 200ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-4 { animation: vine-swing-l-4 2.5s ease-out 260ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-5 { animation: vine-swing-l-5 2.5s ease-out 320ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-6 { animation: vine-swing-l-6 2.5s ease-out 380ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-7 { animation: vine-swing-l-7 2.5s ease-out 440ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(2) .vine-seg-8 { animation: vine-swing-l-8 2.5s ease-out 500ms forwards; }
 
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-1 { animation: vine-swing-l-1 1.8s ease-out 100ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-2 { animation: vine-swing-l-2 1.8s ease-out 140ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-3 { animation: vine-swing-l-3 1.8s ease-out 180ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-4 { animation: vine-swing-l-4 1.8s ease-out 220ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-5 { animation: vine-swing-l-5 1.8s ease-out 260ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-6 { animation: vine-swing-l-6 1.8s ease-out 300ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-7 { animation: vine-swing-l-7 1.8s ease-out 340ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-8 { animation: vine-swing-l-8 1.8s ease-out 380ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-1 { animation: vine-swing-l-1 2.5s ease-out 160ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-2 { animation: vine-swing-l-2 2.5s ease-out 220ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-3 { animation: vine-swing-l-3 2.5s ease-out 280ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-4 { animation: vine-swing-l-4 2.5s ease-out 340ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-5 { animation: vine-swing-l-5 2.5s ease-out 400ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-6 { animation: vine-swing-l-6 2.5s ease-out 460ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-7 { animation: vine-swing-l-7 2.5s ease-out 520ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(3) .vine-seg-8 { animation: vine-swing-l-8 2.5s ease-out 580ms forwards; }
 
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-1 { animation: vine-swing-l-1 1.8s ease-out 150ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-2 { animation: vine-swing-l-2 1.8s ease-out 190ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-3 { animation: vine-swing-l-3 1.8s ease-out 230ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-4 { animation: vine-swing-l-4 1.8s ease-out 270ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-5 { animation: vine-swing-l-5 1.8s ease-out 310ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-6 { animation: vine-swing-l-6 1.8s ease-out 350ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-7 { animation: vine-swing-l-7 1.8s ease-out 390ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-8 { animation: vine-swing-l-8 1.8s ease-out 430ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-1 { animation: vine-swing-l-1 2.5s ease-out 240ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-2 { animation: vine-swing-l-2 2.5s ease-out 300ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-3 { animation: vine-swing-l-3 2.5s ease-out 360ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-4 { animation: vine-swing-l-4 2.5s ease-out 420ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-5 { animation: vine-swing-l-5 2.5s ease-out 480ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-6 { animation: vine-swing-l-6 2.5s ease-out 540ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-7 { animation: vine-swing-l-7 2.5s ease-out 600ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(4) .vine-seg-8 { animation: vine-swing-l-8 2.5s ease-out 660ms forwards; }
 
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-1 { animation: vine-swing-l-1 1.8s ease-out 200ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-2 { animation: vine-swing-l-2 1.8s ease-out 240ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-3 { animation: vine-swing-l-3 1.8s ease-out 280ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-4 { animation: vine-swing-l-4 1.8s ease-out 320ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-5 { animation: vine-swing-l-5 1.8s ease-out 360ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-6 { animation: vine-swing-l-6 1.8s ease-out 400ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-7 { animation: vine-swing-l-7 1.8s ease-out 440ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-8 { animation: vine-swing-l-8 1.8s ease-out 480ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-1 { animation: vine-swing-l-1 2.5s ease-out 320ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-2 { animation: vine-swing-l-2 2.5s ease-out 380ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-3 { animation: vine-swing-l-3 2.5s ease-out 440ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-4 { animation: vine-swing-l-4 2.5s ease-out 500ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-5 { animation: vine-swing-l-5 2.5s ease-out 560ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-6 { animation: vine-swing-l-6 2.5s ease-out 620ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-7 { animation: vine-swing-l-7 2.5s ease-out 680ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(5) .vine-seg-8 { animation: vine-swing-l-8 2.5s ease-out 740ms forwards; }
 
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-1 { animation: vine-swing-l-1 1.8s ease-out 250ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-2 { animation: vine-swing-l-2 1.8s ease-out 290ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-3 { animation: vine-swing-l-3 1.8s ease-out 330ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-4 { animation: vine-swing-l-4 1.8s ease-out 370ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-5 { animation: vine-swing-l-5 1.8s ease-out 410ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-6 { animation: vine-swing-l-6 1.8s ease-out 450ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-7 { animation: vine-swing-l-7 1.8s ease-out 490ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-8 { animation: vine-swing-l-8 1.8s ease-out 530ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-1 { animation: vine-swing-l-1 2.5s ease-out 400ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-2 { animation: vine-swing-l-2 2.5s ease-out 460ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-3 { animation: vine-swing-l-3 2.5s ease-out 520ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-4 { animation: vine-swing-l-4 2.5s ease-out 580ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-5 { animation: vine-swing-l-5 2.5s ease-out 640ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-6 { animation: vine-swing-l-6 2.5s ease-out 700ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-7 { animation: vine-swing-l-7 2.5s ease-out 760ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(6) .vine-seg-8 { animation: vine-swing-l-8 2.5s ease-out 820ms forwards; }
 
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-1 { animation: vine-swing-l-1 1.8s ease-out 300ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-2 { animation: vine-swing-l-2 1.8s ease-out 340ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-3 { animation: vine-swing-l-3 1.8s ease-out 380ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-4 { animation: vine-swing-l-4 1.8s ease-out 420ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-5 { animation: vine-swing-l-5 1.8s ease-out 460ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-6 { animation: vine-swing-l-6 1.8s ease-out 500ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-7 { animation: vine-swing-l-7 1.8s ease-out 540ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-8 { animation: vine-swing-l-8 1.8s ease-out 580ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-1 { animation: vine-swing-l-1 2.5s ease-out 480ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-2 { animation: vine-swing-l-2 2.5s ease-out 540ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-3 { animation: vine-swing-l-3 2.5s ease-out 600ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-4 { animation: vine-swing-l-4 2.5s ease-out 660ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-5 { animation: vine-swing-l-5 2.5s ease-out 720ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-6 { animation: vine-swing-l-6 2.5s ease-out 780ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-7 { animation: vine-swing-l-7 2.5s ease-out 840ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(7) .vine-seg-8 { animation: vine-swing-l-8 2.5s ease-out 900ms forwards; }
 
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-1 { animation: vine-swing-l-1 1.8s ease-out 350ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-2 { animation: vine-swing-l-2 1.8s ease-out 390ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-3 { animation: vine-swing-l-3 1.8s ease-out 430ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-4 { animation: vine-swing-l-4 1.8s ease-out 470ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-5 { animation: vine-swing-l-5 1.8s ease-out 510ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-6 { animation: vine-swing-l-6 1.8s ease-out 550ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-7 { animation: vine-swing-l-7 1.8s ease-out 590ms forwards; }
-      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-8 { animation: vine-swing-l-8 1.8s ease-out 630ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-1 { animation: vine-swing-l-1 2.5s ease-out 560ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-2 { animation: vine-swing-l-2 2.5s ease-out 620ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-3 { animation: vine-swing-l-3 2.5s ease-out 680ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-4 { animation: vine-swing-l-4 2.5s ease-out 740ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-5 { animation: vine-swing-l-5 2.5s ease-out 800ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-6 { animation: vine-swing-l-6 2.5s ease-out 860ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-7 { animation: vine-swing-l-7 2.5s ease-out 920ms forwards; }
+      .grove-parting .grove-vine-right .grove-vine-strip:nth-child(8) .vine-seg-8 { animation: vine-swing-l-8 2.5s ease-out 980ms forwards; }
 
       .grove-parting .grove-entrance-logo {
         animation: grove-logo-exit 600ms ease-in 400ms forwards;

--- a/packages/landing/src/routes/+layout.svelte
+++ b/packages/landing/src/routes/+layout.svelte
@@ -64,8 +64,8 @@
 					// Show the animation and record timestamp
 					overlay.classList.add('grove-parting');
 					recordVinesShown();
-					// Remove after animation completes (reduced from 3500ms for faster cleanup)
-					setTimeout(() => overlay.remove(), 2500);
+					// Remove after animation completes
+					setTimeout(() => overlay.remove(), 3500);
 				} else {
 					// Within cooldown - skip animation and remove immediately
 					overlay.remove();


### PR DESCRIPTION
Reverts the animation speed changes from a5cffc6 that made the vine
parting animation too fast. Restores:
- Animation duration: 1.8s → 2.5s
- Segment delay: 40ms → 60ms
- Vine delay: 50ms → 80ms
- Overlay timeout: 2500ms → 3500ms

The performance improvements (pointer-events, will-change optimization)
are preserved - only the timing values are reverted.

https://claude.ai/code/session_01SGSfJuWk4qvxFnS5nJGDxo