### PR TITLE
fix: dark mode dialog colors and image preview links

### DIFF
--- a/packages/engine/src/lib/ui/components/primitives/dialog/dialog-content.svelte
+++ b/packages/engine/src/lib/ui/components/primitives/dialog/dialog-content.svelte
@@ -23,8 +23,8 @@
 		bind:ref
 		class={cn(
 			"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
-			// Glass morphism background with warm cream/nature tones
-			"bg-cream/95 dark:bg-bark-900/95 backdrop-blur-xl",
+			// Glass morphism background — cream auto-inverts via CSS variable swap in dark mode
+			"bg-cream/95 backdrop-blur-xl",
 			"fixed left-[50%] top-[50%] z-grove-modal grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4",
 			"border border-grove-200/50 dark:border-bark-700/50",
 			"p-6 shadow-2xl shadow-grove-900/10 dark:shadow-black/30 duration-200 sm:rounded-xl",

--- a/packages/engine/src/routes/api/images/list/+server.ts
+++ b/packages/engine/src/routes/api/images/list/+server.ts
@@ -86,13 +86,18 @@ export const GET: RequestHandler = async ({ url, platform, locals }) => {
       limit: Math.min(limit, 100), // Cap at 100
     });
 
+    // Build CDN URL - uses environment variable for flexibility
+    // Defaults to production CDN if not configured (matches upload endpoint)
+    const cdnBaseUrl =
+      (platform?.env?.CDN_BASE_URL as string) || "https://cdn.grove.place";
+
     // Transform and parse filenames
     let images: ImageWithMetadata[] = listResult.objects.map((obj) => {
       const parsed = parseImageFilename(obj.key);
 
       return {
         key: obj.key,
-        url: `https://cdn.grove.place/${obj.key}`,
+        url: `${cdnBaseUrl}/${obj.key}`,
         size: obj.size,
         uploaded: obj.uploaded,
 

--- a/packages/engine/src/routes/arbor/images/+page.svelte
+++ b/packages/engine/src/routes/arbor/images/+page.svelte
@@ -831,7 +831,18 @@
 <Dialog bind:open={deleteModalOpen} title="Delete Image">
   {#if imageToDelete}
     <div class="delete-preview">
-      <img src={imageToDelete.url} alt="Preview" />
+      <img
+        src={imageToDelete.url}
+        alt="Preview"
+        onerror={(e) => { e.currentTarget.style.display = 'none'; e.currentTarget.nextElementSibling?.classList.remove('hidden'); }}
+      />
+      <div class="delete-preview-fallback hidden">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="3" y="3" width="18" height="18" rx="2"/>
+          <circle cx="8.5" cy="8.5" r="1.5"/>
+          <path d="M21 15l-5-5L5 21"/>
+        </svg>
+      </div>
     </div>
     <p class="delete-filename">{getFileName(imageToDelete.key)}</p>
   {/if}
@@ -1686,6 +1697,25 @@
     max-width: 100%;
     max-height: 130px;
     object-fit: contain;
+  }
+
+  .delete-preview-fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 80px;
+    color: var(--color-text-muted);
+    opacity: 0.5;
+  }
+
+  .delete-preview-fallback svg {
+    width: 40px;
+    height: 40px;
+  }
+
+  .delete-preview-fallback.hidden {
+    display: none;
   }
 
   .delete-filename {


### PR DESCRIPTION
Three fixes for the image management page:

1. Dialog dark mode: Remove `dark:bg-bark-900/95` from dialog-content.
   The bark color scale inverts in dark mode (bark-900 becomes light cream
   rgb(240,233,225)), causing a light dialog on a dark page. The `bg-cream/95`
   class already auto-inverts correctly via CSS variable swap in .dark.

2. Image list CDN URL: The /api/images/list endpoint hardcoded
   `https://cdn.grove.place/` while /api/images/upload uses the
   CDN_BASE_URL env var. When CDN_BASE_URL differs from the default,
   gallery images get broken URLs. Now both endpoints use the same
   env var with the same fallback.

3. Delete modal preview: Add graceful fallback when image preview fails
   to load — shows a muted image icon instead of a broken image.

https://claude.ai/code/session_01WvYwfWR4kdSt2XX3VdZr1B