### PR TITLE
fix: exclude multipart/form-data from 1MB body size guard

### DIFF
--- a/packages/engine/src/hooks.server.ts
+++ b/packages/engine/src/hooks.server.ts
@@ -573,16 +573,17 @@ export const handle: Handle = async ({ event, resolve }) => {
   if (["POST", "PUT", "PATCH"].includes(event.request.method)) {
     const contentLength = event.request.headers.get("content-length");
     const contentType = event.request.headers.get("content-type") || "";
-    const isJsonOrForm =
+    const isJsonOrUrlEncoded =
       contentType.includes("application/json") ||
-      contentType.includes("application/x-www-form-urlencoded") ||
-      contentType.includes("multipart/form-data");
+      contentType.includes("application/x-www-form-urlencoded");
+    // multipart/form-data is excluded — it's used for file uploads which
+    // have their own size limits in each upload endpoint (e.g. 10MB for images)
 
-    // 1MB limit for JSON/form requests, skip for binary uploads
+    // 1MB limit for JSON/URL-encoded requests, skip for file uploads
     const MAX_BODY_SIZE = 1024 * 1024;
     if (
       contentLength &&
-      isJsonOrForm &&
+      isJsonOrUrlEncoded &&
       parseInt(contentLength) > MAX_BODY_SIZE
     ) {
       return new Response(

--- a/packages/engine/src/lib/utils/upload-validation.ts
+++ b/packages/engine/src/lib/utils/upload-validation.ts
@@ -463,6 +463,7 @@ export function getActionableUploadError(serverMessage: string): string {
   // File too large
   if (
     msg.includes("too large") ||
+    msg.includes("exceeds maximum") ||
     msg.includes("file size") ||
     msg.includes("payload too large") ||
     msg.includes("413")


### PR DESCRIPTION
The body size check in hooks.server.ts was treating multipart/form-data
as a regular form request, applying a 1MB limit. But file uploads use
multipart/form-data — so any photo over 1MB was rejected before reaching
the upload endpoint (which allows 10MB). Removed multipart/form-data from
the check since each upload endpoint enforces its own size limit.

Also added "exceeds maximum" to the error message mapper in
getActionableUploadError() so if this phrasing appears in any error,
the user sees a helpful message instead of the raw server text.

https://claude.ai/code/session_015HTyeEaV5cbdK2tNx4Uqpj