### PR TITLE
fix(chrome): add explicit text-foreground-subtle utility for menu icon

### DIFF
--- a/packages/engine/src/app.css
+++ b/packages/engine/src/app.css
@@ -101,3 +101,15 @@
 		@apply bg-background text-foreground;
 	}
 }
+
+/* ─────────────────────────────────────────────────────────────────
+   UTILITY CLASSES
+   Explicit definitions to ensure availability in engine components
+   ───────────────────────────────────────────────────────────────── */
+
+@layer utilities {
+	/* Text color utilities using HSL CSS variables */
+	.text-foreground-subtle {
+		color: hsl(var(--foreground-subtle));
+	}
+}


### PR DESCRIPTION
The mobile menu hamburger icon was invisible on tenant sites because
the .text-foreground-subtle class wasn't being explicitly defined.
Landing had explicit utility classes in its app.css, but the engine
relied solely on Tailwind JIT generation which wasn't working reliably.

Added explicit utility class using the existing HSL CSS variable.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

https://claude.ai/code/session_01SAE6H8aQsRog4m1XUSpvLk