### PR TITLE
fix(ui): show inverse grove term in GroveIntro subtitle

### DIFF
--- a/packages/engine/src/lib/ui/components/ui/groveterm/GroveIntro.svelte
+++ b/packages/engine/src/lib/ui/components/ui/groveterm/GroveIntro.svelte
@@ -6,15 +6,16 @@
 	import defaultManifestData from '$lib/data/grove-term-manifest.json';
 	const defaultManifest = defaultManifestData as GroveTermManifest;
 
-	// GroveIntro - Standardized "we call it X" page introduction
+	// GroveIntro - Standardized inverse-term page introduction
 	//
-	// Renders below a page title when Grove Mode is OFF, introducing the
-	// Grove term for the feature. Hidden entirely when Grove Mode is ON.
+	// Always shows the OPPOSITE term from what the heading displays,
+	// so users naturally learn both names:
+	//   - Grove Mode OFF: heading shows "Support", subtitle shows "we call it the Porch"
+	//   - Grove Mode ON: heading shows "Porch", subtitle shows "also known as Support"
 	//
 	// Usage:
-	//   <h1>Support</h1>
+	//   <h1><GroveSwap term="porch">Porch</GroveSwap></h1>
 	//   <GroveIntro term="porch" />
-	//   <!-- Renders: "we call it the Porch" with Porch as interactive GroveTerm -->
 
 	interface Props {
 		/** Term slug to look up (e.g., "porch", "arbor") */
@@ -34,15 +35,21 @@
 	// Direct manifest lookup — callers should pass the exact manifest slug
 	const entry = $derived(term in manifest ? manifest[term] : null);
 
-	// Only show when: Grove Mode is OFF, and the term has a standardTerm, and is not alwaysGrove
+	// Show when: term has both a grove term and a standard term, and is not alwaysGrove
 	const shouldShow = $derived(
-		!groveModeStore.current && entry && entry.standardTerm && !entry.alwaysGrove
+		entry && entry.standardTerm && !entry.alwaysGrove
 	);
+
+	const isGroveMode = $derived(groveModeStore.current);
 </script>
 
 {#if shouldShow && entry}
 	<p class="grove-intro text-sm text-foreground-subtle italic {className || ''}">
-		we call it the <GroveTerm term={term} {manifest} />
+		{#if isGroveMode}
+			also known as <GroveTerm term={term} displayOverride="standard" {manifest} />
+		{:else}
+			we call it the <GroveTerm term={term} displayOverride="grove" {manifest} />
+		{/if}
 	</p>
 {/if}
 

--- a/packages/engine/src/lib/ui/components/ui/groveterm/GroveTerm.svelte
+++ b/packages/engine/src/lib/ui/components/ui/groveterm/GroveTerm.svelte
@@ -33,6 +33,8 @@
 		class?: string;
 		/** Override display text */
 		children?: Snippet;
+		/** Force display of grove or standard term regardless of mode (used by GroveIntro) */
+		displayOverride?: 'grove' | 'standard';
 	}
 
 	let {
@@ -41,7 +43,8 @@
 		href,
 		class: className,
 		manifest = defaultManifest,
-		children
+		children,
+		displayOverride
 	}: Props = $props();
 
 	// State
@@ -74,6 +77,8 @@
 
 	// Whether this term should show as Grove (interactive underline) or standard (plain)
 	const showAsGrove = $derived(
+		displayOverride === 'grove' ? true :
+		displayOverride === 'standard' ? false :
 		groveModeStore.current || !entry?.standardTerm || entry?.alwaysGrove
 	);
 


### PR DESCRIPTION
GroveIntro was showing the same term as the heading, making it redundant
(e.g., "Blog" heading + "we call it the Blog" subtitle). The subtitle
should teach the OPPOSITE name so users naturally learn both terms.

- Grove Mode OFF: "Blog" + "we call it the Garden" (teaches grove term)
- Grove Mode ON: "Garden" + "also known as Blog" (teaches standard term)

Added displayOverride prop to GroveTerm so GroveIntro can force which
term variant to display regardless of the current mode.

https://claude.ai/code/session_01BwsZ3226XdLugWTrywhs5x