### PR TITLE
fix(curios): raise generate rate limit and stop early on 429

### DIFF
--- a/packages/engine/src/routes/api/curios/timeline/generate/+server.ts
+++ b/packages/engine/src/routes/api/curios/timeline/generate/+server.ts
@@ -118,12 +118,13 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
     throwGroveError(401, API_ERRORS.UNAUTHORIZED, "API");
   }
 
-  // Rate limit generation (expensive AI + GitHub API operation)
+  // Rate limit generation (admin-only, tenant pays via BYOK)
+  // Limit is generous since this is an admin endpoint and costs are borne by the tenant
   if (platform?.env?.CACHE_KV) {
     const { response } = await checkRateLimit({
       kv: platform.env.CACHE_KV,
       key: buildRateLimitKey("ai/timeline-generate", user.id),
-      limit: 20,
+      limit: 100,
       windowSeconds: 86400, // 24 hours
       namespace: "ai-ratelimit",
       failClosed: true,


### PR DESCRIPTION
The generate endpoint's rate limit (20/24h) was too restrictive for
batch summary generation. Since this is an admin-only endpoint where
the tenant pays via their own OpenRouter key, raised to 100/24h.

Also added client-side rate limit detection: when a 429 is received,
the batch loop now stops immediately, marks remaining dates as skipped,
and shows a toast with the retry-after time instead of continuing to
hammer the endpoint.

https://claude.ai/code/session_01XQZCP7i8qkSEFNA4AMKu19