### PR TITLE
fix(chrome): pass showTimeline/showGallery flags to mobile nav

### DIFF
--- a/packages/engine/src/routes/+layout.server.ts
+++ b/packages/engine/src/routes/+layout.server.ts
@@ -159,5 +159,8 @@ export const load: LayoutServerLoad = async ({ locals, platform }) => {
     navPageLimit,
     enabledCuriosCount,
     csrfToken: locals.csrfToken,
+    // Explicit curio enable flags for mobile nav (fixes #848 regression)
+    showTimeline: !!timelineResult?.enabled,
+    showGallery: !!galleryResult?.enabled,
   };
 };

--- a/packages/engine/src/routes/+layout.svelte
+++ b/packages/engine/src/routes/+layout.svelte
@@ -54,11 +54,12 @@
 	let isAdminPage = $derived(page.url.pathname.startsWith('/admin'));
 
 	// Build tenant navigation items from context
+	// showTimeline/showGallery flags come from +layout.server.ts (curio config queries)
 	const tenantNavItems = $derived(buildTenantNavItems({
 		siteName: siteName,
 		navPages: data.navPages,
-		showTimeline: data.tenant?.showTimeline,
-		showGallery: data.tenant?.showGallery,
+		showTimeline: data.showTimeline,
+		showGallery: data.showGallery,
 	}));
 
 	// Handle search - navigate to blog search


### PR DESCRIPTION
After migrating to shared chrome components, Timeline and Gallery tabs
were missing from mobile navigation. The buildTenantNavItems() utility
expected explicit boolean flags, but +layout.svelte was referencing
data.tenant?.showTimeline which didn't exist.

Fix: Add showTimeline/showGallery to the server return object using
the existing curio config query results, then reference data.showTimeline
and data.showGallery in the client layout.

https://claude.ai/code/session_01FUEDiAF1QXzJ7LcPDx6XbY