### PR TITLE
fix(editor): remove sanitizeMarkdown from live preview to fix broken rendering

### DIFF
--- a/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
+++ b/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
@@ -1,7 +1,6 @@
 <script>
   import MarkdownIt from "markdown-it";
   import { tick } from "svelte";
-  import { sanitizeMarkdown } from "$lib/utils/sanitize";
 
   // Local instance for admin editor preview
   const editorMd = new MarkdownIt({ html: false, linkify: true });
@@ -181,7 +180,8 @@
   let charCount = $derived(content.length);
   let lineCount = $derived(content.split("\n").length);
   // Use debounced content for expensive operations (markdown rendering)
-  let previewHtml = $derived(debouncedContent ? sanitizeMarkdown(editorMd.render(debouncedContent)) : "");
+  // Note: editorMd has html:false so output is already safe — no sanitization needed for admin preview
+  let previewHtml = $derived(debouncedContent ? editorMd.render(debouncedContent) : "");
   let previewHeaders = $derived(debouncedContent ? extractHeaders(debouncedContent) : []);
 
   let readingTime = $derived.by(() => {


### PR DESCRIPTION
The admin editor preview was broken because sanitizeMarkdown depends on
a dynamic DOMPurify import (async, may not be ready) with a sanitize-html
fallback that doesn't reliably work in browser environments. The demo
EditorDemo on the landing page worked fine because it renders markdown
directly without sanitization.

Since the MarkdownIt instance is configured with html:false, all raw HTML
in the input is already escaped to entities — there's no XSS vector.
Sanitization is still applied server-side when content is saved/published.

https://claude.ai/code/session_01Cwu2JYSAJ4hkxBLxQHoRcn