### PR TITLE
docs(help): add "What is Fireside?" help center article

### DIFF
--- a/.github/knowledge-base-inventory.json
+++ b/.github/knowledge-base-inventory.json
@@ -1,10 +1,10 @@
 {
-  "lastUpdated": "2026-01-29",
+  "lastUpdated": "2026-01-30",
   "docs": {
-    "total": 284,
+    "total": 285,
     "breakdown": {
       "specs": 56,
-      "help": 79,
+      "help": 80,
       "legal": 6,
       "marketing": 19,
       "patterns": 9,

--- a/docs/help-center/articles/what-is-fireside.md
+++ b/docs/help-center/articles/what-is-fireside.md
@@ -1,0 +1,79 @@
+---
+title: What is Fireside?
+description: How Grove turns conversation into writing for those who freeze at the blank page
+category: help
+section: how-it-works
+lastUpdated: '2026-01-30'
+keywords:
+  - fireside
+  - wisp
+  - writing
+  - conversation
+  - drafting
+  - blank page
+  - ai
+  - assistant
+order: 42
+---
+
+# What is Fireside?
+
+Some people have no trouble talking. In group chats, over coffee, explaining something to a friend. The ideas flow. The voice is there. But sit them in front of a blank page and everything locks up. "What do I write? Where do I start?"
+
+Fireside is for those moments.
+
+## The short version
+
+Fireside is a conversational drafting mode inside Flow, Grove's editor. Instead of staring at an empty page, you have a conversation with Wisp. It asks what's on your mind. You answer naturally. After a few exchanges, Wisp organizes *your words* into a draft you can edit.
+
+The fire doesn't tell the story. It creates the space where stories emerge.
+
+## How it works
+
+Open a new post in Flow and choose "Start with a conversation." Wisp greets you with a question. Something open-ended, like "What's been living in your head lately?" or "What surprised you this week?"
+
+You respond. Type like you're texting a friend. Don't worry about structure or polish. Just say what you're thinking.
+
+Wisp asks follow-up questions. "What draws you to that?" or "Tell me more about that last part." The conversation continues as long as you want.
+
+When you feel ready, click "Ready to draft." Wisp takes everything you said and organizes it into a coherent post. Your words, your ideas, your voice. Wisp just arranged them.
+
+Review the draft. Edit it. Add to it. Delete parts. It's yours now. When it feels right, publish.
+
+## What Fireside isn't
+
+Fireside has clear boundaries.
+
+**Wisp organizes. It doesn't generate.** If you give brief answers, you get a brief draft. Wisp won't pad your thoughts into something longer. You get out what you put in.
+
+**Wisp listens. It doesn't contribute.** No new ideas appear that you didn't express. No opinions you didn't share. Wisp might smooth a transition or suggest you elaborate, but it never adds content.
+
+**Wisp asks questions. It doesn't write for you.** If you ask Wisp to "write me a post about X," it'll redirect you back to conversation. "I can't write for you, but I'd love to hear what you think about X. What draws you to it?"
+
+This is intentional. Grove believes your voice is sacred. AI should help you express yourself, not express itself on your behalf.
+
+## The transparency marker
+
+Every post created through Fireside includes a small attribution at the end:
+
+*~ written fireside with Wisp ~*
+
+This marker is permanent. It's enforced at the API level, not just in the editor. You can't remove it by editing the post.
+
+Why? Honesty matters. Readers deserve to know when AI helped shape a piece of writing. The marker acknowledges the process while making clear that the words are yours. Wisp organized your thoughts. It didn't replace them.
+
+## What this means for you
+
+**If you freeze at blank pages:** Fireside might help. Having a conversation is easier than writing from scratch. Your words are already there. Fireside just helps you find them.
+
+**If you're curious about the process:** The draft shows you what you said, reorganized. You can see exactly where each piece came from. Nothing mysterious, nothing hidden.
+
+**If transparency matters to you:** The marker stays. Anyone reading your post will know you started with a conversation. That's the deal.
+
+## Curious about the details?
+
+The complete specification covers the conversation flow, guardrails, draft generation, and technical implementation: [Wisp Specification — Fireside Mode](/knowledge/specs/wisp-spec#fireside-mode).
+
+---
+
+*A good listener, not a ghostwriter.*

--- a/packages/landing/src/routes/workshop/+page.svelte
+++ b/packages/landing/src/routes/workshop/+page.svelte
@@ -147,7 +147,7 @@
 					whatIsLink: '/knowledge/help/what-is-flow',
 					subComponents: [
 						{ name: 'Zen', icon: 'focus', description: 'Distraction-free mode' },
-						{ name: 'Fireside', icon: 'flamekindling', description: 'Conversational drafting' },
+						{ name: 'Fireside', icon: 'flamekindling', description: 'Conversational drafting', href: '/knowledge/help/what-is-fireside' },
 						{ name: 'Draft', icon: 'save', description: 'Auto-save to localStorage' },
 						{ name: 'Vines', icon: 'layoutlist', description: 'Margin notes', href: '/knowledge/help/what-are-vines' }
 					]
@@ -432,7 +432,7 @@
 					whatIsLink: '/knowledge/help/what-is-wisp',
 					subComponents: [
 						{ name: 'Solarpunk', icon: 'solarpanel', description: 'Solarpunk aligned', href: '/knowledge/help/what-is-solarpunk' },
-						{ name: 'Fireside', icon: 'flamekindling', description: 'Conversational drafting' },
+						{ name: 'Fireside', icon: 'flamekindling', description: 'Conversational drafting', href: '/knowledge/help/what-is-fireside' },
 						{ name: 'Privacy', icon: 'globelock', description: 'No data retention' },
 						{ name: 'ZDR', icon: 'shredder', description: 'Zero data retention', href: '/knowledge/help/what-is-zdr' }
 					]


### PR DESCRIPTION
Explains Fireside mode - Wisp's conversational drafting feature for writers
who freeze at the blank page. Covers the conversation flow, guardrails
(organizes not generates), and the permanent transparency marker.

Fixes #661

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>