### PR TITLE
refactor(pricing): rework tier verbiage to focus on real differentiators

### DIFF
--- a/packages/engine/src/lib/config/tiers.ts
+++ b/packages/engine/src/lib/config/tiers.ts
@@ -165,7 +165,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
       description:
         "A quiet clearing to try your hand at writing. No commitment, no credit card.",
       icon: "footprints",
-      bestFor: "The curious",
+      bestFor: "Trying it out",
       featureStrings: [
         "25 blooms",
         "100 MB storage",
@@ -229,17 +229,17 @@ export const TIERS: Record<TierKey, TierConfig> = {
       name: "Seedling",
       tagline: "Just planted",
       description:
-        "Perfect for getting started. A quiet corner to call your own.",
+        "Your own corner of the internet. Room to write, no distractions, no ads.",
       icon: "sprout",
-      bestFor: "Curious",
+      bestFor: "Writers finding their voice",
       featureStrings: [
         "100 blooms",
         "1 GB storage",
         // TODO(foliage): uncomment when themes launch
         // "3 curated themes",
+        "Unlimited comments",
         "Meadow access",
-        "RSS feed",
-        "No ads ever",
+        "No ads, no tracking",
       ],
       standardName: "Starter",
       standardFeatureStrings: [
@@ -247,9 +247,9 @@ export const TIERS: Record<TierKey, TierConfig> = {
         "1 GB storage",
         // TODO(foliage): uncomment when themes launch
         // "3 curated themes",
+        "Unlimited comments",
         "Community feed access",
-        "RSS feed",
-        "No ads ever",
+        "No ads, no tracking",
       ],
     },
     support: { level: "community", displayString: "Community" },
@@ -300,7 +300,7 @@ export const TIERS: Record<TierKey, TierConfig> = {
       tagline: "Growing strong",
       description: "For blogs finding their voice. Room to stretch and grow.",
       icon: "tree-deciduous",
-      bestFor: "Hobbyists",
+      bestFor: "Regular writers",
       featureStrings: [
         "Unlimited blooms",
         "5 GB storage",
@@ -369,9 +369,10 @@ export const TIERS: Record<TierKey, TierConfig> = {
     display: {
       name: "Oak",
       tagline: "Deep roots",
-      description: "Full creative control. Your blog, your rules.",
+      description:
+        "Your own domain, full email, and complete creative control.",
       icon: "trees",
-      bestFor: "Serious Bloggers",
+      bestFor: "Established writers",
       featureStrings: [
         "Unlimited blooms",
         "20 GB storage",
@@ -440,7 +441,8 @@ export const TIERS: Record<TierKey, TierConfig> = {
     display: {
       name: "Evergreen",
       tagline: "Always flourishing",
-      description: "The complete package. Everything Grove has to offer.",
+      description:
+        "Domain included, dedicated support, and everything Grove has to offer.",
       icon: "crown",
       bestFor: "Professionals",
       featureStrings: [

--- a/packages/engine/src/lib/grafts/pricing/PricingFineprint.svelte
+++ b/packages/engine/src/lib/grafts/pricing/PricingFineprint.svelte
@@ -83,18 +83,16 @@
 				"Grove is designed around portability. Export everything at any time. If we ever register a domain for you, you own it — transfer it whenever you want, no fees, no questions.",
 		},
 		ai: {
-			title: "AI Features",
+			title: "AI Protection",
 			content:
-				"Every Grove blog is protected by [[shade|Shade]] — our 8-layer defense against AI crawlers, scrapers, and training bots. Your words are never used to train AI models. Paid tiers include [[wisp|Wisp]], a writing assistant that polishes your voice without replacing it: grammar fixes, tone analysis, readability scores, and [[fireside|Fireside]] mode. [[seedling|Seedling]]: 100 assists/day. [[sapling|Sapling]]: 500/day. [[oak|Oak]]: 2,000/day. [[evergreen|Evergreen]]: 10,000/day.",
+				"Every Grove blog is protected by [[shade|Shade]] — our defense against AI crawlers, scrapers, and training bots. Your words are yours, and they're never used to train AI models. This protection is active on every tier, free and paid.",
 			detail:
-				"[[wisp|Wisp]] is a helper, not a writer — it never generates content from scratch. [[fireside|Fireside]] mode asks you thoughtful questions, then organizes your answers into a draft using only your words. Every Fireside post is marked '~ written fireside with Wisp ~' for transparency. Content moderation ([[thorn|Thorn]]) runs automatically on all posts to keep the community safe — no human surveillance, zero data retention.",
+				"We're building writing tools that help polish your voice without replacing it — grammar checks, readability scoring, and more. They're not ready yet, and when they arrive, they'll be available to paid tiers. For now, [[shade|Shade]] keeps your content safe.",
 		},
 		api: {
 			title: "API Access",
 			content:
-				"[[oak|Oak]] and [[evergreen|Evergreen]] tiers include API access for building custom integrations, automated publishing, and programmatic blog management. [[oak|Oak]]: REST API with standard rate limits and webhook support. [[evergreen|Evergreen]]: Priority API access with higher rate limits and dedicated endpoints.",
-			detail:
-				"[[seedling|Seedling]] and [[sapling|Sapling]] blogs are accessible via RSS feeds and standard web protocols. Full programmatic API access is reserved for [[oak|Oak]]+ to ensure platform stability. API documentation will be available at launch.",
+				"API access for custom integrations and automated publishing is planned for [[oak|Oak]] and [[evergreen|Evergreen]] tiers. All blogs are accessible via RSS feeds and standard web protocols today.",
 		},
 	};
 


### PR DESCRIPTION
De-emphasize AI features that aren't publicly available yet and
refocus tier descriptions on what actually differentiates each plan:
storage, posts, domains, email, comments, and support.

- Update bestFor values to eliminate overlap (both free and seedling
  said "curious") and better describe each tier's audience
- Improve tier descriptions to highlight tangible benefits
- Add "Unlimited comments" to Seedling (real differentiator vs free)
- Replace "No ads ever" with "No ads, no tracking"
- Rename fineprint "AI Features" to "AI Protection" — focus on Shade
  (which IS live) instead of Wisp/Fireside (which aren't)
- Simplify API fineprint to honestly note it's planned, not describe
  it as if it exists

https://claude.ai/code/session_016fLbMLADgZiDN3M3v2m5Dg