### PR TITLE
fix(arbor): fix mobile sidebar gap and boxy appearance

### DIFF
--- a/packages/engine/src/routes/arbor/+layout.svelte
+++ b/packages/engine/src/routes/arbor/+layout.svelte
@@ -780,6 +780,15 @@
       left: 0;
       bottom: 0;
       border-radius: 0;
+      /* Reset desktop constraints so sidebar fills full viewport height */
+      height: 100vh;
+      height: 100dvh; /* Dynamic viewport height — accounts for mobile browser chrome */
+      max-height: none;
+      /* Remove the floating-card border on mobile — edge-to-edge panel */
+      border-right: 1px solid var(--grove-overlay-15);
+      border-top: none;
+      border-bottom: none;
+      border-left: none;
     }
 
     .sidebar.open {


### PR DESCRIPTION
The mobile sidebar had three issues:
- max-height from desktop styles wasn't reset, causing a visible gap
  at the bottom of the viewport
- Used 100vh which doesn't account for mobile browser chrome (address
  bar, bottom nav), switched to 100dvh with vh fallback
- Full-border glass card styling looked boxy on a full-edge panel,
  replaced with a subtle right-edge border only

https://claude.ai/code/session_01BhHkNLVQBaEuJkzE8kq3J9