### PR TITLE
Remove home footer and update credits link to external URL

### DIFF
--- a/packages/engine/src/routes/+page.svelte
+++ b/packages/engine/src/routes/+page.svelte
@@ -60,9 +60,6 @@
 	</section>
 {/if}
 
-<footer class="home-footer">
-	<a href="/credits">Font Credits & Attribution</a>
-</footer>
 
 <style>
 	.setup-page {
@@ -110,23 +107,6 @@
 		margin: 0;
 		opacity: 0.8;
 		transition: color 0.3s ease;
-	}
-	.home-footer {
-		text-align: center;
-		padding: 2rem 0;
-		margin-top: 3rem;
-		border-top: 1px solid var(--color-border);
-		transition: border-color 0.3s ease;
-	}
-	.home-footer a {
-		color: var(--color-text-muted);
-		text-decoration: none;
-		font-size: 0.9rem;
-		transition: color 0.2s ease;
-	}
-	.home-footer a:hover {
-		color: var(--color-primary);
-		text-decoration: underline;
 	}
 	.hero {
 		text-align: center;

--- a/packages/engine/src/routes/arbor/settings/+page.svelte
+++ b/packages/engine/src/routes/arbor/settings/+page.svelte
@@ -850,7 +850,7 @@
       </div>
 
       <p class="note">
-        See <a href="/credits">font credits and licenses</a> for attribution.
+        See <a href="https://grove.place/credits">font credits and licenses</a> for attribution.
       </p>
     {/if}
   </GlassCard>


### PR DESCRIPTION
## Summary

Removes the footer section from the home page and updates the font credits link in the arbor settings page to point to an external URL (`https://grove.place/credits`) instead of a relative route.

## Type of Change

- [x] Refactoring

## Details

**Changes in `packages/engine/src/routes/+page.svelte`:**
- Removed the `<footer class="home-footer">` element containing the "Font Credits & Attribution" link
- Removed all associated CSS styles for `.home-footer` and `.home-footer a` (including hover states)

**Changes in `packages/engine/src/routes/arbor/settings/+page.svelte`:**
- Updated the font credits link from a relative route (`/credits`) to an external URL (`https://grove.place/credits`)

## Testing

N/A - This is a straightforward UI refactoring and link update with no functional logic changes.

https://claude.ai/code/session_01WvWcePHTHfed1SnuN5L4Dq