### PR TITLE
fix(admin): resolve focus trap in markdown editor and admin panel

### DIFF
--- a/packages/engine/src/lib/components/admin/FloatingToolbar.svelte
+++ b/packages/engine/src/lib/components/admin/FloatingToolbar.svelte
@@ -227,14 +227,14 @@
     isTextareaFocused = true;
   }
 
-  function handleTextareaBlur() {
-    // Small delay to allow click events on toolbar buttons to complete
-    setTimeout(() => {
-      if (document.activeElement !== textareaRef && !toolbarRef?.contains(document.activeElement)) {
-        isTextareaFocused = false;
-        isVisible = false;
-      }
-    }, 100);
+  /** @param {FocusEvent} e */
+  function handleTextareaBlur(e) {
+    // If focus moved to toolbar, keep it open
+    if (e.relatedTarget && toolbarRef?.contains(/** @type {Node} */ (e.relatedTarget))) {
+      return;
+    }
+    isTextareaFocused = false;
+    isVisible = false;
   }
 
   // Set up focus tracking on the textarea

--- a/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
+++ b/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
@@ -585,7 +585,10 @@
   $effect(() => {
     if (showFullPreview) {
       // Store the currently focused element to restore on close
-      previouslyFocusedBeforePreview = /** @type {HTMLElement} */ (document.activeElement);
+      const activeEl = document.activeElement;
+      if (activeEl instanceof HTMLElement) {
+        previouslyFocusedBeforePreview = activeEl;
+      }
       // Focus the modal for keyboard accessibility
       setTimeout(() => {
         fullPreviewModalRef?.focus();


### PR DESCRIPTION
The FloatingToolbar was adding global document event listeners (mousedown,
keydown, selectionchange) unconditionally on mount, which could interfere
with form interactions across the entire admin panel - including on pages
that don't use the markdown editor but share the admin layout.

Changes:
- FloatingToolbar now only adds global listeners when the textarea is focused
- Added focus/blur tracking to properly scope event listener lifecycle
- Added focus management to full-preview-modal (stores/restores focus)
- Cleanup ensures listeners are removed when textarea loses focus

This fixes the issue where users could tap form elements but state
wouldn't update until page refresh, particularly affecting:
- Markdown editor in Arbor flow editor
- Gallery curio configuration page
- Other admin panel forms

https://claude.ai/code/session_01JGTxSGqRKKnjKhufPD1XiT