### PR TITLE
fix(landing): rewrite GroveTerm as proper markdown-it plugin

### DIFF
--- a/packages/landing/src/lib/utils/docs-loader.ts
+++ b/packages/landing/src/lib/utils/docs-loader.ts
@@ -8,7 +8,7 @@ import type {
   DocWithContent,
   DocHeader,
 } from "$lib/types/docs";
-import { processGroveTerms } from "./markdown-groveterm";
+import { groveTermPlugin } from "./markdown-groveterm";
 
 /**
  * Generate a URL-safe ID from text.
@@ -35,8 +35,9 @@ function escapeHtml(text: string): string {
     .replace(/'/g, "&#39;");
 }
 
-// Create markdown-it instance with custom renderers
+// Create markdown-it instance with custom renderers and GroveTerm plugin
 const md = new MarkdownIt({ html: false, linkify: true });
+md.use(groveTermPlugin);
 
 // Heading renderer - adds IDs for TOC navigation
 md.renderer.rules.heading_open = function (tokens, idx, options, _env, self) {
@@ -297,7 +298,7 @@ export function loadDocBySlug(
     return {
       ...docWithoutPath,
       content: markdownContent,
-      html: md.render(processGroveTerms(markdownContent)),
+      html: md.render(markdownContent),
       headers,
     };
   } catch (error) {

--- a/packages/landing/src/routes/api/kb/excerpt/[slug]/+server.ts
+++ b/packages/landing/src/routes/api/kb/excerpt/[slug]/+server.ts
@@ -14,12 +14,14 @@ import { getDocFilePath, findDocBySlug } from "$lib/server/docs-scanner";
 import { readFileSync } from "fs";
 import matter from "@11ty/gray-matter";
 import MarkdownIt from "markdown-it";
+import { groveTermPlugin } from "$lib/utils/markdown-groveterm";
 
 // Prerender all excerpt endpoints at build time
 export const prerender = true;
 
-// Markdown renderer for excerpts (simpler than full article renderer)
+// Markdown renderer for excerpts with GroveTerm support
 const md = new MarkdownIt({ html: false, linkify: true });
+md.use(groveTermPlugin);
 
 /**
  * Extract first section from markdown content.


### PR DESCRIPTION
The [[term]] syntax was rendering raw <abbr> HTML tags as visible text
because processGroveTerms() was a text preprocessor that injected HTML
before markdown-it processed the content. With html: false, markdown-it
escaped those tags to &lt;abbr&gt;, which then showed as literal text.

Rewrote markdown-groveterm.ts as a proper markdown-it plugin that
registers an inline tokenizer rule and renderer. This works regardless
of the html config because it goes through markdown-it's own rendering
pipeline — no more fighting against HTML escaping.

https://claude.ai/code/session_01LGGFUFjAS5TAgZJzhf4Zdw