### PR TITLE
feat(arbor): add personal links and missing dashboard cards

### DIFF
--- a/packages/landing/src/routes/arbor/+page.svelte
+++ b/packages/landing/src/routes/arbor/+page.svelte
@@ -20,7 +20,8 @@
 		CreditCard,
 		CircleDot,
 		ExternalLink,
-		Trees
+		Trees,
+		Kanban
 	} from 'lucide-svelte';
 
 	let { data }: { data: PageData } = $props();
@@ -299,6 +300,21 @@
 						<div class="flex-1 min-w-0">
 							<p class="text-sm font-sans font-medium text-foreground">Issues</p>
 							<p class="text-xs text-foreground-muted font-sans">GitHub Issue Tracker</p>
+						</div>
+						<ExternalLink class="w-3.5 h-3.5 text-foreground-muted flex-shrink-0" />
+					</div>
+				</GlassCard>
+			</a>
+
+			<a href="https://github.com/users/AutumnsGrove/projects/1" target="_blank" rel="noopener noreferrer" class="block">
+				<GlassCard hoverable class="p-4 h-full">
+					<div class="flex items-center gap-3">
+						<div class="w-9 h-9 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center flex-shrink-0">
+							<Kanban class="w-5 h-5 text-purple-600 dark:text-purple-400" />
+						</div>
+						<div class="flex-1 min-w-0">
+							<p class="text-sm font-sans font-medium text-foreground">Lattice Board</p>
+							<p class="text-xs text-foreground-muted font-sans">GitHub Project Kanban</p>
 						</div>
 						<ExternalLink class="w-3.5 h-3.5 text-foreground-muted flex-shrink-0" />
 					</div>


### PR DESCRIPTION
Add Status, Tenants, and Minecraft cards to the dashboard grid
to match the nav tabs. Add a new "My Links" section (Wayfinder-only)
with quick access to GitHub, Cloudflare, Known Agents, grove.place
analytics, Stripe, and GitHub Issues.

https://claude.ai/code/session_01Vjx4vgTH9m1VaeTJWVdz7i