### PR TITLE
fix(settings): prevent browser caching of user-modifiable settings

### DIFF
--- a/packages/engine/src/routes/api/settings/+server.ts
+++ b/packages/engine/src/routes/api/settings/+server.ts
@@ -49,7 +49,10 @@ export const GET: RequestHandler = async ({ platform, locals }) => {
 
     return json(settings, {
       headers: {
-        "Cache-Control": "public, max-age=300", // 5 minute cache
+        // Settings can be modified by user - don't let browser cache stale values
+        // This prevents the "color doesn't save" bug where browser serves cached
+        // response after user updates settings (#color-save-bug)
+        "Cache-Control": "private, no-cache",
       },
     });
   } catch (err) {


### PR DESCRIPTION
The /api/settings endpoint was returning Cache-Control: public, max-age=300
which caused browsers to cache the response for 5 minutes. When users
saved a new accent color and refreshed, the browser served stale cached
data instead of the freshly saved value from the database.

Changed to Cache-Control: private, no-cache to ensure browsers always
revalidate settings with the server after modifications.

https://claude.ai/code/session_01RHaxNGBbeWLyihRMQ53Xyo