### PR TITLE
fix(ui): replace arrow emoji with Lucide ExternalLink icon

### DIFF
--- a/packages/engine/src/routes/admin/blog/edit/[slug]/+page.svelte
+++ b/packages/engine/src/routes/admin/blog/edit/[slug]/+page.svelte
@@ -7,6 +7,7 @@
   import Dialog from "$lib/ui/components/ui/Dialog.svelte";
   import { toast } from "$lib/ui/components/ui/toast";
   import { api } from "$lib/utils";
+  import { ExternalLink } from "lucide-svelte";
 
   let { data } = $props();
 
@@ -269,7 +270,7 @@
         Delete
       </Button>
       <Button variant="outline" href="/blog/{slug}">
-        View Live ↗
+        View Live <ExternalLink size={16} class="inline-block ml-1" />
       </Button>
       <Button onclick={handleSave} disabled={saving}>
         {saving ? "Saving..." : "Save Changes"}


### PR DESCRIPTION
Replaces the ↗ emoji in the "View Live" button with a proper
Lucide ExternalLink icon for better consistency and accessibility.

https://claude.ai/code/session_01MtGCgUjcwboR7WB5McGL18