### PR TITLE
fix(ui): replace emojis with SVG icons, fix text readability and font in settings

### DIFF
--- a/packages/engine/src/lib/grafts/greenhouse/GraftControlPanel.svelte
+++ b/packages/engine/src/lib/grafts/greenhouse/GraftControlPanel.svelte
@@ -20,7 +20,7 @@
 	import type { GraftControlPanelProps } from "./types.js";
 	import GraftToggleRow from "./GraftToggleRow.svelte";
 	import { GlassCard, Button, Waystone } from "$lib/ui";
-	import { Sprout, RotateCcw, Sparkles, FlaskConical } from "lucide-svelte";
+	import { Sprout, RotateCcw, Sparkles, FlaskConical, Leaf } from "lucide-svelte";
 
 	let {
 		grafts,
@@ -82,12 +82,12 @@
 			<!-- Stats -->
 			<div class="stats">
 				<span class="stat enabled">
-					<span class="stat-icon">🌿</span>
+					<span class="stat-icon"><Sprout size={20} /></span>
 					<span class="stat-value">{enabledCount}</span>
 					<span class="stat-label">Enabled</span>
 				</span>
 				<span class="stat total">
-					<span class="stat-icon">🌱</span>
+					<span class="stat-icon"><Leaf size={20} /></span>
 					<span class="stat-value">{grafts.length}</span>
 					<span class="stat-label">Available</span>
 				</span>
@@ -240,7 +240,14 @@
 	}
 
 	.stat-icon {
-		font-size: 1.25rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--color-text-muted);
+	}
+
+	.stat.enabled .stat-icon {
+		color: var(--color-primary);
 	}
 
 	.stat-value {

--- a/packages/engine/src/lib/grafts/greenhouse/GraftToggleRow.svelte
+++ b/packages/engine/src/lib/grafts/greenhouse/GraftToggleRow.svelte
@@ -16,6 +16,7 @@
 
 	import type { GraftToggleRowProps } from "./types.js";
 	import GreenhouseToggle from "./GreenhouseToggle.svelte";
+	import { Sprout, Leaf } from "lucide-svelte";
 
 	let {
 		graft,
@@ -42,9 +43,9 @@
 	<div class="graft-content">
 		<div class="graft-icon" class:enabled={graft.enabled}>
 			{#if graft.enabled}
-				<span title="Enabled">🌿</span>
+				<Sprout size={18} />
 			{:else}
-				<span title="Disabled">🌱</span>
+				<Leaf size={18} />
 			{/if}
 		</div>
 
@@ -108,17 +109,18 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		font-size: 1.25rem;
 		flex-shrink: 0;
 		width: 32px;
 		height: 32px;
 		border-radius: var(--border-radius-button);
 		background: var(--grove-overlay-10);
+		color: var(--color-text-muted);
 		transition: all 0.2s ease;
 	}
 
 	.graft-icon.enabled {
 		background: rgba(16, 185, 129, 0.15);
+		color: var(--color-primary);
 	}
 
 	.graft-info {

--- a/packages/engine/src/lib/grafts/greenhouse/GreenhouseStatusCard.svelte
+++ b/packages/engine/src/lib/grafts/greenhouse/GreenhouseStatusCard.svelte
@@ -53,7 +53,7 @@
 
 			<!-- Content -->
 			<div class="flex-1 min-w-0">
-				<h3 class="text-lg font-serif text-bark dark:text-cream">
+				<h3 class="text-lg font-semibold" style="color: var(--color-text)">
 					{#if inGreenhouse}
 						Greenhouse Member
 					{:else}
@@ -61,7 +61,7 @@
 					{/if}
 				</h3>
 
-				<p class="text-sm text-bark/60 dark:text-cream/60 mt-1">
+				<p class="text-sm mt-1" style="color: var(--color-text-muted)">
 					{#if inGreenhouse}
 						You're part of Grove's greenhouse program! You'll get early access
 						to experimental features before they're released to everyone.
@@ -72,7 +72,7 @@
 				</p>
 
 				{#if inGreenhouse && formattedDate}
-					<p class="text-xs text-bark/40 dark:text-cream/40 mt-2">
+					<p class="text-xs mt-2" style="color: var(--color-text-subtle)">
 						Enrolled since {formattedDate}
 					</p>
 				{/if}

--- a/packages/engine/src/routes/arbor/settings/+page.svelte
+++ b/packages/engine/src/routes/arbor/settings/+page.svelte
@@ -247,7 +247,7 @@
       });
 
       logoMessage = showGroveLogo
-        ? "Grove logo enabled! Tap it to cycle through seasons. 🌲"
+        ? "Grove logo enabled! Tap it to cycle through seasons."
         : "Grove logo hidden from header.";
     } catch (error) {
       logoMessage =
@@ -387,8 +387,8 @@
       if (result.type === "success") {
         toast.success(
           enabled
-            ? `🌿 ${graftId.replace(/_/g, " ")} enabled!`
-            : `🌱 ${graftId.replace(/_/g, " ")} disabled`,
+            ? `${graftId.replace(/_/g, " ")} enabled`
+            : `${graftId.replace(/_/g, " ")} disabled`,
         );
         await invalidateAll();
       } else {
@@ -414,7 +414,7 @@
 
       const result = await response.json();
       if (result.type === "success") {
-        toast.success("🌱 Reset to default settings");
+        toast.success("Reset to default settings");
         await invalidateAll();
       } else {
         toast.error(result.data?.error || "Failed to reset preferences");
@@ -451,7 +451,7 @@
 
       const result = await response.json();
       if (result.type === "success") {
-        toast.success("🌱 Tenant enrolled in greenhouse");
+        toast.success("Tenant enrolled in greenhouse");
         adminFormResult = { success: true, message: result.data?.message };
         await invalidateAll();
       } else {
@@ -490,8 +490,8 @@
       if (result.type === "success") {
         toast.success(
           enabled
-            ? "🌿 Greenhouse access enabled"
-            : "🌱 Greenhouse access disabled",
+            ? "Greenhouse access enabled"
+            : "Greenhouse access disabled",
         );
         await invalidateAll();
       } else {
@@ -550,7 +550,7 @@
 
       const result = await response.json();
       if (result.type === "success") {
-        toast.success(`🌿 ${flagId} is now cultivated`);
+        toast.success(`${flagId} is now cultivated`);
         await invalidateAll();
       } else {
         toast.error(result.data?.error || "Failed to cultivate flag");
@@ -580,7 +580,7 @@
 
       const result = await response.json();
       if (result.type === "success") {
-        toast.success(`🍂 ${flagId} is now pruned`);
+        toast.success(`${flagId} is now pruned`);
         await invalidateAll();
       } else {
         toast.error(result.data?.error || "Failed to prune flag");


### PR DESCRIPTION
- Replace emoji characters (🌿🌱🍂🌲) with Lucide SVG icons (Sprout, Leaf)
  in GraftControlPanel and GraftToggleRow for consistent visual language
- Remove emoji prefixes from all toast messages in settings page
- Fix GreenhouseStatusCard dark mode text: replace text-bark/dark:text-cream
  with CSS variable approach (--color-text, --color-text-muted) matching the
  rest of the admin panel
- Remove font-serif from GreenhouseStatusCard heading to use the site's
  configured font instead of falling back to Times New Roman

https://claude.ai/code/session_01Bn2CYvS522QG1Dqw8TLYg1