### PR TITLE
feat(tiers): raise post limits and shift upgrade incentive to features

### DIFF
--- a/docs/help-center/articles/choosing-your-plan.md
+++ b/docs/help-center/articles/choosing-your-plan.md
@@ -3,7 +3,7 @@ title: Choosing Your Plan
 description: Understanding Grove's pricing tiers and features
 category: help
 section: getting-started
-lastUpdated: '2025-12-01'
+lastUpdated: "2025-12-01"
 keywords:
   - plan
   - pricing
@@ -21,7 +21,7 @@ order: 2
 
 # Choosing Your Plan
 
-**First, the important bit:** Reading Grove blogs is free. Always. Every blog is publicly accessible. Just visit and read, no account needed. You only need a plan if you want to *write* your own blog.
+**First, the important bit:** Reading Grove blogs is free. Always. Every blog is publicly accessible. Just visit and read, no account needed. You only need a plan if you want to _write_ your own blog.
 
 Grove has a few plans, each designed for different needs. Here's what you get at each level.
 
@@ -33,8 +33,8 @@ Grove has a few plans, each designed for different needs. Here's what you get at
 
 A quiet clearing to try your hand at writing — no credit card, no commitment. Wanderer is a real blog, not just community access. You get your own grove.place address and everything you need to start.
 
-- Up to 5 blog posts
-- 50 MB storage for images
+- Up to 25 blog posts
+- 100 MB storage for images
 - Your own grove.place address
 - RSS feed
 - [[meadow]] access for browsing and reacting
@@ -46,7 +46,7 @@ A quiet clearing to try your hand at writing — no credit card, no commitment. 
 
 Everything you need to start writing. No feature walls, no "upgrade to unlock basic functionality." Seedling is a real plan.
 
-- Up to 50 posts
+- Up to 100 posts
 - 1 GB storage for images and media
 - All 10 fonts + accent color customization
 - 3 curated themes (coming soon)
@@ -60,7 +60,7 @@ Everything you need to start writing. No feature walls, no "upgrade to unlock ba
 
 More room to grow. If you're posting frequently or building up an archive, Sapling gives you space.
 
-- Up to 250 posts
+- Unlimited posts
 - 5 GB storage
 - All 10 fonts + accent color
 - All 10 curated themes (coming soon)
@@ -100,9 +100,9 @@ Everything Grove offers, including a domain on us.
 
 ## How to think about it
 
-**Just curious?** Start with Wanderer — it's free, no credit card needed. Five posts, your own address, a real blog.
+**Just curious?** Start with Wanderer — it's free, no credit card needed. Twenty-five posts, your own address, a real blog.
 
-**Posting regularly?** Sapling's 250 post limit and extra storage handles most active blogs comfortably.
+**Posting regularly?** Sapling's unlimited posts and extra storage handles most active blogs comfortably.
 
 **Want a custom domain?** That's Oak territory. Bring a domain you already own, or upgrade to Evergreen and we'll register one for you.
 
@@ -114,7 +114,7 @@ You can upgrade or downgrade anytime from **Settings → Plan**.
 
 When you upgrade, you get immediate access to new features. When you downgrade, you keep access through the end of your current billing period.
 
-If you're over the limits of your new plan (say, you have 100 posts and downgrade to Seedling's 50), your existing content stays. You just can't publish new posts until you're under the limit.
+If you're over the limits of your new plan (say, you have 150 posts and downgrade to Seedling's 100), your existing content stays. You just can't publish new posts until you're under the limit.
 
 ## Centennial: Your grove can outlive you
 
@@ -129,6 +129,7 @@ You can opt out anytime if you'd rather your site not persist. But we think your
 The price listed is the price you pay. No setup fees, no surprise charges, no "actually it's more if you want X."
 
 All plans include:
+
 - SSL certificate (your site is secure)
 - Cloudflare CDN (your site loads fast)
 - Daily backups (your content is safe)
@@ -136,4 +137,4 @@ All plans include:
 
 ---
 
-*Questions about which plan fits? [Ask us](/contact). We'll give you an honest answer, even if it's "Wanderer is probably enough."*
+_Questions about which plan fits? [Ask us](/contact). We'll give you an honest answer, even if it's "Wanderer is probably enough."_

--- a/docs/help-center/articles/understanding-your-plan.md
+++ b/docs/help-center/articles/understanding-your-plan.md
@@ -3,7 +3,7 @@ title: Understanding Your Plan
 description: What's included in each Grove plan and how limits work
 category: help
 section: account-billing
-lastUpdated: '2026-01-03'
+lastUpdated: "2026-01-03"
 keywords:
   - plan
   - limits
@@ -23,24 +23,25 @@ Here's what each Grove plan includes—and what happens when you approach your l
 
 ## Plan limits at a glance
 
-| | Wanderer | Seedling | Sapling | Oak | Evergreen |
-|---|:---:|:---:|:---:|:---:|:---:|
-| **Price** | Free | $8/mo | $12/mo | $25/mo | $35/mo |
-| **Posts** | 5 | 50 | 250 | Unlimited | Unlimited |
-| **Storage** | 50 MB | 1 GB | 5 GB | 20 GB | 100 GB |
-| **Fonts** | — | All 10 | All 10 | All 10 | All 10 + custom uploads |
-| **Themes** | — | 3 curated | All 10 | All 10 + customizer | All 10 + customizer |
-| **Custom domain** | — | — | — | BYOD | Included |
-| **Email** | — | — | Forwarding | Full mailbox | Full mailbox |
-| **Centennial** | — | — | ✓ | ✓ | ✓ |
+|                   | Wanderer | Seedling  |  Sapling   |         Oak         |        Evergreen        |
+| ----------------- | :------: | :-------: | :--------: | :-----------------: | :---------------------: |
+| **Price**         |   Free   |   $8/mo   |   $12/mo   |       $25/mo        |         $35/mo          |
+| **Posts**         |    25    |    100    | Unlimited  |      Unlimited      |        Unlimited        |
+| **Storage**       |  100 MB  |   1 GB    |    5 GB    |        20 GB        |         100 GB          |
+| **Fonts**         |    —     |  All 10   |   All 10   |       All 10        | All 10 + custom uploads |
+| **Themes**        |    —     | 3 curated |   All 10   | All 10 + customizer |   All 10 + customizer   |
+| **Custom domain** |    —     |     —     |     —      |        BYOD         |        Included         |
+| **Email**         |    —     |     —     | Forwarding |    Full mailbox     |      Full mailbox       |
+| **Centennial**    |    —     |     —     |     ✓      |          ✓          |            ✓            |
 
 ## What counts toward limits
 
-### Post limits (Wanderer, Seedling, and Sapling)
+### Post limits (Wanderer and Seedling)
 
 Every published post counts toward your limit. Drafts don't count until you publish them.
 
 If you reach your limit:
+
 - You can still edit existing posts
 - You can still save drafts
 - You can't publish new posts until you upgrade or delete old ones
@@ -50,11 +51,13 @@ If you reach your limit:
 Storage is measured in bytes—the actual file sizes of your uploads.
 
 **What counts:**
+
 - Images you upload to posts
 - Featured images
 - Any media files
 
 **What doesn't count:**
+
 - Your post text (Markdown is tiny)
 - Comments and replies
 - Settings and configuration
@@ -67,6 +70,7 @@ If you reach your storage limit, you can't upload new images until you free up s
 2. Look for the **Usage** section
 
 You'll see:
+
 - How many posts you've published vs. your limit
 - How much storage you've used vs. your limit
 - Your current plan and billing date
@@ -92,7 +96,8 @@ Whether you're on Wanderer or Evergreen, every Grove blog includes:
 ### Wanderer (Free)
 
 Your first steps:
-- 5 posts, 50 MB storage
+
+- 25 posts, 100 MB storage
 - Your own grove.place address
 - Markdown editor with live preview and autosave
 - RSS feed
@@ -104,7 +109,8 @@ Good for: The curious, first-time bloggers, seeing if Grove is home.
 ### Seedling ($8/month)
 
 The essentials for starting a blog:
-- 50 posts, 1 GB storage
+
+- 100 posts, 1 GB storage
 - All 10 fonts plus accent color customization
 - 3 curated themes (coming soon)
 - Community support via help documentation
@@ -114,7 +120,8 @@ Good for: Trying blogging out, personal journals, occasional posting.
 ### Sapling ($12/month) — coming soon
 
 Room to grow:
-- 250 posts, 5 GB storage
+
+- Unlimited posts, 5 GB storage
 - All 10 fonts plus accent color
 - All 10 curated themes (coming soon)
 - Email forwarding to `you@grove.place`
@@ -126,6 +133,7 @@ Good for: Regular bloggers, building an archive, hobbyist writers.
 ### Oak ($25/month) — coming soon
 
 Full control:
+
 - Unlimited posts, 20 GB storage
 - All 10 fonts plus accent color
 - All 10 curated themes + theme customizer (coming soon)
@@ -140,6 +148,7 @@ Good for: Serious bloggers, professionals, anyone who wants a custom domain.
 ### Evergreen ($35/month) — coming soon
 
 Everything:
+
 - Unlimited posts, 100 GB storage
 - All 10 fonts plus custom font uploads
 - All 10 curated themes + theme customizer (coming soon)
@@ -170,4 +179,4 @@ A hundred years is roughly how long an oak tree lives. Some trees outlive the pe
 
 ---
 
-*Not sure what plan is right? Start with Wanderer — it's free, and it's a real blog. Cultivate to Seedling when you're ready for more room.*
+_Not sure what plan is right? Start with Wanderer — it's free, and it's a real blog. Cultivate to Seedling when you're ready for more room._

--- a/docs/help-center/articles/upgrading-or-downgrading.md
+++ b/docs/help-center/articles/upgrading-or-downgrading.md
@@ -3,7 +3,7 @@ title: Upgrading or Downgrading Your Plan
 description: How to change your Grove subscription plan
 category: help
 section: account-billing
-lastUpdated: '2025-12-24'
+lastUpdated: "2025-12-24"
 keywords:
   - upgrade
   - downgrade
@@ -38,12 +38,12 @@ That's it. No hoops, no retention flows, no "are you sure?" five times.
 
 **What unlocks by plan:**
 
-| Upgrade to | You gain |
-|------------|----------|
-| Wanderer → Seedling | 45 more posts, ~950 MB more storage, Meadow sharing, unlimited comments, no ads guarantee |
-| Seedling → Sapling | 200 more posts, 4 GB storage, 7 more curated themes (coming soon), email forwarding, Centennial eligibility |
-| Sapling → Oak | Unlimited posts, 15 GB more storage, theme customizer (coming soon), custom domain, Analytics |
-| Oak → Evergreen | 80 GB more storage, custom font uploads (coming soon), domain included (we register it), dedicated support hours |
+| Upgrade to          | You gain                                                                                                         |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Wanderer → Seedling | 75 more posts, ~900 MB more storage, Meadow sharing, unlimited comments, no ads guarantee                        |
+| Seedling → Sapling  | Unlimited posts, 4 GB storage, 7 more curated themes (coming soon), email forwarding, Centennial eligibility     |
+| Sapling → Oak       | 15 GB more storage, theme customizer (coming soon), custom domain, Analytics                                     |
+| Oak → Evergreen     | 80 GB more storage, custom font uploads (coming soon), domain included (we register it), dedicated support hours |
 
 ## When you downgrade
 
@@ -51,9 +51,10 @@ That's it. No hoops, no retention flows, no "are you sure?" five times.
 
 **Your content stays.** If you're over the new plan's limits, your existing content isn't deleted. You just can't publish new posts until you're under the limit.
 
