### PR TITLE
fix(ui): improve mobile responsiveness for Edit Bloom and Reeds pages

### DIFF
--- a/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
+++ b/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
@@ -1854,6 +1854,33 @@
       display: none;
     }
   }
+  @media (max-width: 600px) {
+    .toolbar {
+      padding: 0.35rem 0.5rem;
+      gap: 0.1rem;
+    }
+    .toolbar-divider-line {
+      margin: 0 0.25rem;
+    }
+    .toolbar-icon-btn {
+      padding: 0.35rem;
+    }
+    .formatting-group {
+      padding: 1px;
+      gap: 0.1rem;
+    }
+    .line-numbers {
+      min-width: 2.25rem;
+    }
+    .line-numbers span {
+      padding: 0 0.4rem;
+      font-size: 0.75rem;
+    }
+    .editor-textarea {
+      padding: 0.75rem;
+      font-size: 0.85rem;
+    }
+  }
   @media (max-width: 480px) {
     .status-left .status-item:nth-child(n+3),
     .status-left .status-divider:nth-child(n+3) {

--- a/packages/engine/src/routes/arbor/garden/edit/[slug]/+page.svelte
+++ b/packages/engine/src/routes/arbor/garden/edit/[slug]/+page.svelte
@@ -977,4 +977,32 @@
       justify-content: flex-end;
     }
   }
+
+  /* Mobile-specific refinements */
+  @media (max-width: 600px) {
+    .page-header {
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    .page-header h1 {
+      font-size: 1.35rem;
+    }
+    .inline-title {
+      font-size: 1.35rem;
+    }
+    .header-actions {
+      gap: 0.35rem;
+    }
+    .status-badge {
+      font-size: 0.7rem;
+      padding: 0.2rem 0.5rem;
+    }
+    .details-strip {
+      margin: 0.25rem 0 0.75rem;
+    }
+    .toggle-vines-btn {
+      font-size: 0.8rem;
+      padding: 0.4rem 0.75rem;
+    }
+  }
 </style>

--- a/packages/engine/src/routes/arbor/reeds/+page.svelte
+++ b/packages/engine/src/routes/arbor/reeds/+page.svelte
@@ -997,11 +997,43 @@
     }
   }
 
-  @media (max-width: 540px) {
+  @media (max-width: 640px) {
     .setting-group {
       flex-direction: column;
       align-items: flex-start;
       gap: 0.75rem;
+    }
+
+    .setting-select {
+      width: 100%;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .tab {
+      padding: 0.625rem 0.75rem;
+      font-size: 0.8125rem;
+    }
+
+    .comment-card {
+      padding: 0.75rem 0.875rem;
+    }
+
+    .comment-actions {
+      flex-wrap: wrap;
+    }
+
+    .mod-btn {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8125rem;
+    }
+
+    .setting-group {
+      padding: 0.875rem 1rem;
+    }
+
+    .setting-actions {
+      padding: 1rem;
     }
   }
 </style>


### PR DESCRIPTION
Tighten spacing and sizing at narrow viewports (<=600px) so admin pages
fit comfortably on phone screens without horizontal overflow.

https://claude.ai/code/session_01NBaeSAA2WYC5Ugq7Yrfqb1