### PR TITLE
fix(arbor): load font faces for settings font picker previews

### DIFF
--- a/packages/engine/src/routes/arbor/settings/+page.svelte
+++ b/packages/engine/src/routes/arbor/settings/+page.svelte
@@ -26,6 +26,9 @@
   import { enhance } from "$app/forms";
   import { invalidateAll } from "$app/navigation";
 
+  // Load all font faces so the font picker previews render correctly
+  import "$lib/styles/fonts-optional.css";
+
   /**
    * @typedef {Object} HealthStatus
    * @property {string} [status]


### PR DESCRIPTION
fonts-optional.css was only lazily loaded when a tenant already used a
non-default font, so the arbor settings font picker previews rendered in
system fallback fonts instead of the actual typefaces. Import the CSS
directly in the settings page so all font previews display correctly.

https://claude.ai/code/session_01AjwhBHVaLoBGPe3bT5U2YS