### PR TITLE
fix(editor): restore live preview by resetting isMounted flag in debounce effect

### DIFF
--- a/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
+++ b/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
@@ -153,6 +153,10 @@
 
   // Update debounced content after 150ms of no typing
   $effect(() => {
+    // Reset mounted flag — cleanup sets it to false before each re-run,
+    // so we must restore it here. It only stays false after final unmount.
+    isMounted = true;
+
     // Clear any existing timer
     if (debounceTimer) clearTimeout(debounceTimer);
 


### PR DESCRIPTION
In Svelte 5, $effect cleanup runs before each re-execution, not just on
unmount. The isMounted flag was set to false by cleanup and never reset,
causing debouncedContent to never update after the first content change.
This left previewHtml empty and the preview panel stuck on placeholder text.

https://claude.ai/code/session_01D179mPcWjwBU56XkiKPGkg