### PR TITLE
fix: remove bark/cream single-value overrides that squash preset shade scales

### DIFF
--- a/packages/clearing/tailwind.config.js
+++ b/packages/clearing/tailwind.config.js
@@ -33,8 +33,6 @@ export default {
 					major: '#ef4444',            // Red
 					maintenance: '#3b82f6'       // Blue
 				},
-				cream: '#fefdfb',
-				bark: '#3d2914'
 			},
 			fontFamily: {
 				serif: ['Lexend', 'Georgia', 'Cambria', 'Times New Roman', 'serif'],

--- a/packages/landing/tailwind.config.js
+++ b/packages/landing/tailwind.config.js
@@ -25,8 +25,6 @@ export default {
           900: "#14532d",
           950: "#052e16",
         },
-        cream: "#fefdfb",
-        bark: "#3d2914",
       },
       fontFamily: {
         serif: ["Lexend", "Georgia", "Cambria", "Times New Roman", "serif"],

--- a/packages/meadow/tailwind.config.js
+++ b/packages/meadow/tailwind.config.js
@@ -25,8 +25,6 @@ export default {
           900: "#14532d",
           950: "#052e16",
         },
-        cream: "#fefdfb",
-        bark: "#3d2914",
         // Neutral palette for dark mode and glass effects
         neutral: {
           50: "#fafaf9",

--- a/packages/plant/tailwind.config.js
+++ b/packages/plant/tailwind.config.js
@@ -25,8 +25,6 @@ export default {
           900: "#14532d",
           950: "#052e16",
         },
-        cream: "#fefdfb",
-        bark: "#3d2914",
       },
       fontFamily: {
         serif: ["Lexend", "Georgia", "Cambria", "Times New Roman", "serif"],


### PR DESCRIPTION
All four consumer apps (landing, meadow, plant, clearing) defined
bark and cream as single hex strings in their Tailwind configs:

  cream: "#fefdfb"
  bark: "#3d2914"

This completely overrode the preset's full shade objects (bark-50
through bark-950, cream-50 through cream-500), causing all shade
utilities like dark:bg-bark-800, dark:bg-bark-700, dark:border-bark-600
to generate zero CSS — transparent backgrounds across every dark mode
admin page.

The preset already provides the complete shade scales via CSS
variables, and each app's app.css already defines those variables.
Removing the overrides lets the preset take effect.

https://claude.ai/code/session_0177GhUaV9R6oKfpY2qjcoTq