### PR TITLE
fix(arbor): export missing components and update tier test

### DIFF
--- a/packages/engine/src/lib/config/tiers.test.ts
+++ b/packages/engine/src/lib/config/tiers.test.ts
@@ -276,7 +276,7 @@ describe("Tier Configuration", () => {
       expect(TIERS.free.display.standardName).toBe("Free");
       expect(TIERS.free.display.icon).toBe("footprints");
       expect(TIERS.free.display.tagline).toBe("Your first steps in the grove");
-      expect(TIERS.free.display.bestFor).toBe("The curious");
+      expect(TIERS.free.display.bestFor).toBe("Trying it out");
     });
 
     it("has restrictive rate limits", () => {

--- a/packages/engine/src/lib/ui/components/arbor/index.ts
+++ b/packages/engine/src/lib/ui/components/arbor/index.ts
@@ -21,8 +21,11 @@
  */
 
 // Public components
+export { default as ArborOverlay } from "./ArborOverlay.svelte";
 export { default as ArborPanel } from "./ArborPanel.svelte";
 export { default as ArborSection } from "./ArborSection.svelte";
+export { default as ArborSidebarFooter } from "./ArborSidebarFooter.svelte";
+export { default as ArborSidebarHeader } from "./ArborSidebarHeader.svelte";
 export { default as ArborToggle } from "./ArborToggle.svelte";
 
 // Types


### PR DESCRIPTION
Add missing barrel exports for ArborOverlay, ArborSidebarFooter, and
ArborSidebarHeader components. These components were present but not
exported in the arbor index.ts barrel file, causing the CI barrel
export validation to fail.

Also update tier configuration test to match actual config value for
free tier bestFor field (changed from "The curious" to "Trying it out").

https://claude.ai/code/session_016zV8sBpk4QUhgkht8i3B4u