### PR TITLE
fix(auth): prevent OAuth redirect following in service binding

### DIFF
--- a/packages/login/src/lib/proxy.ts
+++ b/packages/login/src/lib/proxy.ts
@@ -134,6 +134,7 @@ export async function proxyToHeartwood(
     body: ["GET", "HEAD"].includes(request.method)
       ? undefined
       : await request.arrayBuffer(),
+    redirect: "manual",
   });
 
   // Forward only allowed response headers (HAWK-005)


### PR DESCRIPTION
Add redirect: 'manual' to AUTH.fetch() in login proxy so 302 responses
from Better Auth pass through to the browser instead of being followed
inside Cloudflare's network. Fixes Google OAuth callback flow.

Hunted by Panther 🐆