### PR TITLE
feat(engine): gate photo gallery behind greenhouse-only graft

### DIFF
--- a/packages/engine/migrations/049_photo_gallery_graft.sql
+++ b/packages/engine/migrations/049_photo_gallery_graft.sql
@@ -1,0 +1,37 @@
+-- ============================================================================
+-- PHOTO GALLERY GRAFT
+-- ============================================================================
+-- Gates photo gallery and image uploads behind greenhouse mode.
+-- Replaces the old dual-gate system (gallery_curio_config + image_uploads_enabled)
+-- with a single greenhouse-only graft toggle, matching fireside/scribe pattern.
+--
+-- When enabled: tenants can upload photos and their /gallery page is live.
+-- When disabled: uploads are blocked and /gallery returns 404.
+--
+-- @see migrations/040_fireside_scribe_grafts.sql (pattern reference)
+-- ============================================================================
+
+-- Photo Gallery graft (image uploads + public gallery page)
+INSERT OR IGNORE INTO feature_flags (
+  id, name, description, flag_type, default_value, enabled, greenhouse_only
+) VALUES (
+  'photo_gallery',
+  'Photo Gallery',
+  'Upload photos and display a public gallery on your site. Images are stored in R2 with content moderation.',
+  'boolean',
+  'true',
+  1,
+  1  -- Greenhouse only: experimental feature for trusted testers
+);
+
+-- Add tenant rule for autumn-primary (Wayfinder's grove) to always have access
+-- Priority 100 ensures this overrides any tier-based rules
+INSERT OR IGNORE INTO flag_rules (flag_id, priority, rule_type, rule_value, result_value, enabled)
+VALUES (
+  'photo_gallery',
+  100,
+  'tenant',
+  '{"tenant_id": "autumn-primary"}',
+  'true',
+  1
+);

--- a/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
+++ b/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
@@ -69,7 +69,7 @@
   // Derived graft flags - add new ones here as they're created
   const firesideEnabled = $derived(grafts?.fireside_mode ?? false);
   const scribeEnabled = $derived(grafts?.scribe_mode ?? false);
-  const uploadsEnabled = $derived(grafts?.image_uploads_enabled ?? false);
+  const uploadsEnabled = $derived(grafts?.photo_gallery ?? false);
 
   // Core refs and state
   /** @type {HTMLTextAreaElement | null} */

--- a/packages/engine/src/lib/feature-flags/grafts.ts
+++ b/packages/engine/src/lib/feature-flags/grafts.ts
@@ -42,7 +42,8 @@ export type KnownGraftId =
   | "meadow_access"
   | "jxl_encoding"
   | "jxl_kill_switch"
-  | "image_uploads_enabled";
+  | "image_uploads_enabled"
+  | "photo_gallery";
 
 /**
  * Record of graft ID to enabled status.

--- a/packages/engine/src/routes/arbor/images/+page.svelte
+++ b/packages/engine/src/routes/arbor/images/+page.svelte
@@ -27,7 +27,7 @@
   let { data } = $props();
 
   // Feature flag for image uploads (cascaded from Arbor layout grafts)
-  const uploadsEnabled = $derived(data.grafts?.image_uploads_enabled ?? false);
+  const uploadsEnabled = $derived(data.grafts?.photo_gallery ?? false);
 
   // Feature flags from server (reactive to data changes)
   const jxlFeatureEnabled = $derived(data.jxl?.jxlEnabled ?? false);


### PR DESCRIPTION
Replace the dual-gate system (gallery_curio_config + image_uploads_enabled)
with a single photo_gallery graft, matching the fireside/scribe pattern.
Greenhouse tenants can toggle it in their settings via GraftControlPanel.

- Add migration 049 creating photo_gallery graft (greenhouse-only)
- Update root layout to check graft instead of gallery_curio_config
- Update gallery page server to gate on graft with sensible defaults
- Update upload endpoint to check photo_gallery with greenhouse context
- Update client-side graft references in images page and MarkdownEditor

https://claude.ai/code/session_01D8UvhNokZiDiVVzeEroKmY