### PR TITLE
fix(csp): add blob: to img-src directive to unblock image uploads

### DIFF
--- a/packages/domains/src/hooks.server.ts
+++ b/packages/domains/src/hooks.server.ts
@@ -255,7 +255,7 @@ function addSecurityHeaders(response: Response): Response {
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
     "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' https://cdn.grove.place data:",
+    "img-src 'self' https://cdn.grove.place data: blob:",
     "connect-src 'self' https://*.grove.place",
     "frame-src https://challenges.cloudflare.com",
     "frame-ancestors 'none'",

--- a/packages/engine/src/hooks.server.ts
+++ b/packages/engine/src/hooks.server.ts
@@ -712,7 +712,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     "upgrade-insecure-requests",
     `script-src ${scriptSrc}`,
     "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' https://cdn.grove.place data:",
+    "img-src 'self' https://cdn.grove.place data: blob:",
     "font-src 'self' https://cdn.grove.place",
     "connect-src 'self' https://api.github.com https://grove.place https://*.grove.place https://challenges.cloudflare.com",
     "frame-src https://challenges.cloudflare.com",

--- a/packages/heartwood/src/utils/constants.ts
+++ b/packages/heartwood/src/utils/constants.ts
@@ -66,7 +66,7 @@ export const SECURITY_HEADERS = {
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
   "Content-Security-Policy":
-    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self'",
+    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; font-src 'self'",
 };
 
 // Stricter CSP for security-sensitive pages (passkey management, settings)
@@ -74,7 +74,7 @@ export const SECURITY_HEADERS = {
 // - Explicitly denies frame-ancestors to prevent clickjacking on security pages
 // - Adds upgrade-insecure-requests for mixed content protection
 export const SECURITY_PAGE_CSP =
-  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests";
+  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; font-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests";
 
 // Allowed OAuth scopes
 export const GOOGLE_SCOPES = ["openid", "email", "profile"];

--- a/packages/landing/src/hooks.server.ts
+++ b/packages/landing/src/hooks.server.ts
@@ -173,7 +173,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
     "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' https://cdn.grove.place data:",
+    "img-src 'self' https://cdn.grove.place data: blob:",
     "font-src 'self' https://cdn.grove.place",
     "connect-src 'self' https://*.grove.place https://challenges.cloudflare.com",
     "frame-src https://challenges.cloudflare.com",

--- a/packages/plant/src/hooks.server.ts
+++ b/packages/plant/src/hooks.server.ts
@@ -45,7 +45,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
     "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' https://cdn.grove.place data:",
+    "img-src 'self' https://cdn.grove.place data: blob:",
     "frame-src https://challenges.cloudflare.com",
     "connect-src 'self' https://*.grove.place https://api.lemonsqueezy.com",
     "frame-ancestors 'none'",


### PR DESCRIPTION
The CSP img-src directive was missing blob:, which caused the browser
to silently block all blob: URLs created by URL.createObjectURL() in
the image upload pipeline. This made loadImage() fail with onerror for
every image type — the browser couldn't load the blob URL into an
HTMLImageElement regardless of format, producing the "Failed to load
image" error on every upload attempt.

https://claude.ai/code/session_01Bfee3zdCQkSvo2itZFntGb