### PR TITLE
docs(planning): add malleable software exploration research

### DIFF
--- a/docs/help-center/articles/what-is-reverie.md
+++ b/docs/help-center/articles/what-is-reverie.md
@@ -1,0 +1,80 @@
+---
+title: What is Reverie?
+description: Grove's composition layer that turns your dreams into decorations, powered by AI
+category: help
+section: how-it-works
+lastUpdated: '2026-02-02'
+keywords:
+  - reverie
+  - composition
+  - ai
+  - decorations
+  - customization
+  - malleable
+  - agent
+order: 14
+---
+
+# What is Reverie?
+
+You know that moment when you're gazing at sunlight through branches, half-awake, and a scene forms in your mind? Not a plan. A feeling. "Something glowing... peaceful... like fireflies at dusk."
+
+Reverie turns that feeling into your grove.
+
+Instead of dragging components around a canvas or writing code, you describe what you want. An AI agent listens, searches Grove's library of nature components, and composes a scene that captures what you meant. You describe the dream. Reverie makes it real.
+
+## Why Reverie exists
+
+Grove has beautiful components: trees, butterflies, fireflies, flowers, lanterns. Terrarium lets you arrange them by hand. But there's a gap.
+
+What if you don't know exactly which components you want? What if you just have a feeling, like "cozy" or "magical evening"? What if you'd rather describe the vibe than drag icons around?
+
+Reverie fills that gap. It's the layer between "I have a feeling" and "here's my decoration." You stay in the dreamy part. Reverie handles the details.
+
+## How it works
+
+You chat with an AI agent. Maybe through Grove's assistant, maybe through another tool. You describe what you're imagining:
+
+*"Add fireflies around my guestbook, something peaceful for evening"*
+
+The agent uses Reverie to:
+1. Understand your intent (glowing, peaceful, evening, around guestbook)
+2. Search Grove's component library for matches
+3. Compose a scene with the right elements
+4. Show you a preview
+
+If you like it, apply it. If you want changes, just say so. "More fireflies." "Less bright." "Add a moon."
+
+**Note:** Reverie is currently in planning. The features described here represent what we're building toward.
+
+## What this means for you
+
+**Describe, don't design.** You don't need to know component names or configuration options. Just describe the feeling you want.
+
+**The library does the work.** Grove has 60+ nature components, each tagged with qualities like "glowing," "animated," "seasonal." Reverie knows what's available and what works together.
+
+**It's still your creation.** The agent proposes. You approve or adjust. The final scene is uniquely yours, just arrived at through conversation rather than configuration.
+
+**Optional depth.** Behind every Reverie composition is a readable format called the Vision DSL. If you're curious, you can see exactly how your scene is built. Edit it directly if you want. The door to deeper customization stays open.
+
+## For the technically curious
+
+Reverie works through three parts:
+
+**The Manifest** holds every Grove component with semantic tags. Not just "butterfly" but "flying, animated, colorful, small, spring." When you say "something that glows," the manifest knows fireflies, lanterns, and stars all match.
+
+**The Vision DSL** describes compositions in a format simpler than code. It specifies which components, how many, where they go, and how they're configured. Agents generate it; humans can read and edit it.
+
+**The Agent Interface** translates between natural language and technical composition. Your dream goes in; a structured vision comes out.
+
+## Related
+
+- [What is Terrarium?](/knowledge/help/what-is-terrarium) — The canvas where you can hand-arrange components
+- [What is Foliage?](/knowledge/help/what-is-foliage) — Where themes and decorations get applied
+- [What are Curios?](/knowledge/help/what-are-curios) — Interactive elements for your site
+- [Reverie Specification](/knowledge/specs/reverie-spec)
+- [Grove Workshop → Reverie](/workshop#tool-reverie)
+
+---
+
+*A reverie is that state between waking and dreaming. Something forms in your mind's eye. Not quite real yet. But close. That's what you're creating.*

--- a/docs/philosophy/grove-naming.md
+++ b/docs/philosophy/grove-naming.md
@@ -135,6 +135,19 @@ Curios is your personal cabinet of wonders. Guestbooks, shrines, hit counters, c
 
 *What curiosities will they find?*
 
+### Reverie
+**Composition Layer** · `reverie.grove.place`
+
+A reverie is that state between waking and dreaming, when you're gazing at sunlight through branches, lost in thought, and something forms in your mind's eye. Not a plan. A vision.
+
+Reverie is how you compose your grove. You don't design; you *see*. "Fireflies around my guestbook" isn't a specification—it's a reverie. The system takes your half-formed dream and gives it shape. The manifest knows what exists. The DSL knows how things arrange. But you just... drift into what you want.
+
+Behind every "make it cozy" or "add something that glows," there's a translation layer: your intent becomes a query, the query finds components in the manifest, and the components arrange into a composition. You describe the feeling. Reverie finds the pieces. The result appears in Terrarium or Foliage, ready to become part of your space.
+
+You might never interact with Reverie directly. Like the moment between waking and sleeping, it happens in the background—half-conscious, half-automatic. All you see is what emerges: a scene that captures what you meant.
+
+*Half-dream, half-real. Yours.*
+
 ### Grafts
 **Feature Customization** · *Operator-configured*
 
@@ -518,6 +531,7 @@ Shade is Grove's layered defense against AI crawlers, scrapers, and automated da
 | **Terrarium** | Platform | Creative canvas | grove.place/terrarium |
 | **Weave** | Platform | Visual composition | *(part of Terrarium)* |
 | **Curios** | Platform | Cabinet of wonders | curios.grove.place |
+| **Reverie** | Platform | AI composition layer | reverie.grove.place |
 | **Grafts** | Platform | Feature customization | *(operator-configured)* |
 | **Burrow** | Platform | Cross-property access | *(integrated into Arbor)* |
 | **Gossamer** | Tools | ASCII visual effects | npm: gossamer |
@@ -575,6 +589,7 @@ For development, debugging, and internal documentation, the `Grove[Thing]` namin
 | Terrarium | GroveTerrarium |
 | Weave | GroveWeave |
 | Curios | GroveCurios |
+| Reverie | GroveReverie |
 | Grafts | GroveGrafts |
 | Burrow | GroveBurrow |
 | Greenhouse mode | Dave mode[^1] |

--- a/docs/plans/planning/reverie/overview.md
+++ b/docs/plans/planning/reverie/overview.md
@@ -1,12 +1,12 @@
-# Bower: Malleable Software for the Grove
+# Reverie: Malleable Software for the Grove
 
-> *Found, selected, arranged.*
+> *Half-dream, half-real. Yours.*
 
 ---
 
 ## Inspiration
 
-This exploration is inspired by [Ink & Switch's essay on Malleable Software](https://www.inkandswitch.com/essay/malleable-software/)—a vision for computing where "anyone can adapt their tools to their needs with minimal friction."
+This exploration is inspired by [Ink & Switch's essay on Malleable Software](https://www.inkandswitch.com/essay/malleable-software/), a vision for computing where "anyone can adapt their tools to their needs with minimal friction."
 
 The essay identifies a fundamental problem: modern software treats users as passive consumers of locked-down applications. When computerized systems replaced physical tools, we gained power but lost agency. The development team becomes a bottleneck; the long tail of niche requirements goes unserved.
 
@@ -18,7 +18,7 @@ The underlying system must be designed for malleability.
 
 ## Why Grove Is Positioned for This
 
-Ink & Switch says further research is needed. But they're thinking about *general* software—any application, any domain. That's hard.
+Ink & Switch says further research is needed. But they're thinking about *general* software. That's hard.
 
 Grove is different. We have:
 
@@ -55,13 +55,15 @@ The gap is between:
 
 There's a cliff. No gentle slope.
 
-**Bower is the bridge.**
+**Reverie is the bridge.**
 
 ---
 
-## What Is Bower?
+## What Is Reverie?
 
-Bower is the composition layer that makes Grove malleable. It has three parts:
+A reverie is that state between waking and dreaming, when you're gazing at sunlight through branches, lost in thought, and something forms in your mind's eye. Not a plan. A vision.
+
+Reverie is the composition layer that makes Grove malleable. It has three parts:
 
 ### 1. The Manifest
 A machine-readable catalog of all components with semantic metadata:
@@ -71,11 +73,11 @@ A machine-readable catalog of all components with semantic metadata:
 - Composition hints (what it pairs well with, what to avoid)
 - Constraints (tier requirements, performance cost)
 
-### 2. The DSL
+### 2. The Vision DSL
 A composition language simpler than Svelte but richer than drag-and-drop:
 ```yaml
 name: Firefly Garden
-description: "Glowing fireflies dancing around flowers"
+mood: "glowing, peaceful, evening"
 elements:
   - component: firefly
     count: 5-8
@@ -90,14 +92,63 @@ elements:
       color: vary(palette.flowers.*)
 ```
 
-Humans can read and edit this. Agents can generate it.
+Humans can read and edit this. Agents can generate it. It reads like a dream taking shape.
 
 ### 3. The Agent Interface
-How AI agents interact with Bower:
-- **Query**: "Find components that fly and glow"
-- **Compose**: "Arrange fireflies around a guestbook"
-- **Constrain**: "Must work in sidebar, respect Oak tier limits"
-- **Preview**: Generate a visual preview before committing
+How AI agents interact with Reverie:
+- **Dream**: "I want fireflies around my guestbook"
+- **Discover**: Find components matching fuzzy criteria
+- **Compose**: Arrange elements into a vision
+- **Form**: Generate the final output for Terrarium or Foliage
+
+---
+
+## The Reverie Metaphor
+
+You don't *design* your grove. You *see* it.
+
+"Fireflies around my guestbook" isn't a specification. It's a reverie. The system takes your half-formed dream and gives it shape:
+
+1. Your **dream** enters ("something that glows, peaceful, evening vibes")
+2. The **manifest** reveals what could be (fireflies, lanterns, moonlight, stars)
+3. The **vision** takes shape (elements arrange themselves)
+4. The **form** emerges (a composition, ready for Terrarium)
+
+Like the moment between waking and sleeping, it happens in the background. All you see is what emerges: a scene that captures what you meant.
+
+---
+
+## Integration with Existing Systems
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         DREAM                               │
+│              "Add fireflies around my guestbook"            │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                        REVERIE                              │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
+│  │  Manifest   │  │   Vision    │  │  Agent Interface    │  │
+│  │  (catalog)  │→ │   (DSL)     │→ │  (dream→form)       │  │
+│  └─────────────┘  └─────────────┘  └─────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                          FORM                               │
+│  ┌───────────────┐  ┌───────────────┐  ┌────────────────┐   │
+│  │   Terrarium   │  │    Foliage    │  │     Curios     │   │
+│  │   (scenes)    │  │   (themes)    │  │  (templates)   │   │
+│  └───────────────┘  └───────────────┘  └────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Reverie doesn't replace anything.** It's a layer that makes existing systems more accessible:
+- Terrarium consumes Reverie visions as importable scenes
+- Foliage consumes Reverie visions as decoration presets
+- Curios could consume Reverie visions as configurable templates
 
 ---
 
@@ -109,11 +160,11 @@ How AI agents interact with Bower:
 |-------|------------|----------------|
 | 1 | Pick a theme (Foliage) | None |
 | 2 | Drag-drop in Terrarium | Minimal |
-| **3** | **Describe intent → Agent composes via Bower** | **Natural language** |
-| **3.5** | **Edit Bower DSL directly** | **Reading YAML** |
+| **3** | **Describe a dream → Agent composes via Reverie** | **Natural language** |
+| **3.5** | **Edit the Vision DSL directly** | **Reading YAML** |
 | 4 | Write custom Svelte | Developer skills |
 
-Bower creates **Level 3 and 3.5**—the missing middle ground.
+Reverie creates **Level 3 and 3.5**, the missing middle ground.
 
 ### Pattern 2: Tools, Not Apps
 
@@ -122,66 +173,14 @@ Grove components are already tools, not monolithic apps:
 - They use CSS variables for theming
 - They have typed interfaces
 
-Bower makes them *discoverable* and *composable* without code.
+Reverie makes them *discoverable* and *composable* without code.
 
 ### Pattern 3: Communal Creation
 
-**Phase 1 (Personal):** Wanderers create compositions for their own sites.
-**Phase 2 (Templates):** Wanderers publish compositions as templates others can use.
+**Phase 1 (Personal):** Wanderers create visions for their own sites.
+**Phase 2 (Templates):** Wanderers publish visions as templates others can use.
 
-Not full collaboration—that's overkill. But sharing what you've created? That's the Grove way.
-
----
-
-## The Bowerbird Metaphor
-
-A bowerbird creates an architectural display from found objects:
-1. **DISCOVERS** objects in the environment
-2. **SELECTS** based on criteria (color, shininess)
-3. **ARRANGES** them into a coherent structure
-4. **PRESENTS** the result
-
-Bower does the same:
-1. Manifest enables **discovery**
-2. Semantic tags enable **selection**
-3. DSL enables **arrangement**
-4. Output is a **composition** (scene, decoration, curio template)
-
-*The bird's selection process is invisible. What you see is the bower itself—the arranged beauty.*
-
----
-
-## Integration with Existing Systems
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                        USER INTENT                          │
-│              "Add fireflies around my guestbook"            │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                          BOWER                              │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
-│  │  Manifest   │  │    DSL      │  │  Agent Interface    │  │
-│  │  (catalog)  │→ │ (compose)   │→ │  (query/generate)   │  │
-│  └─────────────┘  └─────────────┘  └─────────────────────┘  │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                         OUTPUT                              │
-│  ┌───────────────┐  ┌───────────────┐  ┌────────────────┐   │
-│  │   Terrarium   │  │    Foliage    │  │     Curios     │   │
-│  │   (scenes)    │  │   (themes)    │  │  (templates)   │   │
-│  └───────────────┘  └───────────────┘  └────────────────┘   │
-└─────────────────────────────────────────────────────────────┘
-```
-
-**Bower doesn't replace anything.** It's a layer that makes existing systems more accessible:
-- Terrarium consumes Bower compositions as importable scenes
-- Foliage consumes Bower compositions as decoration presets
-- Curios could consume Bower compositions as configurable curio templates
+Not full collaboration. But sharing what you've dreamed? That's the Grove way.
 
 ---
 
@@ -192,42 +191,40 @@ Composition power should scale with tier:
 | Tier | What They Can Do |
 |------|------------------|
 | **Seedling** | Use pre-made templates, basic customization |
-| **Sapling** | Full agent composition, save personal templates |
+| **Sapling** | Full agent composition, save personal visions |
 | **Oak** | Share templates publicly, advanced composition features |
 | **Evergreen** | Everything, priority agent access |
 
-Complexity budgets (like Terrarium's 200 points) should apply to Bower compositions too.
+Complexity budgets (like Terrarium's 200 points) should apply to Reverie visions too.
 
 ---
 
 ## Open Questions
 
 ### Technical
-1. **Manifest generation**: Auto-generate from TypeScript types? Or hand-curated? Probably hybrid—auto-generate props, hand-curate semantic tags.
+1. **Manifest generation**: Auto-generate from TypeScript types? Hand-curated? Probably hybrid.
 
-2. **DSL format**: YAML? JSON? Something custom? YAML is human-readable and well-understood.
+2. **DSL format**: YAML? JSON? YAML is human-readable and dreamlike.
 
 3. **Preview rendering**: How do we show a preview before committing? Probably a headless Terrarium render.
 
-4. **Validation**: How do we ensure compositions are valid, accessible, performant? Lint rules? Runtime checks?
+4. **Validation**: How do we ensure visions are valid, accessible, performant?
 
-5. **Storage**: Where do compositions live? User's site? Central catalog? Probably both—personal storage + shareable catalog.
+5. **Storage**: Where do visions live? Personal storage + shareable catalog.
 
 ### Product
-1. **Entry point**: Where does the user access this? Chat with Wisp? A "Compose" button in Terrarium? Mycelium integration?
+1. **Entry point**: Where does the user access this? Chat with Wisp? Mycelium integration? Both?
 
-2. **Failure modes**: What happens when the agent can't find matching components? Graceful fallbacks? Suggestions?
+2. **Failure modes**: What happens when the agent can't find matching components? Graceful suggestions?
 
-3. **Template curation**: If templates can be shared, who curates? Quality control?
-
-4. **Naming templates**: Do users name their compositions? Grove-style names?
+3. **Template curation**: If visions can be shared, who curates? Quality control?
 
 ### Philosophical
-1. **How much magic?** Should the user see the Bower DSL at all, or is it purely internal?
+1. **How much magic?** Should the user see the Vision DSL at all, or is it purely internal?
 
-2. **Ownership**: When you create a composition, is it "yours"? What does sharing mean?
+2. **Ownership**: When you create a vision, is it "yours"? What does sharing mean?
 
-3. **Evolution**: As we add components, how do compositions stay compatible?
+3. **Evolution**: As we add components, how do visions stay compatible?
 
 ---
 
@@ -235,7 +232,7 @@ Complexity budgets (like Terrarium's 200 points) should apply to Bower compositi
 
 ### Phase 0: Research & Design (Now)
 - Define manifest schema
-- Define DSL schema
+- Define Vision DSL schema
 - Prototype agent interface
 - Identify integration points
 
@@ -244,10 +241,10 @@ Complexity budgets (like Terrarium's 200 points) should apply to Bower compositi
 - Add semantic tags to key components
 - Create manifest validation tooling
 
-### Phase 2: DSL
+### Phase 2: Vision DSL
 - Define composition format
 - Build parser/validator
-- Create manual compositions for testing
+- Create manual visions for testing
 
 ### Phase 3: Agent Interface
 - Integrate with Mycelium (MCP)
@@ -268,13 +265,13 @@ Complexity budgets (like Terrarium's 200 points) should apply to Bower compositi
 
 ## Success Criteria
 
-**We'll know Bower works when:**
+**We'll know Reverie works when:**
 
 1. A user can say "make my site feel cozy with glowing things" and get a composed scene without touching code
 2. The agent can discover components matching fuzzy criteria
 3. The output is valid, accessible, and performs well
-4. A technically-curious user can read and tweak the DSL
-5. Templates can be shared and reused
+4. A technically-curious user can read and tweak the Vision DSL
+5. Visions can be shared and reused
 
 ---
 
@@ -288,4 +285,6 @@ Complexity budgets (like Terrarium's 200 points) should apply to Bower compositi
 
 ---
 
-*This is an exploration, not a commitment. We're asking: could Grove become malleable? What would that take? Bower is the hypothesis.*
+*This is an exploration, not a commitment. We're asking: could Grove become malleable? What would that take? Reverie is the hypothesis.*
+
+*Half-dream, half-real. Yours.*

--- a/docs/scratch/malleable-bridge-naming-journey.md
+++ b/docs/scratch/malleable-bridge-naming-journey.md
@@ -353,12 +353,118 @@ Possible verbs:
 
 ---
 
+## Round 2 Decision (Rejected)
+
+**Name:** Bower — felt too much like old Bower.js package manager. Moving on.
+
+---
+
+## Round 3: The Morning Walk
+
+*Instruction from the Wayfinder: Focus on the PROCESS and the RESULT. The FEELING. Bring in the serenity of dew on a fresh morning after light rain. Sunlight streaming through branches.*
+
+Walking deeper into the forest. Morning after rain. Dew on leaves. Light streaming through branches. You're not commanding anything. You're feeling what wants to exist, and it... appears. Like mist clearing to reveal what was always there.
+
+---
+
+## Final Candidates
+
+### Dewfall
+The moment dew forms—not rain falling, but moisture appearing silently overnight. By morning, every leaf glistens. You didn't make it happen. It just appeared.
+
+*Appearing without effort. Glistening by morning.*
+
+### Reverie
+A reverie is that state between waking and dreaming—when you're gazing at sunlight through branches, lost in thought, and something forms in your mind's eye. Not a plan. A vision.
+
+*Half-dream, half-real. Yours.*
+
+### Dapple
+Dappled light through leaves—not uniform brightness, but a living pattern of light and shadow. Composition without a composer.
+
+*Light through leaves. Pattern without plan.*
+
+### Idyll
+A scene of rural peace. A poem about shepherds at rest. A moment outside of time. Serene.
+
+*A scene worth staying in.*
+
+### Gleam
+Light catching something—dew on a leaf, a beetle's wing. Brief, beautiful, surprising.
+
+*Light catching. Worth a closer look.*
+
+---
+
+## The Choice: Reverie
+
+Reverie captures everything:
+
+1. **The process** — You drift into a vision, not engineer a spec
+2. **The feeling** — Dreamy, serene, contemplative
+3. **The result** — A half-dream made real
+4. **The mystery** — You don't know exactly how it happened, but there it is
+5. **The warmth** — Like gazing at morning light through branches
+
+**Testing Reverie:**
+
+| Context | Test |
+|---------|------|
+| As a state | "I had a reverie about fireflies" ✓ |
+| As a system | "Reverie found matching components" ✓ |
+| As output | "A reverie of butterflies and flowers" ✓ |
+| Domain | "reverie.grove.place" ✓ |
+| Agent use | "The agent uses Reverie to compose" ✓ |
+| Human feel | Warm, dreamy, magical ✓ |
+
+**The Tagline Test:**
+
+> "Reverie is where your vision takes shape."
+> "Reverie turns feeling into form."
+> "You describe the dream. Reverie makes it real."
+
+---
+
 ## Decision
 
-**Name:** Bower
-**Internal Name:** GroveBower
-**Domain:** bower.grove.place
-**Package:** @autumnsgrove/bower
-**Icon:** Suggestion: `Gem` or `Sparkles` (the collected treasures)
+**Name:** Reverie
+**Internal Name:** GroveReverie
+**Domain:** reverie.grove.place
+**Package:** @autumnsgrove/reverie
+**Icon:** `sparkles` — the magical, ethereal quality of dreams made real
 
-*Found, selected, arranged.*
+*Half-dream, half-real. Yours.*
+
+---
+
+## The Entry (for grove-naming.md)
+
+### Reverie
+**Composition Layer** · `reverie.grove.place`
+
+A reverie is that state between waking and dreaming—when you're gazing at sunlight through branches, lost in thought, and something forms in your mind's eye. Not a plan. A vision.
+
+Reverie is how you compose your grove. You don't design; you *see*. "Fireflies around my guestbook" isn't a specification—it's a reverie. The system takes your half-formed dream and gives it shape. The manifest knows what exists. The DSL knows how things arrange. But you just... drift into what you want.
+
+Behind every "make it cozy" or "add something that glows," there's a translation layer: your intent becomes a query, the query finds components in the manifest, and the components arrange into a composition. You describe the feeling. Reverie finds the pieces. The result appears in Terrarium or Foliage, ready to become part of your space.
+
+You might never interact with Reverie directly. Like the moment between waking and sleeping, it happens in the background—half-conscious, half-automatic. All you see is what emerges: a scene that captures what you meant.
+
+*Half-dream, half-real. Yours.*
+
+---
+
+## Reverie Lexicon
+
+| Term | Meaning |
+|------|---------|
+| **Manifest** | The catalog of all components with semantic metadata |
+| **Vision** | A composition described in the DSL |
+| **Dream** | The user's intent before it takes shape |
+| **Form** | The final output (scene, decoration, curio template) |
+
+Possible expressions:
+- "A reverie of fireflies" — a composed scene
+- "Enter a reverie" — begin composing
+- "The reverie manifest" — the component catalog
+- "Drift into your design" — the process of composing

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -73,6 +73,7 @@ Grove specifications define the architecture, interfaces, and implementation det
 | **[Terrarium](terrarium-spec.md)** | Creative canvas for scene composition | **New** | Foliage, Engine |
 | **[Weave](weave-spec.md)** | Visual composition studio (node-graph) | **New** | Terrarium |
 | **[Curios](curios-spec.md)** | Cabinet of wonders & personal touches | **New** | Engine, Foliage |
+| **[Reverie](reverie-spec.md)** | AI-powered composition layer | **New** | Terrarium, Foliage, Mycelium |
 
 ### Tools & Services
 

--- a/docs/specs/reverie-spec.md
+++ b/docs/specs/reverie-spec.md
@@ -1,0 +1,570 @@
+---
+title: "Reverie — Composition Layer"
+description: "AI-powered component composition that turns intent into form, making Grove malleable software."
+category: specs
+specCategory: "customization"
+icon: sparkles
+lastUpdated: "2026-02-02"
+aliases: []
+date created: Sunday, February 2nd 2026
+date modified: Sunday, February 2nd 2026
+tags:
+  - composition
+  - ai
+  - malleable-software
+  - svelte
+type: tech-spec
+---
+
+# Reverie — Composition Layer
+
+```
+                    ☀️
+                 ·  · ·  ·
+              ·    ╱│╲    ·
+           ·    ╱  │  ╲    ·
+        ·    ╱    │    ╲    ·
+           🌲    🌲    🌲
+          ╱  ╲  ╱  ╲  ╱  ╲
+         ╱    ╲╱    ╲╱    ╲
+        ·  ·  ·  ✨  ·  ·  ·
+           ·    ·    ·
+              ·  ·
+
+    morning light through branches
+    dew on leaves
+    a vision taking shape
+
+        Half-dream, half-real.
+```
+
+> *Half-dream, half-real. Yours.*
+
+Reverie is the composition layer that makes Grove malleable. You describe a feeling. Reverie finds the components. The vision takes form.
+
+**Public Name:** Reverie
+**Internal Name:** GroveReverie
+**Domain:** `reverie.grove.place`
+**Package:** `@autumnsgrove/reverie`
+**Status:** Planning (Research Phase)
+
+A reverie is that state between waking and dreaming, when you're gazing at sunlight through branches and something forms in your mind's eye. Not a plan. A vision. Reverie takes your half-formed dreams and gives them shape.
+
+---
+
+## Overview
+
+### The Problem
+
+Grove has 60+ nature components, a composition canvas (Terrarium), and interactive curios. But there's a gap:
+
+| Level | What It Is | Skill Required |
+|-------|------------|----------------|
+| 1 | Pick a theme (Foliage) | None |
+| 2 | Drag-drop in Terrarium | Minimal |
+| 3 | ??? | ??? |
+| 4 | Write custom Svelte | Developer skills |
+
+The jump from Level 2 to Level 4 is a cliff. Most Wanderers will never cross it.
+
+### The Solution
+
+Reverie creates **Level 3**: describe what you want in natural language, and an AI agent composes it from existing components.
+
+```
+"Add fireflies around my guestbook, something peaceful for evening"
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                        REVERIE                              │
+│                                                             │
+│  1. Parse intent: glowing, peaceful, evening, guestbook     │
+│  2. Query manifest: firefly, lantern, moonlight, star       │
+│  3. Compose vision: 5-8 fireflies, scattered, foreground    │
+│  4. Generate form: Terrarium-compatible scene               │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+              [Scene ready for Terrarium import]
+```
+
+---
+
+## Design Philosophy
+
+### Dreams, Not Specifications
+
+Wanderers don't think in component names and prop values. They think in feelings:
+- "Something cozy"
+- "Glowing but not too bright"
+- "Like a forest at dusk"
+
+Reverie translates feelings into technical composition.
+
+### Invisible by Default
+
+Most Wanderers will never see Reverie directly. They'll chat with an agent, describe what they want, and see results in Terrarium. The composition layer disappears into the background.
+
+### Gentle Slope Available
+
+For curious Wanderers, the Vision DSL is human-readable. They can see what the agent generated, tweak it, learn from it. The door to Level 3.5 stays open.
+
+### Bounded Creativity
+
+Reverie only composes from Grove's curated component library. You can't create something garish because the palette is curated. Creative freedom with guardrails.
+
+---
+
+## Architecture
+
+### Three Parts
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                           REVERIE                                   │
+│                                                                     │
+│  ┌───────────────────┐  ┌───────────────────┐  ┌─────────────────┐  │
+│  │     MANIFEST      │  │    VISION DSL     │  │ AGENT INTERFACE │  │
+│  │                   │  │                   │  │                 │  │
+│  │ Component catalog │  │ Composition       │  │ Dream → Form    │  │
+│  │ with semantic     │→ │ language simpler  │→ │ translation     │  │
+│  │ metadata & tags   │  │ than Svelte       │  │ layer           │  │
+│  │                   │  │                   │  │                 │  │
+│  └───────────────────┘  └───────────────────┘  └─────────────────┘  │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 1. The Manifest
+
+A machine-readable catalog of all composable components:
+
+```yaml
+# Example manifest entry
+butterfly:
+  displayName: Butterfly
+  category: creatures
+  description: "A delicate creature with flapping wings"
+
+  tags:
+    - flying
+    - animated
+    - colorful
+    - small
+    - spring
+    - summer
+
+  props:
+    wingColor:
+      type: color
+      default: palette.flowers.wildflower.purple
+      description: "Main wing color"
+    accentColor:
+      type: color
+      default: palette.flowers.wildflower.buttercup
+    animate:
+      type: boolean
+      default: true
+
+  composesWellWith:
+    - wildflower
+    - garden
+    - meadow
+    - spring-scene
+
+  avoidWith:
+    - underwater
+    - winter
+    - night-only
+
+  complexity: 5
+  tier: seedling
+```
+
+**Manifest Generation:**
+- Auto-generate base from TypeScript prop interfaces
+- Hand-curate semantic tags, composition hints
+- Validate against component inventory
+
+### 2. The Vision DSL
+
+A YAML-based composition language:
+
+```yaml
+# A "Firefly Garden" vision
+name: Firefly Garden
+description: "Peaceful evening scene with glowing fireflies"
+mood:
+  - glowing
+  - peaceful
+  - evening
+
+elements:
+  - component: firefly
+    count: 5-8
+    placement: scattered
+    layer: foreground
+    props:
+      animate: true
+
+  - component: wildflower
+    count: 3-5
+    placement: ground-level
+    props:
+      color: vary(palette.flowers.*)
+
+  - component: moon
+    count: 1
+    placement: sky-right
+    props:
+      phase: crescent
+
+constraints:
+  maxComplexity: 150
+  respectsReducedMotion: true
+
+exports:
+  - terrarium-scene
+  - foliage-decoration
+```
+
+**DSL Features:**
+- `count: 5-8` — Random within range
+- `placement: scattered` — Automatic positioning algorithm
+- `vary(palette.*)` — Random selection from palette
+- `layer: foreground` — Z-index control
+- `constraints` — Performance and accessibility budgets
+
+### 3. The Agent Interface
+
+How AI agents interact with Reverie:
+
+```typescript
+interface ReverieAgent {
+  // Parse natural language into structured intent
+  dream(input: string): Promise<Intent>;
+
+  // Query manifest for matching components
+  discover(intent: Intent): Promise<Component[]>;
+
+  // Compose components into a vision
+  compose(components: Component[], intent: Intent): Promise<Vision>;
+
+  // Generate final form for target system
+  form(vision: Vision, target: 'terrarium' | 'foliage' | 'curio'): Promise<Output>;
+}
+
+interface Intent {
+  mood: string[];           // "cozy", "glowing", "evening"
+  elements: string[];       // "fireflies", "guestbook"
+  constraints: Constraint[];
+  context: Context;         // Where this will be used
+}
+```
+
+---
+
+## Integration Points
+
+### With Terrarium
+
+Reverie visions export as Terrarium-compatible scenes:
+
+```
+Reverie Vision → TerrariumScene → Import into Terrarium
+```
+
+Wanderers can:
+1. Generate a vision via agent
+2. Import into Terrarium
+3. Fine-tune with drag-drop
+4. Export as decoration
+
+### With Foliage
+
+Reverie visions can become theme decorations:
+
+```
+Reverie Vision → FoliageDecoration → Apply to blog
+```
+
+### With Curios
+
+Reverie could compose curio templates:
+
+```
+Reverie Vision → CurioTemplate → Customized shrine/guestbook styling
+```
+
+### With Mycelium (MCP)
+
+Reverie exposes tools through Mycelium for Claude Code:
+
+```typescript
+// MCP tool definitions
+tools: [
+  {
+    name: "reverie_dream",
+    description: "Parse natural language into composition intent",
+    input: { description: string }
+  },
+  {
+    name: "reverie_discover",
+    description: "Find components matching intent",
+    input: { intent: Intent }
+  },
+  {
+    name: "reverie_compose",
+    description: "Compose components into a vision",
+    input: { components: Component[], intent: Intent }
+  },
+  {
+    name: "reverie_form",
+    description: "Generate output for target system",
+    input: { vision: Vision, target: string }
+  }
+]
+```
+
+---
+
+## Tier Access
+
+| Tier | Capabilities |
+|------|-------------|
+| **Seedling** | Use pre-made vision templates |
+| **Sapling** | Full agent composition, save personal visions |
+| **Oak** | Share visions publicly, access advanced components |
+| **Evergreen** | Everything, priority agent access, custom tags |
+
+### Complexity Budgets
+
+Like Terrarium's 200-point budget, Reverie visions have limits:
+
+| Tier | Max Complexity |
+|------|---------------|
+| Seedling | 100 |
+| Sapling | 200 |
+| Oak | 300 |
+| Evergreen | 500 |
+
+---
+
+## Validation & Safety
+
+### Composition Validation
+
+Every vision is validated before forming:
+
+```typescript
+interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+
+  // Performance
+  estimatedComplexity: number;
+  estimatedLoadTime: number;
+
+  // Accessibility
+  respectsReducedMotion: boolean;
+  hasAltText: boolean;
+  contrastOk: boolean;
+}
+```
+
+### Content Safety
+
+Reverie inherits Grove's content policies:
+- No components that could be combined harmfully
+- Respect tier restrictions
+- Rate limiting on generation
+
+---
+
+## User Experience Flows
+
+### Flow 1: Chat-Based Composition
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  Wanderer chats with agent                                     │
+│                                                                │
+│  👤 "I want fireflies around my guestbook"                     │
+│                                                                │
+│  🤖 "I found some options. Here's a peaceful evening          │
+│      scene with 5-8 fireflies scattered around your           │
+│      guestbook. Want me to add it to your sidebar?"           │
+│                                                                │
+│  [Preview Image]                                               │
+│                                                                │
+│  [ Looks good! ]  [ Show me options ]  [ Tweak it ]           │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Flow 2: Template Gallery
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  ✧ Vision Gallery                                       [×]    │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│  PEACEFUL                                                      │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
+│  │  🌙 Evening  │  │  🌿 Garden   │  │  💧 Stream   │         │
+│  │    Glow      │  │    Rest      │  │    Side      │         │
+│  └──────────────┘  └──────────────┘  └──────────────┘         │
+│                                                                │
+│  PLAYFUL                                                       │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
+│  │  🦋 Flutter  │  │  ✨ Sparkle  │  │  🐝 Buzz     │         │
+│  │    By        │  │    Dance     │  │    Around    │         │
+│  └──────────────┘  └──────────────┘  └──────────────┘         │
+│                                                                │
+│  [ Use Template ]        [ Customize ]        [ Create New ]   │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Flow 3: Vision Editor (Level 3.5)
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  ✧ Vision Editor                                        [×]    │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│  ┌─ Preview ─────────────────────┐  ┌─ Vision DSL ──────────┐ │
+│  │                               │  │                        │ │
+│  │      ✨  ✨                   │  │ name: My Evening       │ │
+│  │    ✨      ✨                 │  │ mood:                  │ │
+│  │  ┌──────────────┐            │  │   - peaceful           │ │
+│  │  │  Guestbook   │  ✨        │  │   - glowing            │ │
+│  │  └──────────────┘            │  │ elements:              │ │
+│  │      ✨    ✨                 │  │   - component: firefly │ │
+│  │                               │  │     count: 6           │ │
+│  └───────────────────────────────┘  │     ...                │ │
+│                                      └────────────────────────┘ │
+│                                                                │
+│  Complexity: ████████░░ 156/200                               │
+│                                                                │
+│  [ Save Vision ]              [ Export to Terrarium ]          │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Data Storage
+
+### Vision Storage
+
+```sql
+CREATE TABLE reverie_visions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  mood TEXT,           -- JSON array
+  dsl TEXT NOT NULL,   -- Full Vision DSL as YAML
+  complexity INTEGER,
+  is_template BOOLEAN DEFAULT FALSE,
+  is_public BOOLEAN DEFAULT FALSE,
+  created_at INTEGER DEFAULT (unixepoch()),
+  updated_at INTEGER DEFAULT (unixepoch()),
+
+  FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_visions_tenant ON reverie_visions(tenant_id);
+CREATE INDEX idx_visions_public ON reverie_visions(is_public, created_at);
+```
+
+### Template Catalog
+
+```sql
+CREATE TABLE reverie_templates (
+  id TEXT PRIMARY KEY,
+  vision_id TEXT NOT NULL,
+  author_id TEXT NOT NULL,
+  category TEXT NOT NULL,
+  tags TEXT,           -- JSON array
+  use_count INTEGER DEFAULT 0,
+  featured BOOLEAN DEFAULT FALSE,
+  created_at INTEGER DEFAULT (unixepoch()),
+
+  FOREIGN KEY (vision_id) REFERENCES reverie_visions(id) ON DELETE CASCADE,
+  FOREIGN KEY (author_id) REFERENCES tenants(id) ON DELETE CASCADE
+);
+```
+
+---
+
+## Implementation Phases
+
+### Phase 0: Research & Design (Current)
+- [x] Define concept and metaphor
+- [x] Write initial spec
+- [ ] Design manifest schema
+- [ ] Design Vision DSL schema
+- [ ] Prototype agent prompts
+
+### Phase 1: Manifest
+- [ ] Auto-generate manifest from component TypeScript
+- [ ] Add semantic tags to 20 key components
+- [ ] Build manifest validation tooling
+- [ ] Create manifest viewer/browser
+
+### Phase 2: Vision DSL
+- [ ] Define DSL schema (JSON Schema)
+- [ ] Build DSL parser
+- [ ] Build DSL validator
+- [ ] Create manual test visions
+
+### Phase 3: Agent Interface
+- [ ] Implement dream → intent parsing
+- [ ] Implement manifest querying
+- [ ] Implement composition logic
+- [ ] Integrate with Mycelium (MCP)
+- [ ] Test with Claude Code
+
+### Phase 4: Integration
+- [ ] Export to Terrarium scenes
+- [ ] Export to Foliage decorations
+- [ ] Build preview renderer
+- [ ] Create template gallery UI
+
+### Phase 5: Polish
+- [ ] Template sharing system
+- [ ] Vision editor UI
+- [ ] Performance optimization
+- [ ] Documentation & help articles
+
+---
+
+## Success Criteria
+
+1. **Natural Language Works**: A Wanderer can say "make my site feel cozy with glowing things" and get a composed scene
+2. **Fuzzy Matching**: The agent discovers components matching imprecise criteria
+3. **Valid Output**: Generated visions are valid, accessible, and performant
+4. **Human Readable**: Curious Wanderers can read and edit the Vision DSL
+5. **Shareable**: Visions can be saved as templates for others
+
+---
+
+## References
+
+- [Ink & Switch: Malleable Software](https://www.inkandswitch.com/essay/malleable-software/)
+- [Terrarium Spec](terrarium-spec.md)
+- [Curios Spec](curios-spec.md)
+- [Mycelium Spec](mycelium-spec.md)
+- [Grove Naming](../philosophy/grove-naming.md)
+- [Naming Journey](../scratch/malleable-bridge-naming-journey.md)
+- [Planning Overview](../plans/planning/reverie/overview.md)
+
+---
+
+*This is an exploration, not a commitment. We're asking: could Grove become malleable? What would that take? Reverie is the hypothesis.*
+
+*Half-dream, half-real. Yours.*


### PR DESCRIPTION
Initial planning docs exploring how Grove could become "malleable software"
inspired by Ink & Switch essay. Includes:
- Naming journey scratchpad with candidate names
- Overview document with vision and architecture


Name - Reverie

https://claude.ai/code/session_01Bbhz1Um3ZMjWo7hd29afLr