### PR TITLE
fix(ui): remove font-sans override on navbar so nav items respect font settings

### DIFF
--- a/packages/engine/src/lib/ui/components/chrome/Header.svelte
+++ b/packages/engine/src/lib/ui/components/chrome/Header.svelte
@@ -194,7 +194,7 @@
 		</div>
 
 		<!-- Desktop navigation -->
-		<nav aria-label="Main navigation" class="hidden md:flex items-center gap-4 lg:gap-6 text-sm font-sans">
+		<nav aria-label="Main navigation" class="hidden md:flex items-center gap-4 lg:gap-6 text-sm">
 			{#each items as item}
 				<a
 					href={item.href}


### PR DESCRIPTION
The desktop nav in Header.svelte had Tailwind's `font-sans` class, which
explicitly set the system font stack and prevented nav links from inheriting
the user's chosen font via `--font-family-main` on the body.

https://claude.ai/code/session_014CqKn3nAYCxCDYGJGwUMfz