### PR TITLE
feat(landing): redesign hero carousel with trees & lanterns only

### DIFF
--- a/packages/landing/src/lib/components/hero/HeroCentennial.svelte
+++ b/packages/landing/src/lib/components/hero/HeroCentennial.svelte
@@ -1,7 +1,8 @@
 <!--
-  HeroCentennial — Slide 4: "Some trees outlive the people who planted them"
-  Legacy — 100-year guarantee. Large TreePine, Lantern at base,
-  StonePath, MushroomCluster, Stars in sky, twilight mood.
+  HeroCentennial — "Some trees outlive the people who planted them."
+  Legacy — 100-year guarantee. A grand sentinel pine with
+  lanterns glowing at its base. Twilight mood with depth.
+  More companion trees and lanterns revealed on larger screens.
 -->
 <script lang="ts">
 	import type { HeroSlideContentProps } from './hero-types';
@@ -9,11 +10,9 @@
 	import { ArrowRight } from 'lucide-svelte';
 	import {
 		TreePine,
-		Lantern,
-		StonePath,
-		MushroomCluster,
-		Star
+		Lantern
 	} from '@autumnsgrove/groveengine/ui/nature';
+	import { greens, bark } from '@autumnsgrove/groveengine/ui/nature';
 
 	let { season, active, index }: HeroSlideContentProps = $props();
 </script>
