### PR TITLE
docs(skills): update 11 skills to reference GroveTerm V2 component suite

### DIFF
--- a/.claude/skills/chameleon-adapt/SKILL.md
+++ b/.claude/skills/chameleon-adapt/SKILL.md
@@ -641,20 +641,63 @@ Desktop navigation items that don't fit should go to a mobile sheet menu:
 {/if}
 ```
 
-**User Identity Language:**
+**Grove Mode & Terminology (GroveTerm V2):**
 
-| Term | Who | Use For |
-|------|-----|---------|
-| **Wanderer** | Everyone | Greetings, welcome messages, all users |
-| **Rooted** | Subscribers | Subscription confirmations, thank-yous |
-| **Pathfinder** | Trusted guides | Community leaders (appointed) |
-| **Wayfinder** | Autumn | The grove keeper (singular) |
+Grove has a complete terminology system that automatically switches between Grove-themed terms and standard/understandable terms based on the user's **Grove Mode** setting. **Always use GroveTerm components instead of hardcoding Grove terminology.**
 
-**In UI text:**
-- "Welcome, Wanderer." (not "Welcome, user")
-- "Welcome back, Wanderer." (dashboard greeting)
-- "You've taken root." (subscription confirmation)
-- "Thanks for staying rooted." (payment received)
+When Grove Mode is OFF (the default for new visitors), users see familiar terms like "Posts" instead of "Blooms", "Dashboard" instead of "Arbor", "Support" instead of "Porch". This keeps the experience welcoming and non-alienating. When users opt in to Grove Mode, they see the full nature-themed vocabulary.
+
+**The GroveTerm Component Suite:**
+
+```svelte
+import { GroveTerm, GroveSwap, GroveText, GroveSwapText, GroveIntro } from '@autumnsgrove/groveengine/ui';
+import groveTermManifest from '$lib/data/grove-term-manifest.json';
+```
+
+| Component | When to Use | Behavior |
+|-----------|-------------|----------|
+| `GroveTerm` | Interactive terms with popup definitions | Shows standard term when Grove Mode OFF, Grove term with colored underline when ON. Click opens popup. |
+| `GroveSwap` | Silent text replacement (no popup) | Reactively swaps between Grove/standard terms. No underline, no interaction. |
+| `GroveText` | Parsing `[[term]]` syntax in strings | Converts `[[bloom\|posts]]` in data strings to interactive GroveTerm components. |
+| `GroveSwapText` | Parsing `[[term]]` syntax silently | Same parsing but renders silent swaps (no popups). |
+| `GroveIntro` | "We call it X" banners below page titles | Shows a standardized intro: "we call it the [Grove Term]". |
+
+**Usage Examples:**
+
+```svelte
+<!-- Interactive term with popup -->
+<GroveTerm term="bloom" manifest={groveTermManifest} />
+
+<!-- Custom display text -->
+<GroveTerm term="wanderer" manifest={groveTermManifest}>wanderers</GroveTerm>
+
+<!-- Silent swap (no popup, no underline) -->
+<GroveSwap term="arbor" manifest={groveTermManifest} />
+
+<!-- Parse [[term]] syntax in data strings -->
+<GroveText content="Your [[bloom|posts]] live in your [[garden|blog]]." manifest={groveTermManifest} />
+
+<!-- Page intro banner -->
+<GroveIntro term="meadow" manifest={groveTermManifest} />
+```
+
+**Key Rules:**
+- **Never hardcode Grove terms** in user-facing UI. Always use GroveTerm components.
+- **Default is OFF** for new visitors. They see standard, familiar terminology.
+- **URLs stay as Grove terms** (e.g., `/porch`, `/garden`) regardless of display mode.
+- **Subscription tiers** (Seedling/Sapling/Oak/Evergreen) and brand terms (Grove) always show as-is.
+- **The `[[term]]` syntax** is preferred for data-driven content (FAQ items, pricing text, etc.).
+
+**Grove Mode Store:**
+
+```svelte
+import { groveModeStore } from '@autumnsgrove/groveengine/ui/stores';
+
+// Check current mode
+const isGroveMode = $derived(groveModeStore.current);
+
+// Toggle is in the footer — don't add competing toggles
+```
 
 **Final Checklist:**
 
@@ -667,6 +710,8 @@ Desktop navigation items that don't fit should go to a mobile sheet menu:
 - [ ] Trees randomized with proper spacing (8% minimum gap)?
 - [ ] Dark mode supported with appropriate glass variants?
 - [ ] User-facing text follows Grove voice?
+- [ ] Grove terminology uses GroveTerm components (not hardcoded)?
+- [ ] `[[term]]` syntax used in data-driven content strings?
 
 **Output:** Fully adapted, accessible, responsive UI ready for production
 

--- a/.claude/skills/deer-sense/SKILL.md
+++ b/.claude/skills/deer-sense/SKILL.md
@@ -267,7 +267,36 @@ Setup: Multi-step registration form with conditional fields
    ✓ Can activate with Enter AND Space?
 ```
 