-**Example:** You have 100 posts on Sapling (250 limit) and downgrade to Seedling (50 limit). All 100 posts remain published and visible. You just can't create post #101 until you delete or unpublish some.
+**Example:** You have 150 posts on Sapling (unlimited) and downgrade to Seedling (100 limit). All 150 posts remain published and visible. You just can't create post #151 until you delete or unpublish some.
 
 **Features revert.** When the billing period ends:
+
 - Theme customizer settings revert to defaults (if downgrading from Oak/Evergreen)
 - Custom domain stops working (if downgrading from Oak/Evergreen)
 - Some curated themes become unavailable (if downgrading to Seedling's 3 themes)
@@ -80,7 +81,7 @@ You never lose content because of a plan change.
 
 ## If you're on Wanderer
 
-Wanderer is your free starting point — 5 posts, 50 MB storage, your own grove.place address. When you're ready for more room, cultivate to any paid tier.
+Wanderer is your free starting point — 25 posts, 100 MB storage, your own grove.place address. When you're ready for more room, cultivate to any paid tier.
 
 The growth path: **Wanderer → Seedling → Sapling → Oak → Evergreen**
 
@@ -96,4 +97,4 @@ Downgrades don't trigger refunds for the current period. You keep access to your
 
 ---
 
-*Questions about which plan fits? [Ask us](/contact)—we'll give you an honest recommendation.*
+_Questions about which plan fits? [Ask us](/contact)—we'll give you an honest recommendation._

--- a/docs/help-center/articles/what-are-tiers.md
+++ b/docs/help-center/articles/what-are-tiers.md
@@ -3,7 +3,7 @@ title: What are Tiers?
 description: Understanding Grove's subscription tiers from Seedling to Evergreen
 category: help
 section: how-it-works
-lastUpdated: '2026-01-28'
+lastUpdated: "2026-01-28"
 keywords:
   - tiers
   - pricing
@@ -33,8 +33,9 @@ Five levels—Wanderer, Seedling, Sapling, Oak, and Evergreen—each offering mo
 You're curious. Maybe you've been meaning to start a blog for years. Maybe you just want to see what this place feels like. No credit card, no commitment — just a quiet clearing to try your hand at writing.
 
 Wanderer gives you:
-- Up to 5 posts
-- 50 MB storage
+
+- Up to 25 posts
+- 100 MB storage
 - Your own grove.place address
 - RSS feed
 - Meadow access for browsing and reacting
@@ -48,7 +49,8 @@ It's enough to find out if this is home.
 You've decided to put down roots. Wanderer felt right, and now you want more room to grow.
 
 Seedling gives you:
-- Up to 50 posts
+
+- Up to 100 posts
 - 1 GB storage
 - Basic theming with accent colors
 - Access to the community
@@ -62,7 +64,8 @@ It's enough to genuinely explore whether Grove is right for you.
 You've decided this is your space. You post regularly. You want more room to grow.
 
 Sapling includes everything in Seedling, plus:
-- Up to 250 posts
+
+- Unlimited posts
 - 5 GB storage
 - Full theming options
 - Email forwarding to your `@grove.place` address
@@ -80,6 +83,7 @@ Most hobbyist bloggers live comfortably here.
 Your blog is part of your identity. Maybe it supports your work or side business. You need professional features.
 
 Oak includes everything in Sapling, plus:
+
 - Unlimited posts
 - 20 GB storage
 - Theme customizer (full control over colors, typography, spacing)
@@ -96,6 +100,7 @@ No more limits. Your grove grows as big as you need.
 You want Grove to handle everything. Domain search, registration, priority support, all the bells and whistles.
 
 Evergreen includes everything in Oak, plus:
+
 - 100 GB storage
 - Custom fonts
 - [[forage]] domain discovery (included)
@@ -120,7 +125,7 @@ The full-service option for people who value their time.
 
 **Annual discounts available.** Pay yearly and save. The commitment makes sense once you know you're staying.
 
-**Free is where everyone starts.** Wanderer gives you 5 posts and 50 MB — enough to try things out with zero commitment. Running a quality platform costs money, which is why paid tiers exist. But your first steps? Those are on us.
+**Free is where everyone starts.** Wanderer gives you 25 posts and 100 MB — enough to build a real blog with zero commitment. Running a quality platform costs money, which is why paid tiers exist. But your first steps? Those are on us.
 
 ## Related
 
@@ -130,4 +135,4 @@ The full-service option for people who value their time.
 
 ---
 
-*Wanderers find their clearing. Seedlings take root. Saplings grow strong. Oaks stand tall. Evergreens stay green through every season. That's the journey.*
+_Wanderers find their clearing. Seedlings take root. Saplings grow strong. Oaks stand tall. Evergreens stay green through every season. That's the journey._

--- a/docs/internal/business/grove-pricing.md
+++ b/docs/internal/business/grove-pricing.md
@@ -2,7 +2,7 @@
 
 Grove.place
 
-*Effective December 2025*
+_Effective December 2025_
 
 ---
 
@@ -16,23 +16,23 @@ Your content is yours. Your domain is yours. No lock-in, no hostage situations.
 
 ## Subscription Tiers
 
-| Feature | Free | Seedling | Sapling | Oak | Evergreen |
-|---------|:----:|:--------:|:-------:|:---:|:---------:|
-| **Monthly** | **$0** | **$8** | **$12** | **$25** | **$35** |
-| **Yearly** | — | **$82** | **$122** | **$255** | **$357** |
-| Blog | — | ✓ | ✓ | ✓ | ✓ |
-| Blog Posts | — | 50 | 250 | Unlimited | Unlimited |
-| Storage | — | 1 GB | 5 GB | 20 GB | 100 GB |
-| Themes | — | 3 + accent | 10 + accent | Customizer | Customizer + Custom Fonts |
-| Community Themes | — | — | — | ✓ | ✓ |
-| Meadow | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Public Comments | 20/week | Unlimited | Unlimited | Unlimited | Unlimited |
-| Custom Domain | — | — | — | BYOD | ✓ |
-| @grove.place Email | — | — | Forward | Full | Full |
-| Centennial Status | — | — | ✓ | ✓ | ✓ |
-| Privacy Controls | — | — | — | — | Login-required option |
-| Support | Community | Community | Email | Priority | 8hrs + Priority |
-| **Best For** | *Readers* | *Curious* | *Hobbyists* | *Serious Bloggers* | *Professionals* |
+| Feature            |   Free    |  Seedling  |   Sapling   |        Oak         |         Evergreen         |
+| ------------------ | :-------: | :--------: | :---------: | :----------------: | :-----------------------: |
+| **Monthly**        |  **$0**   |   **$8**   |   **$12**   |      **$25**       |          **$35**          |
+| **Yearly**         |     —     |  **$82**   |  **$122**   |      **$255**      |         **$357**          |
+| Blog               |     ✓     |     ✓      |      ✓      |         ✓          |             ✓             |
+| Blog Posts         |    25     |    100     |  Unlimited  |     Unlimited      |         Unlimited         |
+| Storage            |  100 MB   |    1 GB    |    5 GB     |       20 GB        |          100 GB           |
+| Themes             |     —     | 3 + accent | 10 + accent |     Customizer     | Customizer + Custom Fonts |
+| Community Themes   |     —     |     —      |      —      |         ✓          |             ✓             |
+| Meadow             |     ✓     |     ✓      |      ✓      |         ✓          |             ✓             |
+| Public Comments    |  20/week  | Unlimited  |  Unlimited  |     Unlimited      |         Unlimited         |
+| Custom Domain      |     —     |     —      |      —      |        BYOD        |             ✓             |
+| @grove.place Email |     —     |     —      |   Forward   |        Full        |           Full            |
+| Centennial Status  |     —     |     —      |      ✓      |         ✓          |             ✓             |
+| Privacy Controls   |     —     |     —      |      —      |         —          |   Login-required option   |
+| Support            | Community | Community  |    Email    |      Priority      |      8hrs + Priority      |
+| **Best For**       | _Readers_ | _Curious_  | _Hobbyists_ | _Serious Bloggers_ |      _Professionals_      |
 
 **Yearly plans save 15%**: pay for 10 months, get 12.
 
@@ -61,26 +61,31 @@ This is by design. Grove is about sharing your voice with the world. If you need
 
 ---
 
-## Free Tier
+## Free Tier (Wanderer)
 
-*Browse, engage, and be part of the community.*
+_Your first steps in the grove._
 
 Free accounts get:
-- **Meadow access:** Browse the community feed, curate your following, react to posts
+
+- **Blog:** 25 published posts at `username.grove.place`
+- **100 MB storage** for images and media
+- **Meadow access:** Browse the community feed, react to posts, leave replies
 - **Comment on posts:** Leave replies (private) and comments (public) on blogs you follow
 - **Public comment limit:** 20 per week (private replies are rate-limited)
-- **No blog:** Free accounts can't publish posts
+- **RSS feed** included
+- **No credit card required**
 
-Free is for readers and community members. When you're ready to write, upgrade to Seedling.
+Free is for the curious. Write, share, see if this is home. When you're ready to grow, take root with Seedling.
 
 ---
 
 ## What Each Tier Includes
 
 ### Seedling: $8/month
-*Try it. See if blogging is for you.*
 
-- 50 blog posts
+_Try it. See if blogging is for you._
+
+- 100 blog posts
 - 1 GB storage for images and media
 - Your blog at `username.grove.place`
 - **3 themes** + custom accent color
@@ -89,9 +94,10 @@ Free is for readers and community members. When you're ready to write, upgrade t
 - Community support via documentation
 
 ### Sapling: $12/month
-*You blog regularly. This is your space.*
 
-- 250 blog posts
+_You blog regularly. This is your space._
+
+- **Unlimited** blog posts
 - 5 GB storage
 - Your blog at `username.grove.place`
 - **10 themes** + custom accent color
@@ -100,7 +106,8 @@ Free is for readers and community members. When you're ready to write, upgrade t
 - Email support
 
 ### Oak: $25/month
-*Your blog is part of your identity.*
+
+_Your blog is part of your identity._
 
 - **Unlimited** blog posts
 - 20 GB storage
@@ -112,7 +119,8 @@ Free is for readers and community members. When you're ready to write, upgrade t
 - Priority email support
 
 ### Evergreen: $35/month
-*Your blog is your business. We handle everything.*
+
+_Your blog is your business. We handle everything._
 
 - **Unlimited** blog posts
 - 100 GB storage
@@ -132,12 +140,12 @@ Free is for readers and community members. When you're ready to write, upgrade t
 
 Grove offers hand-curated themes that you can customize with your own accent color.
 
-| Tier | Theme Access |
-|------|--------------|
-| Seedling | 3 themes (Grove, Minimal, Night Garden) + custom accent color |
-| Sapling | All 10 themes + custom accent color |
-| Oak | All 10 themes + full theme customizer + community themes |
-| Evergreen | Everything Oak gets + custom font uploads |
+| Tier      | Theme Access                                                  |
+| --------- | ------------------------------------------------------------- |
+| Seedling  | 3 themes (Grove, Minimal, Night Garden) + custom accent color |
+| Sapling   | All 10 themes + custom accent color                           |
+| Oak       | All 10 themes + full theme customizer + community themes      |
+| Evergreen | Everything Oak gets + custom font uploads                     |
 
 **Theme Customizer (Oak+):** Adjust colors, fonts, spacing, layout, and add custom CSS.
 
@@ -160,10 +168,10 @@ Grove supports two types of interaction on blog posts:
 - **Replies (private):** Only the blog author sees these
 - **Comments (public):** Visible to everyone after author approval
 
-| Tier | Public Comments | Private Replies |
-|------|-----------------|-----------------|
-| Free | 20/week | Rate limited |
-| Seedling+ | Unlimited | Unlimited |
+| Tier      | Public Comments | Private Replies |
+| --------- | --------------- | --------------- |
+| Free      | 20/week         | Rate limited    |
+| Seedling+ | Unlimited       | Unlimited       |
 
 Blog authors control who can comment on their posts and moderate all public comments before they appear.
 
@@ -179,11 +187,11 @@ Already have a domain? Connect it to your Grove blog at no extra cost. Available
 
 Don't have a domain yet? Our AI-powered domain search tool finds the perfect domain for your blog—turning what's normally a 2-week search into 1-2 hours.
 
-| Turnaround | Setup Fee | Credited As |
-|:----------:|:---------:|:-----------:|
-| Same Day | $200 | 4 months Evergreen |
-| 3 Days | $100 | 2 months Evergreen |
-| 1 Week | $50 | 1 month Evergreen |
+| Turnaround | Setup Fee |    Credited As     |
+| :--------: | :-------: | :----------------: |
+|  Same Day  |   $200    | 4 months Evergreen |
+|   3 Days   |   $100    | 2 months Evergreen |
+|   1 Week   |    $50    | 1 month Evergreen  |
 
 **Setup fees are credited toward your subscription**: you're not losing money, you're prepaying for service.
 
@@ -192,6 +200,7 @@ Don't have a domain yet? Our AI-powered domain search tool finds the perfect dom
 ### Your Domain, Your Ownership
 
 When we register a domain for you, **you own it**. If you ever leave Grove:
+
 - Transfer your domain to any registrar
 - We provide authorization codes within 48 hours
 - No transfer fees, no hostage situations
@@ -202,17 +211,17 @@ See our [Data Portability & Separation Policy](https://grove.place/knowledge/leg
 
 ## Centennial Status
 
-*Some trees outlive the people who planted them.*
+_Some trees outlive the people who planted them._
 
 Centennial is Grove's promise that your words can have the same longevity. After 12 cumulative months on Sapling tier or above, your grove earns **Centennial status** — your site stays online for 100 years from the day you planted it.
 
 ### How It Works
 
-| Path to Centennial | Timeline |
-|-------------------|----------|
-| Yearly subscription (Sapling+) | Instant upon first renewal |
-| Monthly subscription (Sapling+) | After 12 monthly payments |
-| Mixed (upgrade/downgrade) | Cumulative months counted |
+| Path to Centennial              | Timeline                   |
+| ------------------------------- | -------------------------- |
+| Yearly subscription (Sapling+)  | Instant upon first renewal |
+| Monthly subscription (Sapling+) | After 12 monthly payments  |
+| Mixed (upgrade/downgrade)       | Cumulative months counted  |
 
 ### What Centennial Means
 
@@ -237,11 +246,11 @@ For full technical details, see the [Centennial Specification](/knowledge/specs/
 
 ## @grove.place Email
 
-| Tier | Email Feature | What You Get |
-|------|---------------|--------------|
-| Sapling | Forwarding | Emails to `you@grove.place` forward to your personal inbox |
-| Oak | Full mailbox | Send AND receive as `you@grove.place` |
-| Evergreen | Full mailbox | Send AND receive as `you@grove.place` |
+| Tier      | Email Feature | What You Get                                               |
+| --------- | ------------- | ---------------------------------------------------------- |
+| Sapling   | Forwarding    | Emails to `you@grove.place` forward to your personal inbox |
+| Oak       | Full mailbox  | Send AND receive as `you@grove.place`                      |
+| Evergreen | Full mailbox  | Send AND receive as `you@grove.place`                      |
 
 A professional email address for your blog—no extra cost, no separate service to manage.
 
@@ -249,13 +258,13 @@ A professional email address for your blog—no extra cost, no separate service 
 
 ## Support
 
-| Tier | What's Included | Additional Hours |
-|------|-----------------|------------------|
-| Free | Help Center only | — |
-| Seedling | Help Center & community | $100/hour |
-| Sapling | Email support | $100/hour |
-| Oak | Priority email support | $100/hour |
-| Evergreen | 8 hours free (first month) + priority | $75/hour |
+| Tier      | What's Included                       | Additional Hours |
+| --------- | ------------------------------------- | ---------------- |
+| Free      | Help Center only                      | —                |
+| Seedling  | Help Center & community               | $100/hour        |
+| Sapling   | Email support                         | $100/hour        |
+| Oak       | Priority email support                | $100/hour        |
+| Evergreen | 8 hours free (first month) + priority | $75/hour         |
 
 ---
 
@@ -295,4 +304,4 @@ No venture capital. No investor pressure to maximize extraction. Just a service 
 
 ---
 
-*Build it. They will come. Let the roots intermingle.*
+_Build it. They will come. Let the roots intermingle._

--- a/docs/security/hawk-report-2026-02-09-upgrades-graft.md
+++ b/docs/security/hawk-report-2026-02-09-upgrades-graft.md
@@ -12,7 +12,7 @@
 ### Key Findings
 
 | Severity | Count |
-|----------|-------|
+| -------- | ----- |
 | Critical | 0     |
 | High     | 1     |
 | Medium   | 4     |
@@ -20,16 +20,17 @@
 | Info     | 8     |
 
 ### Top 3 Risks
+
 1. **HIGH**: `verifiedTenantId` ReferenceError in billing PATCH handler — breaks cancel/resume subscription operations at runtime
 2. **MEDIUM**: "wanderer" vs "free" key mismatch in component stageNames — breaks free-tier display in account page
 3. **MEDIUM**: API response field mismatch — arbor account reads `response.url` but TendResponse defines `shedUrl`
 
 ### Previous Findings Status
 
-| ID | Previous Severity | Finding | Status |
-|----|-------------------|---------|--------|
-| HAWK-001 | MEDIUM | Plan selection skips onboarding steps | **FIXED** — sequential validation added (`select-plan:103-146`) |
-| HAWK-002 | MEDIUM | Tenant ID from query parameter | **FIXED** — removed, now uses `locals.tenantId` only |
+| ID       | Previous Severity | Finding                               | Status                                                          |
+| -------- | ----------------- | ------------------------------------- | --------------------------------------------------------------- |
+| HAWK-001 | MEDIUM            | Plan selection skips onboarding steps | **FIXED** — sequential validation added (`select-plan:103-146`) |
+| HAWK-002 | MEDIUM            | Tenant ID from query parameter        | **FIXED** — removed, now uses `locals.tenantId` only            |
 
 ---
 
@@ -38,7 +39,8 @@
 ### System Overview
 
 This PR introduces:
-- **Wanderer tier**: Free plan with constrained limits (5 posts, 50 MB, 100 drafts)
+
+- **Wanderer tier**: Free plan with constrained limits (25 posts, 100 MB, 100 drafts)
 - **UpgradesGraft**: Engine graft module for cultivation (upgrade), tending (billing portal), and growth (status)
 - **Activity tracking**: Fire-and-forget `updateLastActivity()` for future inactivity reclamation
 - **Free account IP limiting**: 3 free accounts per IP per 30-day rolling window
@@ -47,16 +49,16 @@ This PR introduces:
 
 ### STRIDE Analysis
 
-| Component | S | T | R | I | D | E | Priority |
-|-----------|---|---|---|---|---|---|----------|
-| Cultivate API | . | . | . | . | . | ! | MEDIUM |
-| Tend API | . | ! | . | ! | . | . | MEDIUM |
-| Growth API | . | . | . | ? | . | . | LOW |
-| Billing PATCH | . | . | . | . | . | ! | HIGH |
-| Blooms tier limits | . | . | . | . | ? | . | MEDIUM |
-| Free account creation | . | ! | . | . | ! | . | MEDIUM |
-| Activity tracking | . | . | . | . | . | . | LOW |
-| Migration 053 | . | . | . | . | . | . | LOW |
+| Component             | S   | T   | R   | I   | D   | E   | Priority |
+| --------------------- | --- | --- | --- | --- | --- | --- | -------- |
+| Cultivate API         | .   | .   | .   | .   | .   | !   | MEDIUM   |
+| Tend API              | .   | !   | .   | !   | .   | .   | MEDIUM   |
+| Growth API            | .   | .   | .   | ?   | .   | .   | LOW      |
+| Billing PATCH         | .   | .   | .   | .   | .   | !   | HIGH     |
+| Blooms tier limits    | .   | .   | .   | .   | ?   | .   | MEDIUM   |
+| Free account creation | .   | !   | .   | .   | !   | .   | MEDIUM   |
+| Activity tracking     | .   | .   | .   | .   | .   | .   | LOW      |
+| Migration 053         | .   | .   | .   | .   | .   | .   | LOW      |
 
 Legend: **!** = likely threat, **?** = needs investigation, **.** = low risk
 
@@ -84,16 +86,16 @@ Blooms POST                       │  Tier-based limits check
 
 ### Data Classification
 
-| Data Type | Classification | Storage | Protection |
-|-----------|---------------|---------|------------|
-| Stripe secret key | CRITICAL | Workers Secrets | Never in code |
-| Session tokens | CRITICAL | Cookies + KV | HttpOnly, Secure, SameSite |
-| Billing records | HIGH | D1 (platform_billing) | Tenant-scoped queries |
-| Provider customer ID | HIGH | D1 | Never exposed to client |
-| Payment method info | MEDIUM | D1 (last4 + brand only) | Filtered by growth API |
-| Activity timestamps | LOW | D1 (tenants.last_activity_at) | Tenant-scoped |
-| IP addresses | MEDIUM | D1 (free_account_creation_log) | 30-day rolling window |
-| Reclamation status | LOW | D1 (tenants.reclamation_status) | Internal only |
+| Data Type            | Classification | Storage                         | Protection                 |
+| -------------------- | -------------- | ------------------------------- | -------------------------- |
+| Stripe secret key    | CRITICAL       | Workers Secrets                 | Never in code              |
+| Session tokens       | CRITICAL       | Cookies + KV                    | HttpOnly, Secure, SameSite |
+| Billing records      | HIGH           | D1 (platform_billing)           | Tenant-scoped queries      |
+| Provider customer ID | HIGH           | D1                              | Never exposed to client    |
+| Payment method info  | MEDIUM         | D1 (last4 + brand only)         | Filtered by growth API     |
+| Activity timestamps  | LOW            | D1 (tenants.last_activity_at)   | Tenant-scoped              |
+| IP addresses         | MEDIUM         | D1 (free_account_creation_log)  | 30-day rolling window      |
+| Reclamation status   | LOW            | D1 (tenants.reclamation_status) | Internal only              |
 
 ---
 
@@ -103,18 +105,19 @@ Blooms POST                       │  Tier-based limits check
 
 #### [HAWK-010] verifiedTenantId ReferenceError in Billing PATCH Handler
 
-| Field | Value |
-|-------|-------|
-| **Severity** | HIGH |
-| **Domain** | Authorization |
-| **Location** | `packages/engine/src/routes/api/billing/+server.ts:550, 571, 596` |
-| **Confidence** | HIGH |
-| **OWASP** | A01:2021 Broken Access Control |
+| Field          | Value                                                             |
+| -------------- | ----------------------------------------------------------------- |
+| **Severity**   | HIGH                                                              |
+| **Domain**     | Authorization                                                     |
+| **Location**   | `packages/engine/src/routes/api/billing/+server.ts:550, 571, 596` |
+| **Confidence** | HIGH                                                              |
+| **OWASP**      | A01:2021 Broken Access Control                                    |
 
 **Description:**
 The billing PATCH handler (cancel/resume subscription) calls `getVerifiedTenantId()` at line 550 but discards the return value. The variable `verifiedTenantId` is then referenced at lines 571 and 596 without being defined, causing a `ReferenceError` at runtime.
 
 **Evidence:**
+
 ```typescript
 // Line 550: Return value discarded
 await getVerifiedTenantId(platform.env.DB, tenantId, locals.user);
@@ -127,15 +130,21 @@ await getVerifiedTenantId(platform.env.DB, tenantId, locals.user);
 ```
 
 **Impact:**
+
 - Cancel subscription, resume subscription, and plan change operations are **completely broken**
 - The error is caught by the try/catch block, so it returns a 500 rather than leaking the error
 - No data exposure, but the billing management functionality is non-functional
 - This is the billing PATCH handler, not the UpgradesGraft tend endpoint (which works correctly)
 
 **Remediation:**
+
 ```typescript
 // Line 550: Capture the return value
-const verifiedTenantId = await getVerifiedTenantId(platform.env.DB, tenantId, locals.user);
+const verifiedTenantId = await getVerifiedTenantId(
+  platform.env.DB,
+  tenantId,
+  locals.user,
+);
 ```
 
 **Status:** Fix before merge — breaks core billing operations
@@ -146,23 +155,24 @@ const verifiedTenantId = await getVerifiedTenantId(platform.env.DB, tenantId, lo
 
 #### [HAWK-011] returnTo URL Not Validated Against Allowlist
 
-| Field | Value |
-|-------|-------|
-| **Severity** | MEDIUM |
-| **Domain** | Input Validation |
-| **Location** | `packages/engine/src/lib/grafts/upgrades/server/api/tend.ts:143-148` |
-| **Confidence** | HIGH |
-| **OWASP** | A01:2021 Broken Access Control |
+| Field          | Value                                                                |
+| -------------- | -------------------------------------------------------------------- |
+| **Severity**   | MEDIUM                                                               |
+| **Domain**     | Input Validation                                                     |
+| **Location**   | `packages/engine/src/lib/grafts/upgrades/server/api/tend.ts:143-148` |
+| **Confidence** | HIGH                                                                 |
+| **OWASP**      | A01:2021 Broken Access Control                                       |
 
 **Description:**
 The `constructReturnUrl()` function in tend.ts passes the user-supplied `returnTo` parameter directly as the portal return URL without any validation or allowlisting.
 
 **Evidence:**
+
 ```typescript
 // Line 143-148: returnTo passed through without validation
 function constructReturnUrl(appUrl: string, returnTo?: string): string {
   if (returnTo) {
-    return returnTo;  // ← User-controlled, no validation
+    return returnTo; // ← User-controlled, no validation
   }
   return `${appUrl}/garden`;
 }
@@ -171,16 +181,18 @@ function constructReturnUrl(appUrl: string, returnTo?: string): string {
 The same pattern appears in cultivate.ts at `constructSuccessUrl()` (line 254) and `constructCancelUrl()` (line 268), though those prepend the `appUrl` prefix which limits the attack surface.
 
 **Impact:**
+
 - Attacker could set `returnTo` to `https://evil.com` and the Stripe portal would redirect there after session ends
 - Since the portal URL itself is Stripe-hosted, the redirect happens on Stripe's domain — Stripe may or may not validate this
 - Combined with social engineering, could redirect users to phishing pages after legitimate billing actions
 
 **Remediation:**
+
 ```typescript
 function constructReturnUrl(appUrl: string, returnTo?: string): string {
   if (returnTo) {
     // Ensure returnTo is a relative path or matches our domain
-    if (returnTo.startsWith('/')) {
+    if (returnTo.startsWith("/")) {
       return `${appUrl}${returnTo}`;
     }
     if (returnTo.startsWith(appUrl)) {
@@ -197,18 +209,19 @@ function constructReturnUrl(appUrl: string, returnTo?: string): string {
 
 #### [HAWK-012] API Response Field Mismatch — shedUrl vs url
 
-| Field | Value |
-|-------|-------|
-| **Severity** | MEDIUM |
-| **Domain** | Input Validation |
-| **Location** | `packages/engine/src/routes/arbor/account/+page.svelte:87-88` |
-| **Confidence** | HIGH |
-| **OWASP** | A04:2021 Insecure Design |
+| Field          | Value                                                         |
+| -------------- | ------------------------------------------------------------- |
+| **Severity**   | MEDIUM                                                        |
+| **Domain**     | Input Validation                                              |
+| **Location**   | `packages/engine/src/routes/arbor/account/+page.svelte:87-88` |
+| **Confidence** | HIGH                                                          |
+| **OWASP**      | A04:2021 Insecure Design                                      |
 
 **Description:**
 The arbor account page reads `response.url` from the tend API response, but `TendResponse` type defines the field as `shedUrl`. This causes a runtime failure where users cannot access the billing portal from the account page.
 
 **Evidence:**
+
 ```typescript
 // arbor/account/+page.svelte:86-88 — reads response.url
 const response = await api.post('/api/grafts/upgrades/tend', {});
@@ -227,11 +240,13 @@ const response: TendResponse = {
 ```
 
 **Impact:**
+
 - "Manage Billing" button in arbor account page silently fails — `response.url` is `undefined`
 - Users shown "Unable to open billing portal" toast instead of being redirected
 - The underlying Stripe session is still created (and audit-logged), just never navigated to
 
 **Remediation:**
+
 ```svelte
 // Fix in +page.svelte
 const response = await api.post('/api/grafts/upgrades/tend', {});
@@ -246,21 +261,22 @@ if (response.shedUrl) {
 
 #### [HAWK-013] IP Rate Limit Race Condition in select-plan
 
-| Field | Value |
-|-------|-------|
-| **Severity** | MEDIUM |
-| **Domain** | Race Conditions |
-| **Location** | `packages/plant/src/routes/api/select-plan/+server.ts` |
-| **Confidence** | MEDIUM |
-| **OWASP** | A04:2021 Insecure Design |
+| Field          | Value                                                  |
+| -------------- | ------------------------------------------------------ |
+| **Severity**   | MEDIUM                                                 |
+| **Domain**     | Race Conditions                                        |
+| **Location**   | `packages/plant/src/routes/api/select-plan/+server.ts` |
+| **Confidence** | MEDIUM                                                 |
+| **OWASP**      | A04:2021 Insecure Design                               |
 
 **Description:**
 The free plan creation flow runs the IP limit check and the `payment_completed` DB update in parallel. If the IP check rejects the request, the user's `payment_completed` flag may already be set to `1`, leaving their onboarding record in an inconsistent state.
 
 **Impact:**
+
 - Rejected users end up with `payment_completed=1` but no tenant
 - Minor: could confuse the onboarding flow or require manual database cleanup
-- The IP check prevents the *tenant creation* itself, so no security bypass occurs
+- The IP check prevents the _tenant creation_ itself, so no security bypass occurs
 
 **Remediation:**
 Run the IP check BEFORE the `payment_completed` update, not in parallel. The IP check should gate the entire operation.
@@ -271,18 +287,19 @@ Run the IP check BEFORE the `payment_completed` update, not in parallel. The IP 
 
 #### [HAWK-019] "wanderer" vs "free" Key Mismatch in Component stageNames
 
-| Field | Value |
-|-------|-------|
-| **Severity** | MEDIUM |
-| **Domain** | Input Validation |
-| **Location** | `packages/engine/src/lib/grafts/upgrades/components/CurrentStageBadge.svelte:14,34-35,64` and `GardenStatus.svelte:27,49-50,157` |
-| **Confidence** | HIGH |
-| **OWASP** | A04:2021 Insecure Design |
+| Field          | Value                                                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**   | MEDIUM                                                                                                                           |
+| **Domain**     | Input Validation                                                                                                                 |
+| **Location**   | `packages/engine/src/lib/grafts/upgrades/components/CurrentStageBadge.svelte:14,34-35,64` and `GardenStatus.svelte:27,49-50,157` |
+| **Confidence** | HIGH                                                                                                                             |
+| **OWASP**      | A04:2021 Insecure Design                                                                                                         |
 
 **Description:**
 Both `CurrentStageBadge` and `GardenStatus` components use `"wanderer"` as the key in their `stageNames` Record and as the default prop value. But `TierKey` is defined as `"free" | "seedling" | "sapling" | "oak" | "evergreen"` — there is no `"wanderer"` value. The `stageNames` is typed as `Record<TierKey, string>`, so the `wanderer` key should be a compile error. In practice, the real data from the billing API will return `"free"` as the plan key.
 
 **Evidence:**
+
 ```typescript
 // CurrentStageBadge.svelte:14 — default value doesn't match TierKey
 currentStage = 'wanderer',
@@ -296,6 +313,7 @@ const stageNames: Record<TierKey, string> = {
 ```
 
 **Impact:**
+
 - `stageNames["free"]` returns `undefined` — free-tier users see no stage name
 - `iconComponents["free"]` falls through to `Sprout` fallback (may be acceptable)
 - The Wanderer upgrade CTA in GardenStatus (`currentStage === 'wanderer'`) never triggers
@@ -303,11 +321,12 @@ const stageNames: Record<TierKey, string> = {
 
 **Remediation:**
 Replace `"wanderer"` with `"free"` in all component maps, or add a display name mapping layer:
+
 ```typescript
 const stageNames: Record<TierKey, string> = {
-    free: 'Wanderer',  // Display name differs from key
-    seedling: 'Seedling',
-    // ...
+  free: "Wanderer", // Display name differs from key
+  seedling: "Seedling",
+  // ...
 };
 ```
 
@@ -319,18 +338,19 @@ const stageNames: Record<TierKey, string> = {
 
 #### [HAWK-014] Dead Code: getStagePriceId Uses process.env
 
-| Field | Value |
-|-------|-------|
-| **Severity** | LOW |
-| **Domain** | Code Quality |
-| **Location** | `packages/engine/src/lib/grafts/upgrades/server/api/cultivate.ts:228-249` |
-| **Confidence** | HIGH |
-| **OWASP** | N/A |
+| Field          | Value                                                                     |
+| -------------- | ------------------------------------------------------------------------- |
+| **Severity**   | LOW                                                                       |
+| **Domain**     | Code Quality                                                              |
+| **Location**   | `packages/engine/src/lib/grafts/upgrades/server/api/cultivate.ts:228-249` |
+| **Confidence** | HIGH                                                                      |
+| **OWASP**      | N/A                                                                       |
 
 **Description:**
 The `getStagePriceId()` function at the bottom of cultivate.ts references `process.env` which is not available in Cloudflare Workers. The function is never called — the cultivate handler uses `getPlantingUrl()` from config instead.
 
 **Impact:**
+
 - Dead code: no security impact since it's never invoked
 - Confusing for maintainers: suggests a different pricing approach than what's actually used
 - `process.env` pattern is a footgun — if someone calls this function, it will fail silently
@@ -344,18 +364,19 @@ Remove the dead function. The `getPlantingUrl()` from config.ts correctly uses t
 
 #### [HAWK-015] GraftId Type Doesn't Include "upgrades" Explicitly
 
-| Field | Value |
-|-------|-------|
-| **Severity** | LOW |
-| **Domain** | Type Safety |
-| **Location** | `packages/engine/src/lib/grafts/types.ts` |
-| **Confidence** | HIGH |
-| **OWASP** | N/A |
+| Field          | Value                                     |
+| -------------- | ----------------------------------------- |
+| **Severity**   | LOW                                       |
+| **Domain**     | Type Safety                               |
+| **Location**   | `packages/engine/src/lib/grafts/types.ts` |
+| **Confidence** | HIGH                                      |
+| **OWASP**      | N/A                                       |
 
 **Description:**
 The `GraftId` type union only explicitly lists `"pricing"` with a `(string & {})` catch-all. The "upgrades" graft ID is accepted via the catch-all but lacks autocomplete and type narrowing in consuming code.
 
 **Impact:**
+
 - No runtime impact — the string catch-all accepts "upgrades"
 - Reduced developer experience — no autocomplete for "upgrades" in IDE
 - Inconsistent with the PricingGraft which is explicitly listed
@@ -369,18 +390,19 @@ Add `"upgrades"` to the `GraftId` union type.
 
 #### [HAWK-016] Duplicate BaseGraftProps in Component Types
 
-| Field | Value |
-|-------|-------|
-| **Severity** | LOW |
-| **Domain** | Code Quality |
-| **Location** | `packages/engine/src/lib/grafts/upgrades/components/types.ts:18-21` |
-| **Confidence** | HIGH |
-| **OWASP** | N/A |
+| Field          | Value                                                               |
+| -------------- | ------------------------------------------------------------------- |
+| **Severity**   | LOW                                                                 |
+| **Domain**     | Code Quality                                                        |
+| **Location**   | `packages/engine/src/lib/grafts/upgrades/components/types.ts:18-21` |
+| **Confidence** | HIGH                                                                |
+| **OWASP**      | N/A                                                                 |
 
 **Description:**
 The UpgradesGraft component types define their own `BaseGraftProps` (just `class?: string`) instead of importing from the shared graft types which includes `context?: GraftContext`. This shadows the core type and omits graft context support.
 
 **Impact:**
+
 - Components lack the `context` prop that enables feature flag evaluation
 - If components need graft context later, the type will need to be changed
 - Inconsistency with the PricingGraft component pattern
@@ -394,18 +416,19 @@ Import `BaseGraftProps` from `../types.js` or extend the shared version.
 
 #### [HAWK-017] isCompedAccount Mock Shape Mismatch in Tests
 
-| Field | Value |
-|-------|-------|
-| **Severity** | LOW |
-| **Domain** | Testing |
-| **Location** | `packages/engine/src/lib/grafts/upgrades/upgrades.test.ts:256` |
-| **Confidence** | HIGH |
-| **OWASP** | N/A |
+| Field          | Value                                                          |
+| -------------- | -------------------------------------------------------------- |
+| **Severity**   | LOW                                                            |
+| **Domain**     | Testing                                                        |
+| **Location**   | `packages/engine/src/lib/grafts/upgrades/upgrades.test.ts:256` |
+| **Confidence** | HIGH                                                           |
+| **OWASP**      | N/A                                                            |
 
 **Description:**
 The test mocks `isCompedAccount` to return `false` directly, but the actual function returns `{ isComped: boolean }`. This means the tests don't verify the destructuring pattern used in the handlers.
 
 **Evidence:**
+
 ```typescript
 // Test: returns boolean directly
 vi.mocked(isCompedAccount).mockResolvedValue(false);
@@ -415,11 +438,13 @@ const { isComped: isCompedBool } = await isCompedAccount(...);
 ```
 
 **Impact:**
+
 - Tests pass because destructuring `false` gives `undefined` for `isComped`, which is falsy
 - If the handler's destructuring pattern is wrong, tests won't catch it
 - May mask bugs in the comped account detection logic
 
 **Remediation:**
+
 ```typescript
 vi.mocked(isCompedAccount).mockResolvedValue({ isComped: false });
 ```
@@ -428,20 +453,21 @@ vi.mocked(isCompedAccount).mockResolvedValue({ isComped: false });
 
 ---
 
-#### [HAWK-018] export * Pattern in UpgradesGraft index.ts
+#### [HAWK-018] export \* Pattern in UpgradesGraft index.ts
 
-| Field | Value |
-|-------|-------|
-| **Severity** | LOW |
-| **Domain** | Code Quality |
-| **Location** | `packages/engine/src/lib/grafts/upgrades/index.ts:13-17` |
-| **Confidence** | HIGH |
-| **OWASP** | N/A |
+| Field          | Value                                                    |
+| -------------- | -------------------------------------------------------- |
+| **Severity**   | LOW                                                      |
+| **Domain**     | Code Quality                                             |
+| **Location**   | `packages/engine/src/lib/grafts/upgrades/index.ts:13-17` |
+| **Confidence** | HIGH                                                     |
+| **OWASP**      | N/A                                                      |
 
 **Description:**
 The UpgradesGraft index.ts uses `export * from "./types"` and `export * from "./components/index.js"` which re-exports everything. The PricingGraft uses explicit named exports, providing better control over the public API surface.
 
 **Impact:**
+
 - Internal types (like `GardenStats`) are exposed as public API
 - Name collisions possible if types overlap with other grafts
 - Harder to track what the graft's public surface actually is
@@ -458,6 +484,7 @@ Switch to explicit named exports matching the PricingGraft pattern.
 #### [HAWK-INFO-010] Previous HAWK-001 Now Fixed
 
 The plan selection onboarding step bypass (HAWK-001) has been addressed. The select-plan endpoint now validates:
+
 - `profile_completed_at` is set (profile step done)
 - `email_verified` is true (email verification done)
 
@@ -470,6 +497,7 @@ The `tenant_id` query parameter in the billing API (HAWK-002) has been removed. 
 #### [HAWK-INFO-012] Consistent Security Pattern Across UpgradesGraft APIs
 
 All three API handlers (cultivate, tend, growth) follow the same defensive pattern:
+
 1. Auth check (`locals.user`)
 2. CSRF validation (origin header — cultivate/tend only)
 3. Environment validation (`platform.env.DB`)
@@ -483,6 +511,7 @@ This consistency is excellent and makes the code easy to review.
 #### [HAWK-INFO-013] Proper Sensitive Data Filtering in Growth API
 
 The growth status endpoint correctly filters billing data:
+
 - Provider customer ID: **not exposed**
 - Provider subscription ID: **not exposed**
 - Payment method: only last4 and brand exposed
@@ -493,6 +522,7 @@ Only the minimum necessary data reaches the client.
 #### [HAWK-INFO-014] SQL Parameterization Throughout
 
 All SQL queries across the PR use parameterized statements (`.bind()`) — zero string concatenation. This applies to:
+
 - Billing queries in cultivate/tend/growth handlers
 - Free account IP limit checks
 - Activity tracking updates
@@ -502,6 +532,7 @@ All SQL queries across the PR use parameterized statements (`.bind()`) — zero 
 #### [HAWK-INFO-015] Audit Logging on All State Changes
 
 Both success and failure paths are audit-logged:
+
 - `cultivation_started` / `cultivation_failed`
 - `garden_shed_opened` / `garden_shed_failed`
 - Includes user email, session IDs, and target stages
@@ -511,6 +542,7 @@ Non-blocking design (won't fail the main operation if audit write fails).
 #### [HAWK-INFO-016] Fail-Open Tier Limits Are Intentional and Documented
 
 The blooms API enforces tier-based limits but fails open on DB errors:
+
 ```typescript
 // If the limit check fails, we don't block the user
 // This is intentional: availability > strict enforcement
@@ -521,6 +553,7 @@ This is the right tradeoff for a content creation API — it prevents a D1 outag
 #### [HAWK-INFO-017] Migration 053 Is Well-Structured
 
 The migration adds:
+
 - `last_activity_at` column to tenants (nullable, safe)
 - `reclamation_status` column with 'active' default
 - `reclaimed_accounts` table with proper foreign key
@@ -533,22 +566,22 @@ All nullable columns have sensible defaults. No destructive changes.
 
 ## Domain Scorecard
 
-| Domain | Rating | Findings | Notes |
-|--------|--------|----------|-------|
-| Authentication | PASS | 0 | Consistent auth checks in all handlers |
-| Authorization | PARTIAL | 1 HIGH, 1 MEDIUM | Billing PATCH bug, returnTo unvalidated |
-| Input Validation | PARTIAL | 1 MEDIUM | API field mismatch |
-| Data Protection | PASS | 0 | Sensitive data properly filtered |
-| HTTP Security | PASS | 0 | CSP, HSTS present |
-| CSRF Protection | PASS | 0 | Origin validation on state-changing endpoints |
-| Session Security | PASS | 0 | HttpOnly, Secure, SameSite |
-| File Uploads | N/A | 0 | Not in scope of this PR |
-| Rate Limiting | PASS | 0 | All endpoints rate-limited |
-| Multi-Tenant | PASS | 0 | Tenant isolation enforced |
-| Infrastructure | PASS | 0 | Cloudflare-compatible patterns |
-| Heartwood Auth | PASS | 0 | Session validation intact |
-| Exotic Vectors | PARTIAL | 1 MEDIUM | Race condition in IP limit |
-| Supply Chain | N/A | 0 | No new dependencies added |
+| Domain           | Rating  | Findings         | Notes                                         |
+| ---------------- | ------- | ---------------- | --------------------------------------------- |
+| Authentication   | PASS    | 0                | Consistent auth checks in all handlers        |
+| Authorization    | PARTIAL | 1 HIGH, 1 MEDIUM | Billing PATCH bug, returnTo unvalidated       |
+| Input Validation | PARTIAL | 1 MEDIUM         | API field mismatch                            |
+| Data Protection  | PASS    | 0                | Sensitive data properly filtered              |
+| HTTP Security    | PASS    | 0                | CSP, HSTS present                             |
+| CSRF Protection  | PASS    | 0                | Origin validation on state-changing endpoints |
+| Session Security | PASS    | 0                | HttpOnly, Secure, SameSite                    |
+| File Uploads     | N/A     | 0                | Not in scope of this PR                       |
+| Rate Limiting    | PASS    | 0                | All endpoints rate-limited                    |
+| Multi-Tenant     | PASS    | 0                | Tenant isolation enforced                     |
+| Infrastructure   | PASS    | 0                | Cloudflare-compatible patterns                |
+| Heartwood Auth   | PASS    | 0                | Session validation intact                     |
+| Exotic Vectors   | PARTIAL | 1 MEDIUM         | Race condition in IP limit                    |
+| Supply Chain     | N/A     | 0                | No new dependencies added                     |
 
 ---
 
@@ -559,6 +592,7 @@ All nullable columns have sensible defaults. No destructive changes.
 **Rating: 7/10 — Good foundation, needs polish**
 
 **What works well:**
+
 1. **Registry integration** — Correctly registered in `GRAFT_REGISTRY` with feature flag linkage (`upgrades_graft`), status `experimental`
 2. **Route delegation** — Thin SvelteKit route files re-export handlers from the graft module, keeping route files clean
 3. **Type system** — Well-defined interfaces for all request/response shapes with Grove-themed naming
@@ -566,6 +600,7 @@ All nullable columns have sensible defaults. No destructive changes.
 5. **Test coverage** — Tests exist for all 3 API handlers covering auth, CSRF, validation, and happy paths
 
 **What needs work:**
+
 1. **GraftId type gap** — "upgrades" not in the explicit union (HAWK-015)
 2. **BaseGraftProps shadow** — Own definition instead of sharing from core graft types (HAWK-016)
 3. **Export pattern divergence** — Uses `export *` instead of PricingGraft's explicit named exports (HAWK-018)
@@ -575,17 +610,17 @@ All nullable columns have sensible defaults. No destructive changes.
 
 ### Comparison to PricingGraft Pattern
 
-| Aspect | PricingGraft | UpgradesGraft | Match? |
-|--------|-------------|---------------|--------|
-| Registry entry | ✓ | ✓ | Yes |
-| Feature flag linked | ✓ | ✓ | Yes |
-| Barrel exports | Named | `export *` | **No** |
-| BaseGraftProps | Shared | Own copy | **No** |
-| Route delegation | Thin files | Thin files | Yes |
-| Config pattern | N/A | `createUpgradeConfig()` | Yes |
-| Component types | Separate file | Separate file | Yes |
-| Tests | N/A | Present | Bonus |
-| Status | `stable` | `experimental` | Appropriate |
+| Aspect              | PricingGraft  | UpgradesGraft           | Match?      |
+| ------------------- | ------------- | ----------------------- | ----------- |
+| Registry entry      | ✓             | ✓                       | Yes         |
+| Feature flag linked | ✓             | ✓                       | Yes         |
+| Barrel exports      | Named         | `export *`              | **No**      |
+| BaseGraftProps      | Shared        | Own copy                | **No**      |
+| Route delegation    | Thin files    | Thin files              | Yes         |
+| Config pattern      | N/A           | `createUpgradeConfig()` | Yes         |
+| Component types     | Separate file | Separate file           | Yes         |
+| Tests               | N/A           | Present                 | Bonus       |
+| Status              | `stable`      | `experimental`          | Appropriate |
 
 ---
 
@@ -593,16 +628,16 @@ All nullable columns have sensible defaults. No destructive changes.
 
 The `/gathering-feature` skill calls for a full feature lifecycle: Bloodhound→Elephant→Turtle→Beaver→Raccoon→Deer→Fox→Owl. Here's how the UpgradesGraft measures up:
 
-| Phase | Animal | Principle | Assessment |
-|-------|--------|-----------|------------|
-| Explore | Bloodhound | Understand existing patterns before building | **PARTIAL** — Follows some engine patterns but diverges on exports and BaseGraftProps |
-| Build | Elephant | Multi-file features with unstoppable momentum | **GOOD** — Clean separation: types, config, server API, components, tests, migration |
-| Harden | Turtle | Security by design, defense in depth | **GOOD** — Auth, CSRF, rate limits, tenant isolation all present. But returnTo validation missing |
-| Test | Beaver | Robust tests that catch bugs | **PARTIAL** — Tests exist but mock shapes don't match reality (HAWK-017) |
-| Audit | Raccoon | Clean up what doesn't belong | **NEEDS WORK** — Dead code present (getStagePriceId), type shadows |
-| Accessibility | Deer | Accessible by design | **N/A** — Components are type definitions only, no rendered UI audited |
-| Optimize | Fox | Performance bottlenecks | **GOOD** — Parallelized queries in blooms, fire-and-forget activity tracking |
-| Document | Owl | Clear documentation | **GOOD** — JSDoc on all exports, clear Grove terminology mapping, plan document exists |
+| Phase         | Animal     | Principle                                     | Assessment                                                                                        |
+| ------------- | ---------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Explore       | Bloodhound | Understand existing patterns before building  | **PARTIAL** — Follows some engine patterns but diverges on exports and BaseGraftProps             |
+| Build         | Elephant   | Multi-file features with unstoppable momentum | **GOOD** — Clean separation: types, config, server API, components, tests, migration              |
+| Harden        | Turtle     | Security by design, defense in depth          | **GOOD** — Auth, CSRF, rate limits, tenant isolation all present. But returnTo validation missing |
+| Test          | Beaver     | Robust tests that catch bugs                  | **PARTIAL** — Tests exist but mock shapes don't match reality (HAWK-017)                          |
+| Audit         | Raccoon    | Clean up what doesn't belong                  | **NEEDS WORK** — Dead code present (getStagePriceId), type shadows                                |
+| Accessibility | Deer       | Accessible by design                          | **N/A** — Components are type definitions only, no rendered UI audited                            |
+| Optimize      | Fox        | Performance bottlenecks                       | **GOOD** — Parallelized queries in blooms, fire-and-forget activity tracking                      |
+| Document      | Owl        | Clear documentation                           | **GOOD** — JSDoc on all exports, clear Grove terminology mapping, plan document exists            |
 
 **Overall gathering-feature adherence: 6/10** — The feature follows the spirit of the lifecycle but skipped the Raccoon (cleanup) and Beaver (thorough testing) phases. The Turtle (security) pass was good but missed the returnTo validation gap.
 
@@ -610,36 +645,40 @@ The `/gathering-feature` skill calls for a full feature lifecycle: Bloodhound→
 
 ## Items Requiring Manual Verification
 
-| ID | Finding | What to Test | Confidence |
-|----|---------|--------------|------------|
-| HAWK-010 | Billing PATCH ReferenceError | Call PATCH /api/billing with cancel action — should 500 | HIGH |
-| HAWK-011 | returnTo open redirect | Send `returnTo: "https://evil.com"` to tend API — check Stripe portal return URL | HIGH |
-| HAWK-012 | shedUrl field mismatch | Click "Manage Billing" on arbor account page — should fail silently | HIGH |
-| N/A | IP rate limit effectiveness | Create 4+ free accounts from same IP within 30 days | MEDIUM |
-| N/A | Tier limit enforcement | Create 6 posts as wanderer tier — should be blocked | MEDIUM |
-| N/A | Activity tracking | Check tenants.last_activity_at updates on API calls | MEDIUM |
+| ID       | Finding                      | What to Test                                                                     | Confidence |
+| -------- | ---------------------------- | -------------------------------------------------------------------------------- | ---------- |
+| HAWK-010 | Billing PATCH ReferenceError | Call PATCH /api/billing with cancel action — should 500                          | HIGH       |
+| HAWK-011 | returnTo open redirect       | Send `returnTo: "https://evil.com"` to tend API — check Stripe portal return URL | HIGH       |
+| HAWK-012 | shedUrl field mismatch       | Click "Manage Billing" on arbor account page — should fail silently              | HIGH       |
+| N/A      | IP rate limit effectiveness  | Create 4+ free accounts from same IP within 30 days                              | MEDIUM     |
+| N/A      | Tier limit enforcement       | Create 26 posts as wanderer tier — should be blocked                             | MEDIUM     |
+| N/A      | Activity tracking            | Check tenants.last_activity_at updates on API calls                              | MEDIUM     |
 
 ---
 
 ## Remediation Priority
 
 ### Immediate (fix before merge)
+
 - **HAWK-010**: Capture `verifiedTenantId` return value in billing PATCH handler (1 line fix)
 - **HAWK-012**: Fix `response.url` → `response.shedUrl` in arbor account page (1 line fix)
 - **HAWK-019**: Replace `"wanderer"` with `"free"` in component stageNames maps and conditionals
 
 ### Short-term (fix before GA)
+
 - **HAWK-011**: Validate `returnTo` URL against allowlist in tend.ts and cultivate.ts
 - **HAWK-013**: Run IP check before `payment_completed` update (reorder async operations)
 - **HAWK-017**: Fix mock shapes in test file to match actual function signatures
 
 ### Medium-term (cleanup pass)
+
 - **HAWK-014**: Remove dead `getStagePriceId()` function
 - **HAWK-015**: Add "upgrades" to `GraftId` union type
 - **HAWK-016**: Import shared `BaseGraftProps` instead of defining own
 - **HAWK-018**: Switch to explicit named exports
 
 ### Long-term (track)
+
 - Registry test coverage for upgrades graft
 - Component accessibility audit when Svelte components are implemented
 - Reclamation system security review when cron is enabled
@@ -673,12 +712,14 @@ The UpgradesGraft implementation demonstrates several strong practices:
 This code was primarily authored by Minimax m2.1 via the crush agent. Assessment of the output quality:
 
 **Strengths:**
+
 - Clean code structure and separation of concerns
 - Consistent patterns across related files
 - Good type definitions with JSDoc documentation
 - Proper error handling with try/catch patterns
 
 **Areas where human (or stronger model) review caught issues:**
+
 - Variable reference bug (HAWK-010) — classic copy-paste error where the refactoring changed `const verifiedTenantId = await ...` to `await ...` but didn't remove the downstream references
 - API field mismatch (HAWK-012) — integration point between tend handler and consuming UI wasn't verified end-to-end
 - Mock shape mismatch (HAWK-017) — tests pass but don't actually verify the code's destructuring patterns
@@ -688,4 +729,4 @@ These are typical "works in isolation, breaks at integration" issues that multi-
 
 ---
 
-*The hawk has spoken. Twenty commits surveyed, sixty-nine files examined, every shadow probed. The grove grows well — a few branches need pruning, and two walls need patching, but the roots are strong and the garden knows its keeper.* 🦅
+_The hawk has spoken. Twenty commits surveyed, sixty-nine files examined, every shadow probed. The grove grows well — a few branches need pruning, and two walls need patching, but the roots are strong and the garden knows its keeper._ 🦅

--- a/docs/specs/wanderer-plan-spec.md
+++ b/docs/specs/wanderer-plan-spec.md
@@ -4,7 +4,7 @@ description: A free, limited blog tier that lets anyone try Grove before committ
 category: specs
 specCategory: platform-services
 icon: footprints
-lastUpdated: '2026-02-09'
+lastUpdated: "2026-02-09"
 aliases: []
 tags:
   - pricing
@@ -29,25 +29,27 @@ tags:
                          ╰────┬────╯
                               │
                          ╭────┴────╮
-                         │ 📝 📝  │
-                         │ 📝 📝  │
-                         │ 📝     │
-                         ╰─────── ╯
-                          5 blooms
+                         │ 📝 📝 📝 📝 📝 │
+                         │ 📝 📝 📝 📝 📝 │
+                         │ 📝 📝 📝 📝 📝 │
+                         │ 📝 📝 📝 📝 📝 │
+                         │ 📝 📝 📝 📝 📝 │
+                         ╰─────────────────╯
+                             25 blooms
 
               the gate is open. come write.
 ```
 
-> *The gate is open. Come write.*
+> _The gate is open. Come write._
 
-A free blog tier for anyone who wants to try Grove. No credit card. No trial countdown. Just a subdomain, five posts, and a little room to breathe. If you like it here, take root. If not, no hard feelings.
+A free blog tier for anyone who wants to try Grove. No credit card. No trial countdown. Just a subdomain, twenty-five posts, and room to breathe. If you like it here, take root. If not, no hard feelings.
 
 **Public Name:** Wanderer Plan
 **Internal Name:** free tier (`free` in tiers.ts)
 **Status:** Proposed
 **Last Updated:** February 2026
 
-Every forest has a clearing where travelers can rest. Set down your pack, sit by the fire, look around. The Wanderer Plan is that clearing. You get enough space to write, enough room to see if this place feels like home. Five blooms. Fifty megabytes. One theme. A `username.grove.place` address that's yours for as long as you're here.
+Every forest has a clearing where travelers can rest. Set down your pack, sit by the fire, look around. The Wanderer Plan is that clearing. You get enough space to write, enough room to see if this place feels like home. Twenty-five blooms. A hundred megabytes. One theme. A `username.grove.place` address that's yours for as long as you're here.
 
 The catch? There isn't one. Just one gentle condition: if you leave and don't come back for a year, we'll reclaim the space for someone who needs it.
 
@@ -65,13 +67,14 @@ The result: people who would love Grove never find out, because they can't affor
 
 You don't need a 14-day trial with a credit card form. You need a front door that's actually open.
 
-Five blog posts is enough to:
+Twenty-five blog posts is enough to:
+
 - Feel the editor
-- See your words on a real URL
-- Share a link with a friend
+- Build a real blog, not just a demo
+- Share links with friends and find your voice
 - Know whether this is your place
 
-And it costs us almost nothing. Five text posts in D1 is fractions of a cent. 50MB in R2 is barely measurable. The subdomain routing already works. The rate limiting already exists.
+And it costs us almost nothing. Twenty-five text posts in D1 is fractions of a cent. 100MB in R2 is barely measurable. The subdomain routing already works. The rate limiting already exists.
 
 ### The Goal
 
@@ -83,28 +86,28 @@ Turn "I've heard of Grove" into "I have a Grove." Remove every barrier between c
 
 ### Included
 
-| Feature | Wanderer (Free) | Seedling ($8/mo) |
-|---------|-----------------|-------------------|
-| Blog | Yes | Yes |
-| Published posts | 5 | 50 |
-| Drafts | 100 | Unlimited |
-| Storage | 50 MB | 1 GB |
-| Themes | 1 (default) | 3 |
-| Subdomain | `username.grove.place` | `username.grove.place` |
-| RSS feed | Yes | Yes |
-| Meadow access | Browse + reply | Full participation |
-| Comments/replies | 20/week (shared reed counter) | Unlimited |
-| Nav pages | 0 | 0 |
-| AI features | No | Yes (750 words/mo) |
-| Custom domain | No | No |
-| Email forwarding | No | No |
-| Shop | No | No |
-| Analytics | No | No |
-| Credit card required | No | Yes |
+| Feature              | Wanderer (Free)               | Seedling ($8/mo)       |
+| -------------------- | ----------------------------- | ---------------------- |
+| Blog                 | Yes                           | Yes                    |
+| Published posts      | 25                            | 100                    |
+| Drafts               | 100                           | Unlimited              |
+| Storage              | 100 MB                        | 1 GB                   |
+| Themes               | 1 (default)                   | 3                      |
+| Subdomain            | `username.grove.place`        | `username.grove.place` |
+| RSS feed             | Yes                           | Yes                    |
+| Meadow access        | Browse + reply                | Full participation     |
+| Comments/replies     | 20/week (shared reed counter) | Unlimited              |
+| Nav pages            | 0                             | 0                      |
+| AI features          | No                            | Yes (750 words/mo)     |
+| Custom domain        | No                            | No                     |
+| Email forwarding     | No                            | No                     |
+| Shop                 | No                            | No                     |
+| Analytics            | No                            | No                     |
+| Credit card required | No                            | Yes                    |
 
 ### Drafts
 
-Drafts do **not** count toward the 5-post limit. Only published posts count. Wanderers can have up to **100 drafts**. Paid tiers get unlimited drafts.
+Drafts do **not** count toward the 25-post limit. Only published posts count. Wanderers can have up to **100 drafts**. Paid tiers get unlimited drafts.
 
 This keeps the creative process frictionless. Write as much as you want. The limit is on what's live, not what's in progress. And 100 drafts is generous enough that nobody hits it by accident, but it prevents someone from using Grove as a free infinite note-taking app.
 
@@ -138,7 +141,7 @@ The Wanderer Plan is designed to make upgrading feel natural, never forced.
   ╭──────────────────────────────────────────────────────────╮
   │                    Wanderer (Free)                       │
   │                                                          │
-  │    📝 📝 📝 📝 📝    ← "You've used 5 of 5 blooms"     │
+  │    📝 📝 📝 ...      ← "You've used 25 of 25 blooms"    │
   │                                                          │
   │    ┌──────────────────────────────────────────────┐      │
   │    │  🌱 Ready to grow?                           │      │
@@ -146,7 +149,7 @@ The Wanderer Plan is designed to make upgrading feel natural, never forced.
   │    │  You've filled your garden. Take root      │      │
   │    │  and get room to keep writing.               │      │
   │    │                                              │      │
-  │    │  Seedling: $8/mo · 50 posts · 1 GB · AI     │      │
+  │    │  Seedling: $8/mo · 100 posts · 1 GB · AI    │      │
   │    │                                              │      │
   │    │        [ Take Root ]    [ Maybe Later ]      │      │
   │    └──────────────────────────────────────────────┘      │
@@ -155,9 +158,9 @@ The Wanderer Plan is designed to make upgrading feel natural, never forced.
 
 ### Upgrade Triggers (Gentle, Never Pushy)
 
-1. **Post limit reached (5/5):** Soft banner in the editor. "You've filled your garden. Take root and get room to keep writing." They can still edit existing posts. They just can't create new ones.
+1. **Post limit reached (25/25):** Soft banner in the editor. "You've filled your garden. Take root and get room to keep writing." They can still edit existing posts. They just can't create new ones.
 
-2. **Storage limit approaching (40/50 MB):** Subtle notice. "Your storage is getting cozy. Seedling gives you 1 GB to spread out."
+2. **Storage limit approaching (80/100 MB):** Subtle notice. "Your storage is getting cozy. Seedling gives you 1 GB to spread out."
 
 3. **Theme browsing:** When they look at other themes, show them locked with a warm "Available with Seedling" label. Let them preview but not apply.
 
@@ -165,7 +168,7 @@ The Wanderer Plan is designed to make upgrading feel natural, never forced.
 
 ### What Carries Over on Upgrade
 
-Everything. All five posts, all uploaded images, their subdomain, their theme settings. Nothing is lost. Taking root means growing from where you already are.
+Everything. All posts, all uploaded images, their subdomain, their theme settings. Nothing is lost. Taking root means growing from where you already are.
 
 ---
 
@@ -180,6 +183,7 @@ Free accounts without expiration attract squatters. Someone grabs `coolname.grov
 If a free-tier account has **no activity for 365 consecutive days**, the account enters a reclamation process.
 
 **What counts as "activity":**
+
 - Logging in
 - Creating or editing a post
 - Uploading media
@@ -187,6 +191,7 @@ If a free-tier account has **no activity for 365 consecutive days**, the account
 - Receiving a comment (someone visited, your blog matters)
 
 **What does NOT count:**
+
 - Automated crawlers hitting the subdomain
 - RSS feed fetches
 - Password reset emails sent but not acted on
@@ -280,7 +285,7 @@ Free tiers attract abuse. Here's how we handle it.
 
 ### What We're NOT Worried About
 
-- **Someone happily using 5 posts forever:** That's fine. Their blog existing at `username.grove.place` is free advertising. Every free blog is a potential referral. The cost to us is effectively zero.
+- **Someone happily using 25 posts forever:** That's fine. Their blog existing at `username.grove.place` is free advertising. Every free blog is a potential referral. The cost to us is effectively zero.
 - **Lots of free accounts:** Good. That means people are trying Grove. Most will either upgrade or leave. Both are fine outcomes.
 
 ---
@@ -295,8 +300,8 @@ The free tier already exists in `packages/engine/src/lib/config/tiers.ts` with `
   Current Free Tier          Wanderer Plan (Proposed)
   ─────────────────          ────────────────────────
   blog: false          →     blog: true
-  posts: 0             →     posts: 5
-  storage: 0           →     storage: 50 MB
+  posts: 0             →     posts: 25
+  storage: 0           →     storage: 100 MB
   themes: 0            →     themes: 1
   status: coming_soon  →     status: available
   uploads: 0/day       →     uploads: 5/day
@@ -314,8 +319,8 @@ The free tier already exists in `packages/engine/src/lib/config/tiers.ts` with `
   Icon:         footprints
   Best For:     "The curious"
   Feature List:
-    - "5 blooms"
-    - "50 MB storage"
+    - "25 blooms"
+    - "100 MB storage"
     - "Your own grove.place address"
     - "RSS feed"
     - "No credit card needed"
@@ -426,27 +431,29 @@ Once launched, track:
 
 All open questions have been resolved:
 
-| Question | Decision |
-|----------|----------|
+| Question          | Decision                                                                                              |
+| ----------------- | ----------------------------------------------------------------------------------------------------- |
 | Canopy visibility | Yes, with 1+ published post. Account age icons shown (see `docs/plans/planned/account-age-icons.md`). |
-| Meadow access | Browse + reply. Cannot start new feed posts. Replies share the 20/week reed counter. |
-| Drafts vs. limit | Drafts don't count. Only published posts. Max 100 drafts (unlimited for paid). |
-| Theme | 1 default theme (Foliage not yet integrated). Can preview others, can't apply. |
-| Receive comments | Yes, 20/week via reed counter. |
-| Auth method | Identical to all other Grove login points. Same Heartwood flow, no restrictions. |
+| Meadow access     | Browse + reply. Cannot start new feed posts. Replies share the 20/week reed counter.                  |
+| Drafts vs. limit  | Drafts don't count. Only published posts. Max 100 drafts (unlimited for paid).                        |
+| Theme             | 1 default theme (Foliage not yet integrated). Can preview others, can't apply.                        |
+| Receive comments  | Yes, 20/week via reed counter.                                                                        |
+| Auth method       | Identical to all other Grove login points. Same Heartwood flow, no restrictions.                      |
 
 ---
 
 ## Implementation Checklist
 
 ### Tier Config & Limits
-- [ ] Update free tier config in `tiers.ts` (blog: true, posts: 5, storage: 50MB, themes: 1, status: available)
+
+- [ ] Update free tier config in `tiers.ts` (blog: true, posts: 25, storage: 100MB, themes: 1, status: available)
 - [ ] Update free tier display strings (name: "Wanderer", tagline, description, feature list)
 - [ ] Update rate limits for free tier (uploads: 5/day, requests: 60/min)
 - [ ] Add draft limit enforcement (100 drafts for free tier, unlimited for paid)
-- [ ] Update post limit enforcement to handle 5-post limit (published only, drafts excluded)
+- [ ] Update post limit enforcement to handle 25-post limit (published only, drafts excluded)
 
 ### Database & Infra
+
 - [ ] Add `last_activity_at` column to tenants table (migration)
 - [ ] Add `reclamation_status` column to tenants table (migration)
 - [ ] Create `reclaimed_accounts` table (migration)
@@ -455,20 +462,23 @@ All open questions have been resolved:
 - [ ] Write "We miss you" and "Final notice" email templates
 
 ### Onboarding & Plans
+
 - [ ] Update onboarding flow to support free signups (skip payment, same Heartwood auth)
 - [ ] Update plans page to show Wanderer Plan first
 - [ ] Add IP-based free account creation limits (3 per IP per 30 days)
 
 ### Upgrade Experience
+
 - [ ] Add upgrade prompts (post limit reached, storage warning, theme preview)
 - [ ] Add draft limit upgrade prompt (approaching 100 drafts)
 - [ ] Test free → Seedling upgrade path (content preservation)
 
 ### Community Integration
+
 - [ ] Update Canopy to show Wanderers with 1+ published post
 - [ ] Meadow: allow browse + reply for free tier, block starting new feed posts
 - [ ] Ensure reed counter is shared across blog comments and Meadow replies
 
 ---
 
-*The gate is open. Come write.*
+_The gate is open. Come write._

--- a/packages/durable-objects/src/tiers.ts
+++ b/packages/durable-objects/src/tiers.ts
@@ -111,18 +111,18 @@ export const TIERS: Record<TierKey, TierConfig> = {
   free: {
     id: "free",
     order: 0,
-    status: "coming_soon",
+    status: "available",
     limits: {
-      posts: 0,
-      storage: 0,
-      storageDisplay: "0 MB",
-      themes: 0,
+      posts: 25,
+      storage: 100 * 1024 * 1024, // 100 MB
+      storageDisplay: "100 MB",
+      themes: 1,
       navPages: 0,
       commentsPerWeek: 20,
       aiWordsPerMonth: 0,
     },
     features: {
-      blog: false,
+      blog: true,
       meadow: true,
       emailForwarding: false,
       fullEmail: false,
@@ -136,9 +136,9 @@ export const TIERS: Record<TierKey, TierConfig> = {
       analytics: false,
     },
     rateLimits: {
-      requests: { limit: 50, windowSeconds: 60 },
+      requests: { limit: 60, windowSeconds: 60 },
       writes: { limit: 20, windowSeconds: 3600 },
-      uploads: { limit: 0, windowSeconds: 86400 },
+      uploads: { limit: 5, windowSeconds: 86400 },
       ai: { limit: 0, windowSeconds: 86400 },
     },
     pricing: {
@@ -148,16 +148,18 @@ export const TIERS: Record<TierKey, TierConfig> = {
       yearlyPriceCents: 0,
     },
     display: {
-      name: "Free",
-      tagline: "Just visiting",
-      description: "Hang out in Meadow, follow blogs, react and comment.",
-      icon: "user",
-      bestFor: "Readers",
+      name: "Wanderer",
+      tagline: "Your first steps in the grove",
+      description:
+        "A quiet clearing to try your hand at writing. No commitment, no credit card.",
+      icon: "footprints",
+      bestFor: "The curious",
       featureStrings: [
-        "Meadow access",
-        "20 comments/week",
-        "Follow blogs",
-        "React to blooms",
+        "25 blooms",
+        "100 MB storage",
+        "Your own grove.place address",
+        "RSS feed",
+        "No credit card needed",
       ],
     },
     support: { level: "help_center", displayString: "Help Center" },
@@ -168,7 +170,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
     order: 1,
     status: "available",
     limits: {
-      posts: 50,
+      posts: 100,
       storage: 1 * 1024 * 1024 * 1024, // 1 GB
       storageDisplay: "1 GB",
       themes: 3,
@@ -210,7 +212,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
       icon: "sprout",
       bestFor: "Curious",
       featureStrings: [
-        "50 blooms",
+        "100 blooms",
         "1 GB storage",
         "3 curated themes",
         "Meadow access",
@@ -226,7 +228,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
     order: 2,
     status: "coming_soon",
     limits: {
-      posts: 250,
+      posts: Infinity,
       storage: 5 * 1024 * 1024 * 1024, // 5 GB
       storageDisplay: "5 GB",
       themes: 10,
@@ -267,7 +269,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
       icon: "tree-deciduous",
       bestFor: "Hobbyists",
       featureStrings: [
-        "250 blooms",
+        "Unlimited blooms",
         "5 GB storage",
         "10 themes",
         "3 nav pages",

--- a/packages/engine/src/lib/config/tiers.test.ts
+++ b/packages/engine/src/lib/config/tiers.test.ts
@@ -78,9 +78,9 @@ describe("Tier Configuration", () => {
     });
 
     it("has increasing post limits", () => {
-      expect(TIERS.free.limits.posts).toBe(5);
-      expect(TIERS.seedling.limits.posts).toBe(50);
-      expect(TIERS.sapling.limits.posts).toBe(250);
+      expect(TIERS.free.limits.posts).toBe(25);
+      expect(TIERS.seedling.limits.posts).toBe(100);
+      expect(TIERS.sapling.limits.posts).toBe(Infinity);
       expect(TIERS.oak.limits.posts).toBe(Infinity);
       expect(TIERS.evergreen.limits.posts).toBe(Infinity);
     });
@@ -92,7 +92,7 @@ describe("Tier Configuration", () => {
       const oakStorage = TIERS.oak.limits.storage;
       const evergreenStorage = TIERS.evergreen.limits.storage;
 
-      expect(freeStorage).toBe(50 * 1024 * 1024); // 50 MB
+      expect(freeStorage).toBe(100 * 1024 * 1024); // 100 MB
       expect(seedlingStorage).toBeGreaterThan(freeStorage);
       expect(saplingStorage).toBeGreaterThan(seedlingStorage);
       expect(oakStorage).toBeGreaterThan(saplingStorage);
@@ -240,7 +240,7 @@ describe("Tier Configuration", () => {
 
     describe("getTierLimit", () => {
       it("returns correct limits", () => {
-        expect(getTierLimit("seedling", "posts")).toBe(50);
+        expect(getTierLimit("seedling", "posts")).toBe(100);
         expect(getTierLimit("sapling", "navPages")).toBe(3);
         expect(getTierLimit("oak", "posts")).toBe(Infinity);
       });
@@ -265,9 +265,9 @@ describe("Tier Configuration", () => {
 
     it("has blog enabled with correct limits", () => {
       expect(TIERS.free.features.blog).toBe(true);
-      expect(TIERS.free.limits.posts).toBe(5);
+      expect(TIERS.free.limits.posts).toBe(25);
       expect(TIERS.free.limits.drafts).toBe(100);
-      expect(TIERS.free.limits.storage).toBe(50 * 1024 * 1024);
+      expect(TIERS.free.limits.storage).toBe(100 * 1024 * 1024);
       expect(TIERS.free.limits.themes).toBe(1);
     });
 

--- a/packages/engine/src/lib/config/tiers.ts
+++ b/packages/engine/src/lib/config/tiers.ts
@@ -5,7 +5,7 @@
  * This file consolidates feature limits, rate limits, pricing, and display info.
  *
  * Tier progression:
- * - free: Wanderer Plan — 5 posts, 50 MB, no credit card
+ * - free: Wanderer Plan — 25 posts, 100 MB, no credit card
  * - seedling: $8/mo entry tier
  * - sapling: $12/mo mid tier - coming soon
  * - oak: $25/mo with BYOD domain - future
@@ -124,10 +124,10 @@ export const TIERS: Record<TierKey, TierConfig> = {
     order: 0,
     status: "available",
     limits: {
-      posts: 5,
+      posts: 25,
       drafts: 100,
-      storage: 50 * 1024 * 1024, // 50 MB
-      storageDisplay: "50 MB",
+      storage: 100 * 1024 * 1024, // 100 MB
+      storageDisplay: "100 MB",
       themes: 1,
       navPages: 0,
       commentsPerWeek: 20,
@@ -167,16 +167,16 @@ export const TIERS: Record<TierKey, TierConfig> = {
       icon: "footprints",
       bestFor: "The curious",
       featureStrings: [
-        "5 blooms",
-        "50 MB storage",
+        "25 blooms",
+        "100 MB storage",
         "Your own grove.place address",
         "RSS feed",
         "No credit card needed",
       ],
       standardName: "Free",
       standardFeatureStrings: [
-        "5 posts",
-        "50 MB storage",
+        "25 posts",
+        "100 MB storage",
         "Your own grove.place address",
         "RSS feed",
         "No credit card needed",
@@ -190,7 +190,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
     order: 1,
     status: "available",
     limits: {
-      posts: 50,
+      posts: 100,
       drafts: Infinity,
       storage: 1 * 1024 * 1024 * 1024, // 1 GB
       storageDisplay: "1 GB",
@@ -233,7 +233,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
       icon: "sprout",
       bestFor: "Curious",
       featureStrings: [
-        "50 blooms",
+        "100 blooms",
         "1 GB storage",
         // TODO(foliage): uncomment when themes launch
         // "3 curated themes",
@@ -243,7 +243,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
       ],
       standardName: "Starter",
       standardFeatureStrings: [
-        "50 posts",
+        "100 posts",
         "1 GB storage",
         // TODO(foliage): uncomment when themes launch
         // "3 curated themes",
@@ -260,7 +260,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
     order: 2,
     status: "coming_soon",
     limits: {
-      posts: 250,
+      posts: Infinity,
       drafts: Infinity,
       storage: 5 * 1024 * 1024 * 1024, // 5 GB
       storageDisplay: "5 GB",
@@ -302,7 +302,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
       icon: "tree-deciduous",
       bestFor: "Hobbyists",
       featureStrings: [
-        "250 blooms",
+        "Unlimited blooms",
         "5 GB storage",
         // TODO(foliage): uncomment when themes launch
         // "10 themes",
@@ -313,7 +313,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
       ],
       standardName: "Growth",
       standardFeatureStrings: [
-        "250 posts",
+        "Unlimited posts",
         "5 GB storage",
         // TODO(foliage): uncomment when themes launch
         // "10 themes",
@@ -481,7 +481,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
  *
  * Seedling is the default because:
  * - It's the entry-level paid tier with reasonable limits
- * - Free tier (Wanderer) has tight limits (5 posts, 50 MB), so defaulting
+ * - Free tier (Wanderer) has tight limits (25 posts, 100 MB), so defaulting
  *   to it could unexpectedly restrict users with unknown/invalid tier data
  * - It provides a good baseline without being overly permissive
  */

--- a/packages/engine/src/lib/grafts/pricing/PricingFineprint.svelte
+++ b/packages/engine/src/lib/grafts/pricing/PricingFineprint.svelte
@@ -30,7 +30,7 @@
 		free: {
 			title: "Wanderer Accounts",
 			content:
-				"Wanderer accounts get 5 blog posts and 50 MB storage — enough to try your hand at writing with no commitment. [[meadow|Meadow]] access for browsing and reacting. No credit card needed. When you're ready for more room, cultivate to [[seedling|Seedling]].",
+				"Wanderer accounts get 25 blog posts and 100 MB storage — enough to try your hand at writing with no commitment. [[meadow|Meadow]] access for browsing and reacting. No credit card needed. When you're ready for more room, cultivate to [[seedling|Seedling]].",
 		},
 		// TODO(foliage): update content when themes launch
 		themes: {

--- a/packages/engine/src/lib/grafts/pricing/config.test.ts
+++ b/packages/engine/src/lib/grafts/pricing/config.test.ts
@@ -86,8 +86,8 @@ describe("Pricing Graft Configuration", () => {
       expect(tier.monthlyPrice).toBe(0);
       expect(tier.annualPrice).toBe(0);
       expect(tier.annualSavings).toBe(0);
-      expect(tier.limits.posts).toBe("5");
-      expect(tier.limits.storage).toBe("50 MB");
+      expect(tier.limits.posts).toBe("25");
+      expect(tier.limits.storage).toBe("100 MB");
     });
 
     it("transforms seedling tier with correct limits", () => {
@@ -97,7 +97,7 @@ describe("Pricing Graft Configuration", () => {
       expect(tier.name).toBe("Seedling");
       expect(tier.monthlyPrice).toBe(8);
       expect(tier.annualSavings).toBe(15);
-      expect(tier.limits.posts).toBe("50");
+      expect(tier.limits.posts).toBe("100");
     });
 
     it("transforms oak tier with unlimited posts", () => {


### PR DESCRIPTION
The free tier's 5-post limit was too restrictive — someone posting weekly
would hit the wall in 5 weeks, before they'd even had a chance to fall
in love with Grove. Raise limits across the board so the upgrade path
shifts from "you can't write anymore" to "you want more features":

- Wanderer (free): 5 → 25 posts, 50 → 100 MB storage
- Seedling ($8/mo): 50 → 100 posts
- Sapling ($12/mo): 250 → Unlimited posts

From Sapling upward, post count is no longer a differentiator — the
upgrade incentive becomes features (themes, email, domains, analytics).

Updates unified config, durable objects copy, pricing docs, help center
articles, wanderer spec, security report, tests, and UI strings.

https://claude.ai/code/session_01HfBD7XDRfV64Dv5gfJtxxa