### PR TITLE
feat(landing): add chrome Header and Footer to arbor admin layout

### DIFF
--- a/packages/landing/src/lib/components/Header.svelte
+++ b/packages/landing/src/lib/components/Header.svelte
@@ -12,9 +12,11 @@
 		signInHref?: string;
 		signInLabel?: string;
 		userHref?: string;
+		showSidebarToggle?: boolean;
 	}
 
-	let { maxWidth, user, signInHref, signInLabel, userHref }: Props = $props();
+	let { maxWidth, user, signInHref, signInLabel, userHref, showSidebarToggle = false }: Props =
+		$props();
 </script>
 
 <EngineHeader
@@ -25,4 +27,5 @@
 	{signInHref}
 	{signInLabel}
 	{userHref}
+	{showSidebarToggle}
 />


### PR DESCRIPTION
The landing's arbor layout was missing the chrome Header (with sidebar
toggle) and Footer, making it impossible to open the sidebar on mobile
and leaving the admin area without a footer. This syncs the landing's
arbor with the engine's pattern: Header with showSidebarToggle above
ArborPanel, Footer with sidebar margin offset below.

https://claude.ai/code/session_01H5sjYN2TF25zW4VBydv6NM