-**Scenario 2: Testing a Data Table with Sorting**
+**Scenario 2: Testing GroveTerm Components**
+
+```
+Setup: Page using GroveTerm/GroveSwap/GroveText for terminology
+
+1. Tab to a GroveTerm element
+   ✓ Focus ring visible (2px outline)?
+   ✓ aria-label reads "Grove term: [term], [category] category"?
+   ✓ role="button" and tabindex="0" present?
+
+2. Activate with Enter or Space
+   ✓ Popup opens with definition?
+   ✓ Focus moves to popup content?
+   ✓ ESC closes popup and returns focus?
+
+3. Toggle Grove Mode OFF
+   ✓ Standard terms display (e.g., "Posts" not "Blooms")?
+   ✓ Screen reader announces "Grove's name for [standard term]" in popup?
+   ✓ GroveSwap silently updates without focus disruption?
+
+4. Check prefers-reduced-motion
+   ✓ No animations on GroveTerm hover/open?
+   ✓ Popup appears instantly without transition?
+
+5. GroveText with [[term]] syntax
+   ✓ Parsed terms are keyboard-navigable?
+   ✓ Each rendered GroveTerm has correct aria attributes?
+```
+
+**Scenario 3: Testing a Data Table with Sorting**
 
 ```
 Setup: Posts table with sortable columns

--- a/.claude/skills/gathering-ui/SKILL.md
+++ b/.claude/skills/gathering-ui/SKILL.md
@@ -120,12 +120,16 @@ Phase: ADAPT
 - Reduced motion support
 - Touch targets 44px minimum
 - Dark mode variants
+- GroveTerm components for all Grove terminology
+  (never hardcode — use GroveTerm, GroveSwap, GroveText)
+  ([[term]] syntax for data-driven content strings)
 
 Output:
 - Complete Svelte components
 - Styled with Tailwind
 - Glass variants applied
 - Seasonal decorations
+- Grove terminology uses GroveTerm V2 components
 ```
 
 **🦌 DEER — SENSE**
@@ -180,6 +184,8 @@ Output:
 - [ ] Deer: Color contrast passes (4.5:1)
 - [ ] Deer: Reduced motion respected
 - [ ] Deer: Touch targets adequate (44px)
+- [ ] Both: Grove terminology uses GroveTerm components (not hardcoded)
+- [ ] Both: `[[term]]` syntax used in data-driven content strings
 
 **Quality Gates:**
 

--- a/.claude/skills/grove-documentation/SKILL.md
+++ b/.claude/skills/grove-documentation/SKILL.md
@@ -88,6 +88,21 @@ Wanderer → Wayfinder reflects the journey:
 
 See `docs/grove-user-identity.md` for full documentation.
 
+### Grove Mode & GroveTerm Components
+
+When writing text that includes Grove terminology in UI or content, **use GroveTerm components instead of hardcoding terms**. Grove Mode lets users toggle between standard terms (default for new visitors) and Grove terms.
+
+**For Svelte UI:** Use `GroveTerm`, `GroveSwap`, or `GroveText` components from `@autumnsgrove/groveengine/ui`.
+
+**For data-driven content** (FAQ items, pricing text, help articles): Use `[[term]]` syntax. Examples:
+- `"Your [[bloom|posts]] are always yours."` renders "posts" when Grove Mode is OFF, "blooms" when ON
+- `"Visit your [[arbor|dashboard]] to get started."` renders "dashboard" or "Arbor"
+- `"Ask a [[pathfinder|community guide]] for help."` renders "community guide" or "Pathfinder"
+
+**For markdown content** (help center articles): The rehype-groveterm plugin transforms `[[term]]` syntax in markdown automatically.
+
+**Key principle:** New visitors should see familiar, standard terminology. Grove's nature-themed vocabulary is opt-in, not forced. This keeps the platform accessible and welcoming while rewarding those who want to explore the ecosystem's personality.
+
 ---
 
 ## Strict Avoidances