@@ -38,41 +37,55 @@
 
 	{#snippet scene()}
 		<div class="relative w-full h-full">
-			<!-- Stars — scattered across the full sky -->
-			<div class="absolute top-[8%] right-[20%]">
-				<Star class="w-2.5 h-2.5 opacity-55" />
-			</div>
-			<div class="absolute top-[6%] right-[40%]">
-				<Star class="w-2 h-2 opacity-35" />
-			</div>
-			<div class="absolute top-[15%] right-[12%]">
-				<Star class="w-3 h-3 opacity-45" />
-			</div>
-			<div class="absolute top-[12%] left-[40%] md:left-[50%]">
-				<Star class="w-2 h-2 opacity-30" />
-			</div>
-			<div class="absolute top-[5%] left-[55%] hidden md:block">
-				<Star class="w-2.5 h-2.5 opacity-40" />
+			<!-- === ALWAYS VISIBLE (mobile+) === -->
+
+			<!-- The sentinel — grand central pine -->
+			<div class="absolute bottom-[6%] right-[22%] md:right-[30%]">
+				<TreePine {season} animate={active} color={greens.grove} trunkColor={bark.warmBark} class="w-18 h-36 md:w-28 md:h-52 lg:w-32 lg:h-60" />
 			</div>
 
-			<!-- Large central pine — the sentinel tree, shifted right -->
-			<div class="absolute bottom-[8%] right-[22%] md:right-[28%]">
-				<TreePine {season} animate={active} class="w-20 h-36 md:w-28 md:h-48" />
+			<!-- Companion pine — smaller, left of sentinel -->
+			<div class="absolute bottom-[9%] right-[42%] md:right-[48%]">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="w-10 h-20 md:w-14 md:h-30 lg:w-16 lg:h-34 opacity-60" />
 			</div>
 
-			<!-- Lantern at base of tree -->
-			<div class="absolute bottom-[6%] right-[38%] md:right-[42%]">
-				<Lantern animate={active} class="w-5 h-8 md:w-6 md:h-10" variant="standing" />
+			<!-- Lantern at base — warm glow -->
+			<div class="absolute bottom-[5%] right-[35%] md:right-[42%]">
+				<Lantern animate={active} class="w-4 h-7 md:w-5 md:h-9 lg:w-6 lg:h-11" variant="standing" />
 			</div>
 
-			<!-- Stone path — visible on all sizes now -->
-			<div class="absolute bottom-[2%] right-[15%] md:right-[20%]">
-				<StonePath class="w-24 h-5 md:w-32 md:h-7 opacity-55" />
+			<!-- === TABLET+ (md) === -->
+
+			<!-- Distant pine — far right background -->
+			<div class="absolute bottom-[12%] right-[6%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="md:w-10 md:h-20 lg:w-12 lg:h-24 opacity-35" />
 			</div>
 
-			<!-- Mushroom cluster -->
-			<div class="absolute bottom-[5%] right-[8%]">
-				<MushroomCluster class="w-10 h-7 md:w-12 md:h-9" />
+			<!-- Mid-right pine — between sentinel and far right -->
+			<div class="absolute bottom-[10%] right-[12%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="md:w-12 md:h-24 lg:w-14 lg:h-28 opacity-50" />
+			</div>
+
+			<!-- Second lantern — post variant, right side -->
+			<div class="absolute bottom-[5%] right-[18%] hidden md:block">
+				<Lantern animate={active} class="md:w-4 md:h-7 lg:w-5 lg:h-9" variant="post" />
+			</div>
+
+			<!-- === DESKTOP (lg) === -->
+
+			<!-- Far-left background pine -->
+			<div class="absolute bottom-[14%] right-[58%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="lg:w-10 lg:h-20 opacity-25" />
+			</div>
+
+			<!-- Fill pine — between companion and sentinel -->
+			<div class="absolute bottom-[8%] right-[38%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.grove} trunkColor={bark.warmBark} class="lg:w-12 lg:h-24 opacity-45" />
+			</div>
+
+			<!-- Third lantern — hanging, near leftmost tree -->
+			<div class="absolute bottom-[8%] right-[52%] hidden lg:block">
+				<Lantern animate={active} class="lg:w-4 lg:h-7 opacity-55" variant="standing" />
 			</div>
 		</div>
 	{/snippet}

--- a/packages/landing/src/lib/components/hero/HeroCommunity.svelte
+++ b/packages/landing/src/lib/components/hero/HeroCommunity.svelte
@@ -1,22 +1,18 @@
 <!--
-  HeroCommunity — Slide 5: "The internet should feel like home"
-  Belonging — the forest. Pond + Reeds + LilyPad, TreeBirch + TreeCherry,
-  Robin, Rabbit, Lantern glowing, dawn mood.
+  HeroCommunity — "The internet should feel like home."
+  Belonging — the forest. A warm grove of trees with
+  lanterns, evoking a welcoming place to gather.
+  Progressively denser grove on larger screens.
 -->
 <script lang="ts">
 	import type { HeroSlideContentProps } from './hero-types';
 	import HeroSlide from './HeroSlide.svelte';
 	import { Sprout } from 'lucide-svelte';
 	import {
-		TreeBirch,
-		TreeCherry,
-		Pond,
-		Reeds,
-		LilyPad,
-		Robin,
-		Rabbit,
+		TreePine,
 		Lantern
 	} from '@autumnsgrove/groveengine/ui/nature';
+	import { greens, bark } from '@autumnsgrove/groveengine/ui/nature';
 
 	let { season, active, index }: HeroSlideContentProps = $props();
 </script>
@@ -41,42 +37,67 @@
 
 	{#snippet scene()}
 		<div class="relative w-full h-full">
-			<!-- Trees — framing the scene, weighted right -->
-			<div class="absolute bottom-[8%] left-[30%] md:left-[40%]">
-				<TreeBirch {season} animate={active} class="w-14 h-26 md:w-20 md:h-38 opacity-60" />
-			</div>
-			<div class="absolute bottom-[8%] right-[6%] md:right-[10%]">
-				<TreeCherry {season} animate={active} class="w-16 h-28 md:w-22 md:h-38 opacity-65" />
+			<!-- Community grove — trees as neighbors, lanterns as gathering lights -->
+
+			<!-- === ALWAYS VISIBLE (mobile+) === -->
+
+			<!-- Center-left pine — medium grove green -->
+			<div class="absolute bottom-[8%] right-[35%] md:right-[40%]">
+				<TreePine {season} animate={active} color={greens.grove} trunkColor={bark.warmBark} class="w-14 h-28 md:w-20 md:h-40 lg:w-24 lg:h-48" />
 			</div>
 
-			<!-- Pond area — center-right -->
-			<div class="absolute bottom-[3%] right-[20%] md:right-[25%]">
-				<Pond class="w-28 h-12 md:w-36 md:h-16" />
+			<!-- Center-right pine — taller, meadow green -->
+			<div class="absolute bottom-[7%] right-[12%] md:right-[18%]">
+				<TreePine {season} animate={active} color={greens.meadow} trunkColor={bark.warmBark} class="w-16 h-32 md:w-22 md:h-44 lg:w-26 lg:h-52" />
 			</div>
 
-			<!-- Reeds beside pond -->
-			<div class="absolute bottom-[9%] right-[40%] md:right-[48%]">
-				<Reeds class="w-7 h-12 md:w-9 md:h-16 opacity-65" />
+			<!-- Gathering lantern — the heart of the community -->
+			<div class="absolute bottom-[6%] right-[24%] md:right-[30%]">
+				<Lantern animate={active} class="w-5 h-9 md:w-6 md:h-11 lg:w-7 lg:h-12" variant="standing" />
 			</div>
 
-			<!-- Lily pad on pond -->
-			<div class="absolute bottom-[5%] right-[25%] md:right-[30%]">
-				<LilyPad class="w-6 h-3.5 md:w-7 md:h-4.5" />
+			<!-- === TABLET+ (md) === -->
+
+			<!-- Left pine — background depth -->
+			<div class="absolute bottom-[11%] left-[22%] md:left-[34%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="md:w-14 md:h-28 lg:w-16 lg:h-32 opacity-55" />
 			</div>
 
-			<!-- Robin — upper area -->
-			<div class="absolute top-[25%] right-[30%]">
-				<Robin animate={active} class="w-6 h-6 md:w-8 md:h-8" />
+			<!-- Far right pine — edge of the grove -->
+			<div class="absolute bottom-[10%] right-[3%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="md:w-10 md:h-20 lg:w-12 lg:h-24 opacity-45" />
 			</div>
 
-			<!-- Rabbit — near pond -->
-			<div class="absolute bottom-[12%] right-[12%]">
-				<Rabbit class="w-7 h-7 md:w-9 md:h-9" />
+			<!-- Second lantern — near the right trees -->
+			<div class="absolute bottom-[8%] right-[8%] hidden md:block">
+				<Lantern animate={active} class="md:w-4 md:h-7 lg:w-5 lg:h-9 opacity-70" variant="standing" />
 			</div>
 
-			<!-- Lantern glowing — visible on all sizes now -->
-			<div class="absolute bottom-[10%] right-[45%] md:right-[52%]">
-				<Lantern animate={active} class="w-4 h-7 md:w-5 md:h-9" variant="standing" />
+			<!-- Back pine — distant mood -->
+			<div class="absolute bottom-[13%] right-[28%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="md:w-9 md:h-18 lg:w-11 lg:h-22 opacity-35" />
+			</div>
+
+			<!-- === DESKTOP (lg) — dense welcoming grove === -->
+
+			<!-- Far-left background pine -->
+			<div class="absolute bottom-[14%] left-[28%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="lg:w-10 lg:h-20 opacity-25" />
+			</div>
+
+			<!-- Fill pine — between left and center -->
+			<div class="absolute bottom-[9%] right-[48%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.grove} trunkColor={bark.warmBark} class="lg:w-16 lg:h-34 opacity-60" />
+			</div>
+
+			<!-- Extra right pine — extends the grove edge -->
+			<div class="absolute bottom-[12%] right-[55%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="lg:w-12 lg:h-24 opacity-40" />
+			</div>
+
+			<!-- Third lantern — far left, distant warmth -->
+			<div class="absolute bottom-[7%] right-[42%] hidden lg:block">
+				<Lantern animate={active} class="lg:w-4 lg:h-7 opacity-50" variant="standing" />
 			</div>
 		</div>
 	{/snippet}

--- a/packages/landing/src/lib/components/hero/HeroOwnership.svelte
+++ b/packages/landing/src/lib/components/hero/HeroOwnership.svelte
@@ -1,24 +1,23 @@
 <!--
-  HeroOwnership — Slide 2: "Your words. Your space. Forever."
-  Personal space — the domain. TreeAspen growing tall, GardenGate,
-  Butterfly, Fern + Bush, monospace domain display.
+  HeroOwnership — "Your words. Your space. Forever."
+  Personal space — the domain. A gentle grove clearing with pines
+  and a welcoming lantern. Trees use explicit palette colors for depth.
+  Responsive density: mobile gets 2-3 trees, tablet 4-5, desktop 6+.
 -->
 <script lang="ts">
 	import type { HeroSlideContentProps } from './hero-types';
 	import HeroSlide from './HeroSlide.svelte';
 	import { ArrowRight } from 'lucide-svelte';
 	import {
-		TreeAspen,
-		GardenGate,
-		Butterfly,
-		Fern,
-		Bush
+		TreePine,
+		Lantern
 	} from '@autumnsgrove/groveengine/ui/nature';
+	import { greens, bark } from '@autumnsgrove/groveengine/ui/nature';
 
 	let { season, active, index }: HeroSlideContentProps = $props();
 </script>
 
-<HeroSlide {season} {active} bgVariant="mist" ariaLabel="Your words, your space, forever">
+<HeroSlide {season} {active} bgVariant="forest" ariaLabel="Your words, your space, forever">
 	{#snippet text()}
 		<h2 class="text-2xl sm:text-display-sm md:text-display lg:text-display-lg text-foreground motion-safe:animate-fade-in-up">
 			Your words. Your space. Forever.
@@ -39,30 +38,50 @@
 
 	{#snippet scene()}
 		<div class="relative w-full h-full">
-			<!-- Tall aspen — shifted right of center -->
-			<div class="absolute bottom-[8%] right-[25%] md:right-[30%]">
-				<TreeAspen {season} animate={active} class="w-16 h-32 md:w-22 md:h-44" />
+			<!-- === ALWAYS VISIBLE (mobile+) === -->
+
+			<!-- Main pine — hero tree, right of center -->
+			<div class="absolute bottom-[8%] right-[28%] md:right-[35%]">
+				<TreePine {season} animate={active} color={greens.grove} trunkColor={bark.warmBark} class="w-14 h-28 md:w-22 md:h-44 lg:w-26 lg:h-52" />
 			</div>
 
-			<!-- Garden gate — center-right -->
-			<div class="absolute bottom-[6%] right-[50%] md:right-[55%]">
-				<GardenGate class="w-14 h-16 md:w-18 md:h-22 opacity-75" />
+			<!-- Secondary pine — smaller, right -->
+			<div class="absolute bottom-[10%] right-[8%] md:right-[14%]">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="w-10 h-20 md:w-16 md:h-32 lg:w-18 lg:h-36 opacity-65" />
 			</div>
 
-			<!-- Butterfly — upper right -->
-			<div class="absolute top-[22%] right-[18%]">
-				<Butterfly animate={active} class="w-7 h-7 md:w-9 md:h-9" />
+			<!-- Standing lantern — warm glow in the clearing -->
+			<div class="absolute bottom-[7%] right-[18%] md:right-[24%]">
+				<Lantern animate={active} class="w-4 h-7 md:w-5 md:h-9 lg:w-6 lg:h-11" variant="standing" />
 			</div>
 
-			<!-- Foliage — spread across bottom -->
-			<div class="absolute bottom-[4%] right-[10%]">
-				<Fern class="w-10 h-8 md:w-12 md:h-10 opacity-65" />
+			<!-- === TABLET+ (md) === -->
+
+			<!-- Back pine — small, atmospheric depth -->
+			<div class="absolute bottom-[12%] right-[48%] md:right-[52%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.meadow} trunkColor={bark.warmBark} class="md:w-18 md:h-36 lg:w-22 lg:h-44" />
 			</div>
-			<div class="absolute bottom-[6%] left-[35%] md:left-[45%]">
-				<Bush {season} class="w-16 h-12 opacity-50" />
+
+			<!-- Far back pine — distant, muted -->
+			<div class="absolute bottom-[13%] right-[5%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="md:w-10 md:h-20 lg:w-12 lg:h-24 opacity-40" />
 			</div>
-			<div class="absolute bottom-[3%] right-[40%] hidden md:block">
-				<Fern class="w-8 h-6 opacity-40" />
+
+			<!-- === DESKTOP (lg) === -->
+
+			<!-- Extra depth pine — far left of scene -->
+			<div class="absolute bottom-[14%] right-[62%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="lg:w-10 lg:h-20 opacity-30" />
+			</div>
+
+			<!-- Mid-ground accent pine -->
+			<div class="absolute bottom-[10%] right-[42%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="lg:w-14 lg:h-28 opacity-55" />
+			</div>
+
+			<!-- Second lantern — further back -->
+			<div class="absolute bottom-[9%] right-[55%] hidden lg:block">
+				<Lantern animate={active} class="lg:w-4 lg:h-7 opacity-60" variant="post" />
 			</div>
 		</div>
 	{/snippet}

--- a/packages/landing/src/lib/components/hero/HeroRefuge.svelte
+++ b/packages/landing/src/lib/components/hero/HeroRefuge.svelte
@@ -1,20 +1,18 @@
 <!--
-  HeroRefuge — "Your words deserve room to bloom"
-  The growth catalyst. Grove Logo center, TreePine + TreeCherry flanking,
-  Fireflies ambient, GrassTuft + Mushroom on the ground.
+  HeroRefuge — "Your words deserve room to bloom."
+  The growth catalyst. Trees arranged small-to-large (right to left)
+  telling a visual growth story. Lanterns light the path.
+  More trees and lanterns revealed on larger screens.
 -->
 <script lang="ts">
 	import type { HeroSlideContentProps } from './hero-types';
 	import HeroSlide from './HeroSlide.svelte';
 	import { Sprout } from 'lucide-svelte';
 	import {
-		Logo,
 		TreePine,
-		TreeCherry,
-		Firefly,
-		GrassTuft,
-		Mushroom
+		Lantern
 	} from '@autumnsgrove/groveengine/ui/nature';
+	import { greens, bark } from '@autumnsgrove/groveengine/ui/nature';
 
 	let { season, active, index }: HeroSlideContentProps = $props();
 </script>
@@ -39,42 +37,62 @@
 
 	{#snippet scene()}
 		<div class="relative w-full h-full">
-			<!-- Background trees — spread across full canvas, weighted right -->
-			<div class="absolute bottom-[8%] left-[15%] md:left-[35%]">
-				<TreePine {season} animate={active} class="w-14 h-24 md:w-20 md:h-36 opacity-50" />
-			</div>
-			<div class="absolute bottom-[8%] right-[8%] md:right-[12%]">
-				<TreeCherry {season} animate={active} class="w-16 h-24 md:w-20 md:h-36 opacity-55" />
-			</div>
-			<div class="absolute bottom-[8%] right-[28%] hidden md:block">
-				<TreePine {season} animate={active} class="w-14 h-28 opacity-40" />
+			<!-- Growth story: small → large, right → left -->
+
+			<!-- === ALWAYS VISIBLE (mobile+) === -->
+
+			<!-- Sapling — smallest, far right -->
+			<div class="absolute bottom-[11%] right-[8%] md:right-[10%]">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.bark} class="w-6 h-12 md:w-8 md:h-16 lg:w-10 lg:h-20 opacity-50" />
 			</div>
 
-			<!-- Center logo — focal point, shifted right on desktop -->
-			<div class="absolute bottom-[25%] right-[20%] md:right-[30%]">
-				<Logo size={72} {season} />
+			<!-- Young tree — growing -->
+			<div class="absolute bottom-[9%] right-[22%] md:right-[24%]">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="w-10 h-20 md:w-14 md:h-28 lg:w-16 lg:h-32 opacity-70" />
 			</div>
 
-			<!-- Ground elements — spread wide -->
-			<div class="absolute bottom-[4%] left-[40%] md:left-[45%]">
-				<GrassTuft class="w-10 h-5 md:w-12 md:h-6 opacity-60" />
-			</div>
-			<div class="absolute bottom-[3%] right-[18%]">
-				<Mushroom class="w-6 h-6 md:w-7 md:h-7" />
-			</div>
-			<div class="absolute bottom-[4%] right-[35%]">
-				<GrassTuft class="w-8 h-4 opacity-45" />
+			<!-- Established tree — medium -->
+			<div class="absolute bottom-[7%] right-[38%] md:right-[40%]">
+				<TreePine {season} animate={active} color={greens.grove} trunkColor={bark.warmBark} class="w-14 h-28 md:w-20 md:h-40 lg:w-24 lg:h-48" />
 			</div>
 
-			<!-- Fireflies — scattered across the full canvas -->
-			<div class="absolute top-[18%] right-[25%]">
-				<Firefly animate={active} class="w-2.5 h-2.5" intensity="subtle" />
+			<!-- Lantern — marking the path of growth -->
+			<div class="absolute bottom-[8%] right-[30%] md:right-[32%]">
+				<Lantern animate={active} class="w-4 h-7 md:w-5 md:h-9 lg:w-5 lg:h-9" variant="standing" />
 			</div>
-			<div class="absolute top-[35%] right-[15%]">
-				<Firefly animate={active} class="w-2 h-2" intensity="subtle" />
+
+			<!-- === TABLET+ (md) — the mature tree appears === -->
+
+			<!-- Mature tree — tallest, completing the growth arc -->
+			<div class="absolute bottom-[6%] right-[52%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.meadow} trunkColor={bark.warmBark} class="md:w-22 md:h-44 lg:w-28 lg:h-54" />
 			</div>
-			<div class="absolute top-[12%] left-[45%] md:left-[55%]">
-				<Firefly animate={active} class="w-3 h-3" intensity="normal" />
+
+			<!-- Second lantern — near the young tree -->
+			<div class="absolute bottom-[9%] right-[16%] hidden md:block">
+				<Lantern animate={active} class="md:w-4 md:h-7 lg:w-4 lg:h-7 opacity-65" variant="standing" />
+			</div>
+
+			<!-- Background tiny sapling — suggests the cycle continues -->
+			<div class="absolute bottom-[13%] right-[3%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="md:w-5 md:h-10 lg:w-6 lg:h-12 opacity-30" />
+			</div>
+
+			<!-- === DESKTOP (lg) — full growth story with depth === -->
+
+			<!-- Ancient tree — the grandest, far left -->
+			<div class="absolute bottom-[5%] right-[65%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.spring} trunkColor={bark.warmBark} class="lg:w-30 lg:h-58 opacity-90" />
+			</div>
+
+			<!-- Background depth pine — behind the arc -->
+			<div class="absolute bottom-[14%] right-[45%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="lg:w-10 lg:h-20 opacity-25" />
+			</div>
+
+			<!-- Third lantern — near the ancient tree -->
+			<div class="absolute bottom-[5%] right-[58%] hidden lg:block">
+				<Lantern animate={active} class="lg:w-5 lg:h-9 opacity-60" variant="post" />
 			</div>
 		</div>
 	{/snippet}

--- a/packages/landing/src/lib/components/hero/HeroShade.svelte
+++ b/packages/landing/src/lib/components/hero/HeroShade.svelte
@@ -1,24 +1,22 @@
 <!--
-  HeroShade — Slide 3: "Your words are not a dataset"
-  AI protection — the shield. Dense canopy with 2× TreePine + TreeCherry,
-  Cardinal perched, falling leaves, bushes, warm/amber mood.
+  HeroShade — "Your words are not a dataset."
+  AI protection — the shield. A dense canopy of pines, protective
+  and sheltering. Trees layered dark-to-light for atmospheric depth.
+  Dense on tablet+, protective wall on desktop.
 -->
 <script lang="ts">
 	import type { HeroSlideContentProps } from './hero-types';
 	import HeroSlide from './HeroSlide.svelte';
 	import { Shield } from 'lucide-svelte';
 	import {
-		TreePine,
-		TreeCherry,
-		Cardinal,
-		Bush,
-		LeafFalling
+		TreePine
 	} from '@autumnsgrove/groveengine/ui/nature';
+	import { greens, bark } from '@autumnsgrove/groveengine/ui/nature';
 
 	let { season, active, index }: HeroSlideContentProps = $props();
 </script>
 
-<HeroSlide {season} {active} bgVariant="warm" ariaLabel="Your words are not a dataset — Shade AI protection">
+<HeroSlide {season} {active} bgVariant="forest" ariaLabel="Your words are not a dataset — Shade AI protection">
 	{#snippet text()}
 		<h2 class="text-2xl sm:text-display-sm md:text-display lg:text-display-lg text-foreground motion-safe:animate-fade-in-up">
 			Your words are not a dataset.
@@ -38,36 +36,55 @@
 
 	{#snippet scene()}
 		<div class="relative w-full h-full">
-			<!-- Dense canopy — trees spread across canvas, weighted right for shelter feel -->
-			<div class="absolute bottom-[8%] left-[25%] md:left-[38%]">
-				<TreePine {season} animate={active} class="w-16 h-28 md:w-22 md:h-40" />
-			</div>
-			<div class="absolute bottom-[8%] right-[8%] md:right-[10%]">
-				<TreePine {season} animate={active} class="w-14 h-24 md:w-18 md:h-34 opacity-75" />
-			</div>
-			<div class="absolute bottom-[8%] right-[25%] md:right-[28%]">
-				<TreeCherry {season} animate={active} class="w-18 h-30 md:w-24 md:h-42" />
+			<!-- === ALWAYS VISIBLE (mobile+) — core canopy === -->
+
+			<!-- Left pine — medium -->
+			<div class="absolute bottom-[8%] left-[22%] md:left-[38%]">
+				<TreePine {season} animate={active} color={greens.grove} trunkColor={bark.warmBark} class="w-14 h-28 md:w-20 md:h-40 lg:w-24 lg:h-48" />
 			</div>
 
-			<!-- Cardinal perched — upper right -->
-			<div class="absolute top-[20%] right-[18%]">
-				<Cardinal animate={active} class="w-7 h-7 md:w-9 md:h-9" facing="left" />
+			<!-- Center pine — tallest -->
+			<div class="absolute bottom-[7%] right-[25%] md:right-[30%]">
+				<TreePine {season} animate={active} color={greens.meadow} trunkColor={bark.warmBark} class="w-16 h-32 md:w-22 md:h-44 lg:w-26 lg:h-52" />
 			</div>
 
-			<!-- Falling leaves — scattered across canopy -->
-			<div class="absolute top-[12%] right-[35%]">
-				<LeafFalling {season} animate={active} class="w-4 h-4" variant="maple" delay={0} />
-			</div>
-			<div class="absolute top-[8%] right-[20%]">
-				<LeafFalling {season} animate={active} class="w-3.5 h-3.5" variant="cherry" delay={1.5} />
+			<!-- Right pine — slightly smaller -->
+			<div class="absolute bottom-[9%] right-[5%] md:right-[10%]">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="w-11 h-22 md:w-16 md:h-32 lg:w-18 lg:h-36 opacity-70" />
 			</div>
 
-			<!-- Ground bushes — wide spread -->
-			<div class="absolute bottom-[4%] left-[30%] md:left-[42%]">
-				<Bush {season} class="w-14 h-10 md:w-18 md:h-12 opacity-65" />
+			<!-- === TABLET+ (md) — fill out the canopy === -->
+
+			<!-- Back-left pine — depth -->
+			<div class="absolute bottom-[12%] left-[30%] md:left-[34%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="md:w-12 md:h-24 lg:w-14 lg:h-28 opacity-45" />
 			</div>
-			<div class="absolute bottom-[3%] right-[15%]">
-				<Bush {season} class="w-12 h-8 opacity-45" />
+
+			<!-- Back-right pine — fills gap -->
+			<div class="absolute bottom-[11%] right-[18%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.deepGreen} trunkColor={bark.bark} class="md:w-14 md:h-28 lg:w-16 lg:h-32 opacity-55" />
+			</div>
+
+			<!-- Far right accent -->
+			<div class="absolute bottom-[13%] right-[3%] hidden md:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="md:w-9 md:h-18 lg:w-11 lg:h-22 opacity-35" />
+			</div>
+
+			<!-- === DESKTOP (lg) — dense protective wall === -->
+
+			<!-- Extra back pine — leftmost -->
+			<div class="absolute bottom-[14%] left-[28%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="lg:w-10 lg:h-20 opacity-30" />
+			</div>
+
+			<!-- Fill pine — between left and center -->
+			<div class="absolute bottom-[9%] right-[42%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.grove} trunkColor={bark.warmBark} class="lg:w-16 lg:h-34 opacity-65" />
+			</div>
+
+			<!-- Far background pine — barely visible, adds depth -->
+			<div class="absolute bottom-[15%] right-[50%] hidden lg:block">
+				<TreePine {season} animate={active} color={greens.darkForest} trunkColor={bark.darkBark} class="lg:w-8 lg:h-16 opacity-25" />
 			</div>
 		</div>
 	{/snippet}

--- a/packages/landing/src/lib/components/hero/HeroSlide.svelte
+++ b/packages/landing/src/lib/components/hero/HeroSlide.svelte
@@ -45,14 +45,14 @@
 	<!-- Layer 2: Gradient veil for text readability -->
 	<div class="absolute inset-0 pointer-events-none
 		bg-gradient-to-t from-white/80 via-white/40 to-transparent
-		dark:from-slate-900/85 dark:via-slate-900/40 dark:to-transparent
+		dark:from-emerald-950/85 dark:via-emerald-950/40 dark:to-transparent
 		md:bg-gradient-to-r md:from-white/75 md:via-white/30 md:to-transparent
-		md:dark:from-slate-900/80 md:dark:via-slate-900/30 md:dark:to-transparent">
+		md:dark:from-emerald-950/80 md:dark:via-emerald-950/30 md:dark:to-transparent">
 	</div>
 
 	<!-- Layer 3: Text overlay -->
 	<div class="relative z-10 w-full h-full flex flex-col justify-end md:justify-center
-		px-16 pt-5 pb-14 md:p-8 lg:p-10 md:max-w-[55%]">
+		px-6 pt-5 pb-14 md:px-8 lg:px-10 md:max-w-[55%]">
 		<Lexend as="div" class="flex flex-col gap-2.5 md:gap-3">
 			{@render text()}
 		</Lexend>

--- a/packages/landing/src/lib/components/hero/hero-types.ts
+++ b/packages/landing/src/lib/components/hero/hero-types.ts
@@ -1,6 +1,6 @@
 import type { Season } from "@autumnsgrove/groveengine/ui/nature";
 
-export type BgVariant = "forest" | "twilight" | "dawn" | "warm" | "mist";
+export type BgVariant = "forest" | "twilight" | "dawn";
 
 export interface HeroSlideContentProps {
   season: Season;
@@ -10,17 +10,20 @@ export interface HeroSlideContentProps {
 
 /**
  * Maps a bgVariant to its Tailwind gradient classes.
- * Extracted as a pure function for testability.
+ * Warmer, nature-rooted gradients inspired by the forest page.
+ *
+ * - forest: Deep grove greens — growth, ownership, protection
+ * - twilight: Warm indigo with green undertones — legacy, timelessness
+ * - dawn: Golden amber through soft rose — community, home, warmth
  */
 export function getGradientClasses(variant: BgVariant): string {
   const variants: Record<BgVariant, string> = {
     forest:
-      "from-emerald-50/80 via-green-50/60 to-emerald-100/40 dark:from-emerald-950/60 dark:via-green-950/40 dark:to-emerald-900/30",
+      "from-emerald-50/90 via-green-100/70 to-emerald-50/50 dark:from-emerald-950/70 dark:via-green-950/50 dark:to-emerald-900/40",
     twilight:
-      "from-indigo-50/80 via-slate-50/60 to-violet-100/40 dark:from-indigo-950/60 dark:via-slate-950/40 dark:to-violet-900/30",
-    dawn: "from-amber-50/80 via-orange-50/60 to-rose-100/40 dark:from-amber-950/60 dark:via-orange-950/40 dark:to-rose-900/30",
-    warm: "from-amber-50/80 via-yellow-50/60 to-orange-100/40 dark:from-amber-950/60 dark:via-yellow-950/40 dark:to-orange-900/30",
-    mist: "from-slate-50/80 via-blue-50/60 to-cyan-100/40 dark:from-slate-950/60 dark:via-blue-950/40 dark:to-cyan-900/30",
+      "from-indigo-50/80 via-emerald-50/50 to-slate-100/60 dark:from-indigo-950/60 dark:via-emerald-950/30 dark:to-slate-900/40",
+    dawn:
+      "from-amber-50/85 via-orange-50/60 to-emerald-50/40 dark:from-amber-950/60 dark:via-orange-950/35 dark:to-emerald-950/30",
   };
   return variants[variant];
 }

--- a/packages/landing/src/lib/components/hero/hero.test.ts
+++ b/packages/landing/src/lib/components/hero/hero.test.ts
@@ -28,42 +28,21 @@ describe("getGradientClasses", () => {
     expect(classes).toContain("to-emerald");
   });
 
-  it("returns indigo gradient for twilight variant", () => {
+  it("returns indigo gradient with emerald tones for twilight variant", () => {
     const classes = getGradientClasses("twilight");
     expect(classes).toContain("from-indigo");
-    expect(classes).toContain("via-slate");
-    expect(classes).toContain("to-violet");
+    expect(classes).toContain("via-emerald");
   });
 
-  it("returns amber/rose gradient for dawn variant", () => {
+  it("returns amber/orange gradient with emerald for dawn variant", () => {
     const classes = getGradientClasses("dawn");
     expect(classes).toContain("from-amber");
     expect(classes).toContain("via-orange");
-    expect(classes).toContain("to-rose");
-  });
-
-  it("returns amber/orange gradient for warm variant", () => {
-    const classes = getGradientClasses("warm");
-    expect(classes).toContain("from-amber");
-    expect(classes).toContain("via-yellow");
-    expect(classes).toContain("to-orange");
-  });
-
-  it("returns slate/cyan gradient for mist variant", () => {
-    const classes = getGradientClasses("mist");
-    expect(classes).toContain("from-slate");
-    expect(classes).toContain("via-blue");
-    expect(classes).toContain("to-cyan");
+    expect(classes).toContain("to-emerald");
   });
 
   it("every variant includes dark mode classes", () => {
-    const variants: BgVariant[] = [
-      "forest",
-      "twilight",
-      "dawn",
-      "warm",
-      "mist",
-    ];
+    const variants: BgVariant[] = ["forest", "twilight", "dawn"];
 
     for (const variant of variants) {
       const classes = getGradientClasses(variant);
@@ -73,27 +52,15 @@ describe("getGradientClasses", () => {
     }
   });
 
-  it("all five variants produce distinct gradient classes", () => {
-    const variants: BgVariant[] = [
-      "forest",
-      "twilight",
-      "dawn",
-      "warm",
-      "mist",
-    ];
+  it("all three variants produce distinct gradient classes", () => {
+    const variants: BgVariant[] = ["forest", "twilight", "dawn"];
     const results = variants.map(getGradientClasses);
     const unique = new Set(results);
-    expect(unique.size).toBe(5);
+    expect(unique.size).toBe(3);
   });
 
   it("uses opacity modifiers for glass layering effect", () => {
-    const variants: BgVariant[] = [
-      "forest",
-      "twilight",
-      "dawn",
-      "warm",
-      "mist",
-    ];
+    const variants: BgVariant[] = ["forest", "twilight", "dawn"];
 
     for (const variant of variants) {
       const classes = getGradientClasses(variant);
@@ -112,39 +79,44 @@ describe("Slide Configuration", () => {
   /**
    * Each slide's expected configuration — documents the contract
    * between the hero components and the carousel.
+   *
+   * Updated to reflect the redesigned hero section:
+   * - Trees + lanterns only (removed cluttered nature elements)
+   * - Reduced to 3 warm, forest-rooted gradient variants
+   * - Responsive density (more elements on larger screens)
    */
   const slideConfig = [
     {
-      name: "HeroRefuge",
+      name: "HeroOwnership",
       index: 0,
       bgVariant: "forest" as BgVariant,
-      headline: "A grove for people who lost their groves",
-      ctaHref: "https://plant.grove.place",
-      ctaText: "Plant Your Blog",
-    },
-    {
-      name: "HeroOwnership",
-      index: 1,
-      bgVariant: "mist" as BgVariant,
       headline: "Your words. Your space. Forever.",
       ctaHref: "/pricing",
       ctaText: "Claim Yours",
     },
     {
       name: "HeroShade",
-      index: 2,
-      bgVariant: "warm" as BgVariant,
+      index: 1,
+      bgVariant: "forest" as BgVariant,
       headline: "Your words are not a dataset",
       ctaHref: "/knowledge/help/what-is-shade",
       ctaText: "Learn About Shade",
     },
     {
       name: "HeroCentennial",
-      index: 3,
+      index: 2,
       bgVariant: "twilight" as BgVariant,
       headline: "Some trees outlive the people who planted them",
       ctaHref: "/knowledge/help/what-is-centennial",
       ctaText: "Plant Your Legacy",
+    },
+    {
+      name: "HeroRefuge",
+      index: 3,
+      bgVariant: "forest" as BgVariant,
+      headline: "Your words deserve room to bloom",
+      ctaHref: "https://plant.grove.place",
+      ctaText: "Plant Your Blog",
     },
     {
       name: "HeroCommunity",
@@ -163,12 +135,6 @@ describe("Slide Configuration", () => {
   it("each slide has a unique index from 0-4", () => {
     const indices = slideConfig.map((s) => s.index);
     expect(indices).toEqual([0, 1, 2, 3, 4]);
-  });
-
-  it("each slide uses a distinct bgVariant", () => {
-    const variants = slideConfig.map((s) => s.bgVariant);
-    const unique = new Set(variants);
-    expect(unique.size).toBe(5);
   });
 
   it("all bgVariants produce valid gradient classes", () => {
@@ -200,12 +166,10 @@ describe("Slide Configuration", () => {
     }
   });
 
-  it("internal CTAs use knowledge base paths", () => {
-    const internal = slideConfig.filter(
-      (s) => s.ctaHref.startsWith("/") && s.ctaHref !== "/pricing",
-    );
+  it("internal CTAs use knowledge base paths or pricing", () => {
+    const internal = slideConfig.filter((s) => s.ctaHref.startsWith("/"));
     for (const slide of internal) {
-      expect(slide.ctaHref).toMatch(/^\/knowledge\//);
+      expect(slide.ctaHref).toMatch(/^\/(knowledge\/|pricing)/);
     }
   });
 });
@@ -215,28 +179,28 @@ describe("Slide Configuration", () => {
 // =============================================================================
 
 describe("BgVariant type coverage", () => {
-  it("handles all five variants without throwing", () => {
-    const variants: BgVariant[] = [
-      "forest",
-      "twilight",
-      "dawn",
-      "warm",
-      "mist",
-    ];
+  it("handles all three variants without throwing", () => {
+    const variants: BgVariant[] = ["forest", "twilight", "dawn"];
 
     for (const variant of variants) {
       expect(() => getGradientClasses(variant)).not.toThrow();
     }
   });
 
-  it("dawn and warm variants are visually distinct despite sharing amber", () => {
+  it("twilight and dawn variants are visually distinct from forest", () => {
+    const forest = getGradientClasses("forest");
+    const twilight = getGradientClasses("twilight");
     const dawn = getGradientClasses("dawn");
-    const warm = getGradientClasses("warm");
 
-    // Both use from-amber, but diverge on via and to
-    expect(dawn).toContain("via-orange");
-    expect(dawn).toContain("to-rose");
-    expect(warm).toContain("via-yellow");
-    expect(warm).toContain("to-orange");
+    // Forest is pure emerald/green
+    expect(forest).toContain("from-emerald");
+    // Twilight has indigo character
+    expect(twilight).toContain("from-indigo");
+    // Dawn has amber warmth
+    expect(dawn).toContain("from-amber");
+
+    // All share emerald undertones for cohesion
+    expect(twilight).toContain("emerald");
+    expect(dawn).toContain("emerald");
   });
 });


### PR DESCRIPTION
- Strip all cluttered nature elements (butterflies, cardinals, garden gates,
  ferns, bushes, ponds, rabbits, mushrooms, stone paths, reeds, lily pads)
- Use only TreePine and Lantern components — the best-looking assets
- Pass explicit palette colors (greens.grove, greens.deepGreen, etc.) to trees
  instead of relying on defaults, inspired by /forest page depth system
- Add responsive density: mobile shows 2-3 trees, tablet 4-5, desktop 6-8+
  using hidden md:block / hidden lg:block progressive reveal
- Trees scale up on larger breakpoints (lg:w-26 lg:h-52 etc.)
- Warm up background gradients: replace cold mist/warm/slate variants with
  forest-rooted emerald tones that share green undertones across all variants
- Dark mode veil uses emerald-950 instead of cold slate-900
- Reduce mobile text padding from px-16 to px-6 to prevent cramping
- Update hero.test.ts for new 3-variant BgVariant system (all 15 tests pass)

Each slide tells a visual story:
  - Ownership: clearing with lantern (welcoming)
  - Shade: dense protective canopy wall
  - Centennial: grand sentinel pine with lanterns (legacy)
  - Refuge: growth arc from sapling to ancient tree
  - Community: neighborly grove with gathering lanterns