--- a/.claude/skills/grove-ui-design/SKILL.md
+++ b/.claude/skills/grove-ui-design/SKILL.md
@@ -34,24 +34,55 @@ Write with the warmth of a midnight tea shop and the clarity of good documentati
 - **Readable** — content-first, decorations enhance, never obstruct
 - **Alive** — subtle animations, seasonal changes, randomization
 
-### User Identity Language
+### Grove Mode & Terminology (GroveTerm V2)
 
-Grove uses specific terms for community members in all UI:
+Grove has a terminology system that automatically switches between Grove-themed terms and standard terms based on the user's **Grove Mode** setting. **Always use GroveTerm components instead of hardcoding Grove terminology in UI.**
 
-| Term | Who | Use For |
-|------|-----|---------|
-| **Wanderer** | Everyone | Greetings, welcome messages, all users |
-| **Rooted** | Subscribers | Subscription confirmations, thank-yous |
-| **Pathfinder** | Trusted guides | Community leaders (appointed) |
-| **Wayfinder** | Autumn | The grove keeper (singular) |
+By default, Grove Mode is OFF for new visitors. They see familiar terms: "Posts" instead of "Blooms", "Dashboard" instead of "Arbor", "Support" instead of "Porch". When users opt in via the footer toggle, they see the full nature-themed vocabulary with interactive definitions.
 
-**In UI text:**
-- "Welcome, Wanderer." (not "Welcome, user")
-- "Welcome back, Wanderer." (dashboard greeting)
-- "You've taken root." (subscription confirmation)
-- "Thanks for staying rooted." (payment received)
+**The Component Suite:**
 
-See `docs/grove-user-identity.md` for full documentation.
+```svelte
+import { GroveTerm, GroveSwap, GroveText, GroveSwapText, GroveIntro } from '@autumnsgrove/groveengine/ui';
+import groveTermManifest from '$lib/data/grove-term-manifest.json';
+```
+
+| Component | Use Case | Behavior |
+|-----------|----------|----------|
+| `GroveTerm` | Interactive terms with popup definitions | Colored underline when ON, click for popup. Shows standard term when OFF. |
+| `GroveSwap` | Silent text replacement | Reactively swaps text. No underline, no interaction. |
+| `GroveText` | Parse `[[term]]` syntax in data strings | Renders `[[bloom\|posts]]` as interactive GroveTerm components. |
+| `GroveSwapText` | Parse `[[term]]` syntax silently | Same parsing, silent swaps (no popups). |
+| `GroveIntro` | "We call it X" page banners | Standardized intro below page titles. |
+
+**Usage:**
+
+```svelte
+<!-- Interactive term with popup -->
+<GroveTerm term="bloom" manifest={groveTermManifest} />
+
+<!-- Custom display text -->
+<GroveTerm term="wanderer" manifest={groveTermManifest}>wanderers</GroveTerm>
+
+<!-- Silent swap (no popup, no underline) -->
+<GroveSwap term="arbor" manifest={groveTermManifest} />
+
+<!-- Parse [[term]] syntax in data strings (ideal for FAQ items, pricing, etc.) -->
+<GroveText content="Your [[bloom|posts]] live in your [[garden|blog]]." manifest={groveTermManifest} />
+
+<!-- Page intro banner: "we call it the Meadow" -->
+<GroveIntro term="meadow" manifest={groveTermManifest} />
+```
+
+**Key Rules:**
+- **Never hardcode Grove terms** in user-facing UI. Always use GroveTerm components.
+- **Default is OFF** for new visitors. Standard, familiar terminology first.
+- **URLs stay as Grove terms** (`/porch`, `/garden`) regardless of display mode.
+- **Brand terms** (Grove) and **subscription tiers** (Seedling/Sapling/Oak/Evergreen) always show as-is.
+- **Use `[[term]]` syntax** for data-driven content (FAQ items, pricing fineprint, feature lists).
+- **Grove Mode store**: `groveModeStore` from `@autumnsgrove/groveengine/ui/stores`. Toggle lives in the footer.
+
+See `docs/grove-user-identity.md` for the full identity language documentation and `packages/engine/src/lib/ui/components/ui/groveterm/` for component source.
 
 ---
 
@@ -987,3 +1018,5 @@ Before shipping a Grove page:
 - [ ] Trees randomized with proper spacing (8% minimum gap)?
 - [ ] Dark mode supported with appropriate glass variants?
 - [ ] User-facing text follows Grove voice (see `grove-documentation`)?
+- [ ] Grove terminology uses GroveTerm components (not hardcoded)?
+- [ ] Data-driven content uses `[[term]]` syntax with GroveText?

--- a/.claude/skills/grove-vineyard/SKILL.md
+++ b/.claude/skills/grove-vineyard/SKILL.md
@@ -279,6 +279,21 @@ No additional styling framework needed — components are self-contained with sc
 - All feature cards as "coming-soon"
 - No interactive demos needed yet
 
+## Grove Terminology
+
+When vineyard pages reference Grove-themed terms (tool names, feature names, user roles), use GroveTerm components to respect the user's Grove Mode setting. New visitors see standard terms by default.
+
+```svelte
+import { GroveTerm, GroveText } from '@autumnsgrove/groveengine/ui';
+import groveTermManifest from '$lib/data/grove-term-manifest.json';
+
+<!-- Use GroveText for data-driven content with [[term]] syntax -->
+<GroveText content="Manage your [[bloom|posts]] and [[garden|blog]] appearance." manifest={groveTermManifest} />
+
+<!-- Or GroveTerm for individual interactive terms -->
+<p>Customize how your <GroveTerm term="garden" manifest={groveTermManifest} /> looks.</p>
+```
+
 ## Checklist
 
 Before shipping a vineyard page:
@@ -289,3 +304,4 @@ Before shipping a vineyard page:
 - [ ] Works on mobile (feature grid responsive)
 - [ ] Icons are valid lucide-svelte names
 - [ ] Status badges accurately reflect feature state
+- [ ] Grove terminology uses GroveTerm components (not hardcoded)

--- a/.claude/skills/hummingbird-compose.md
+++ b/.claude/skills/hummingbird-compose.md
@@ -159,6 +159,9 @@ await sendEmail({
 - Excessive exclamation points
 - Pushy sales language
 
+### Note on Grove Terminology in Emails:
+Emails are rendered as static HTML (not Svelte components), so GroveTerm components don't apply here. Use Grove terms directly in emails (Wanderer, Rooted, etc.) since email recipients have already opted in to the Grove ecosystem by subscribing. The GroveTerm toggle system is for web UI only, where new visitors may not yet understand the vocabulary.
+
 ### Example Opening:
 ```
 ❌ "Hey there! We have some exciting news!"

--- a/.claude/skills/museum-documentation/SKILL.md
+++ b/.claude/skills/museum-documentation/SKILL.md
@@ -385,6 +385,7 @@ Before finalizing any museum documentation:
 
 3. **grove-spec-writing** — Borrow ASCII art techniques for diagrams
 4. **grove-documentation** — Check terminology (Wanderer, Rooted, etc.)
+5. **GroveTerm components** — When exhibits include Grove terminology in UI, use `GroveTerm`, `GroveSwap`, or `GroveText` from `@autumnsgrove/groveengine/ui` instead of hardcoding terms. New visitors see standard terms by default; Grove Mode users see the nature-themed vocabulary. Use `[[term]]` syntax in markdown content for auto-transformation via the rehype-groveterm plugin.
 
 ### After Writing
 

--- a/.claude/skills/owl-archive/SKILL.md
+++ b/.claude/skills/owl-archive/SKILL.md
@@ -132,6 +132,15 @@ Wanderer → Wayfinder reflects the journey:
 - Wanderers *seek* the way (exploring, finding paths)
 - The Wayfinder *shows* the way (guiding, creating paths)
 
+**Grove Mode & GroveTerm Components:**
+
+When writing content that includes Grove terminology, use the GroveTerm component system instead of hardcoding terms. Grove Mode lets users toggle between standard terms (the default) and Grove-themed terms.
+
+- **In Svelte UI:** Use `GroveTerm`, `GroveSwap`, or `GroveText` from `@autumnsgrove/groveengine/ui`
+- **In data strings** (FAQ items, tooltips, onboarding text): Use `[[term]]` syntax, e.g., `"Your [[bloom|posts]] are always yours."`
+- **In markdown** (help articles): The `[[term]]` syntax is auto-transformed by the rehype-groveterm plugin
+- **Key principle:** New visitors see standard, familiar terms by default. Grove vocabulary is opt-in.
+
 ---
 
 ### Phase 3: GATHER

--- a/.claude/skills/svelte5-development/SKILL.md
+++ b/.claude/skills/svelte5-development/SKILL.md
@@ -245,6 +245,28 @@ src/
 └── hooks.server.js
 ```
 
+## Grove-Specific: GroveTerm Components
+
+When building Grove UI that includes nature-themed terminology, always use the GroveTerm component suite instead of hardcoding terms. This respects users' Grove Mode setting (standard terms by default, opt-in to Grove vocabulary).
+
+```svelte
+<script lang="ts">
+  import { GroveTerm, GroveSwap, GroveText } from '@autumnsgrove/groveengine/ui';
+  import groveTermManifest from '$lib/data/grove-term-manifest.json';
+</script>
+
+<!-- Interactive term with popup definition -->
+<GroveTerm term="bloom" manifest={groveTermManifest} />
+
+<!-- Silent swap (no popup, no underline) -->
+<GroveSwap term="arbor" manifest={groveTermManifest} />
+
+<!-- Parse [[term]] syntax in data strings -->
+<GroveText content="Your [[bloom|posts]] live in your [[garden|blog]]." manifest={groveTermManifest} />
+```
+
+See `packages/engine/src/lib/ui/components/ui/groveterm/` for component source and `chameleon-adapt` skill for full UI design guidance.
+
 ## Related Resources
 
 See `AgentUsage/svelte5_guide.md` for complete documentation including:

--- a/.claude/skills/walking-through-the-grove/SKILL.md
+++ b/.claude/skills/walking-through-the-grove/SKILL.md
@@ -160,10 +160,12 @@ Before finalizing:
 
 Update all the files:
 1. `docs/grove-naming.md` — Add the full entry
-2. `packages/grove-router/src/index.ts` — Claim subdomain
-3. `plant/src/routes/api/check-username/+server.ts` — Reserve username
-4. Workshop page if applicable
-5. Icons if applicable
+2. `docs/philosophy/grove-naming.md` — Update source (generates manifest)
+3. `packages/grove-router/src/index.ts` — Claim subdomain
+4. `plant/src/routes/api/check-username/+server.ts` — Reserve username
+5. Workshop page if applicable
+6. Icons if applicable
+7. **Regenerate the GroveTerm manifest** — Run `scripts/generate/grove-term-manifest.ts` to rebuild `grove-term-manifest.json` with the new term. This manifest powers all GroveTerm components (`GroveTerm`, `GroveSwap`, `GroveText`, etc.) that automatically switch between standard and Grove terminology based on the user's Grove Mode setting.
 
 ---
 


### PR DESCRIPTION
Skills now document the GroveTerm component system (GroveTerm, GroveSwap,
GroveText, GroveSwapText, GroveIntro) for handling Grove terminology in UI.
The key principle: never hardcode Grove terms — use components that respect
users' Grove Mode settings, showing standard terms by default.

Updated skills:
- chameleon-adapt: replaced static User Identity Language with full
  GroveTerm V2 section including component table, usage examples, store
  reference, and updated checklist
- grove-ui-design: same replacement with component suite documentation
  and checklist additions
- grove-documentation: added GroveTerm usage guidance and [[term]] syntax
  for content strings and markdown
- gathering-ui: added GroveTerm to Chameleon ADAPT phase and validation
  checklist
- deer-sense: added GroveTerm accessibility testing scenario (aria-labels,
  keyboard activation, focus management, Grove Mode toggle behavior)
- owl-archive: added GroveTerm note in terminology section for docs/UI
- grove-vineyard: added Grove Terminology section with usage examples and
  checklist item
- svelte5-development: added Grove-Specific GroveTerm section with import
  patterns
- museum-documentation: added GroveTerm integration note for exhibits
- walking-through-the-grove: added manifest regeneration step after naming
  new terms
- hummingbird-compose: clarified that emails use Grove terms directly
  (not GroveTerm components) since recipients have already opted in

https://claude.ai/code/session_01YMNRVSQuaGxa4tg6F9aYbx