### PR TITLE
fix(auth): fix login redirect sending Meadow users to Plant

### DIFF
--- a/packages/login/src/lib/redirect.ts
+++ b/packages/login/src/lib/redirect.ts
@@ -6,8 +6,13 @@
  * a login link that redirects to a malicious site after auth.
  */
 
-/** Default redirect when none specified or validation fails */
-export const DEFAULT_REDIRECT = "https://plant.grove.place/auth/callback";
+/**
+ * Default redirect when none specified or validation fails.
+ * Goes to the main landing page rather than Plant's onboarding flow,
+ * so existing users don't get funneled into account creation again.
+ * New users signing up via Plant will have an explicit redirect set.
+ */
+export const DEFAULT_REDIRECT = "https://grove.place";
 
 /** Allowed redirect patterns */
 const ALLOWED_PATTERNS = [

--- a/packages/login/src/routes/+page.svelte
+++ b/packages/login/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	 * Supports Google OAuth, passkey sign-in, and email magic links.
 	 *
 	 * Reads ?redirect=URL to know where to send the user after auth.
-	 * Defaults to plant.grove.place/auth/callback for new signups.
+	 * Defaults to grove.place when no redirect is specified.
 	 */
 
 	import { page } from '$app/state';

--- a/packages/login/src/routes/callback/+server.ts
+++ b/packages/login/src/routes/callback/+server.ts
@@ -18,7 +18,12 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
   // drops the ?redirect= query parameter from the callbackURL.
   const redirectParam = url.searchParams.get("redirect");
   const redirectCookie = cookies.get("grove_auth_redirect");
-  const redirectTo = validateRedirectUrl(redirectParam || redirectCookie);
+  // The cookie value is stored with encodeURIComponent() by the login page,
+  // so we must decode it before validation (e.g. "%2Ffeed" → "/feed").
+  const decodedCookie = redirectCookie
+    ? decodeURIComponent(redirectCookie)
+    : undefined;
+  const redirectTo = validateRedirectUrl(redirectParam || decodedCookie);
 
   // Clean up the fallback cookie now that we've read it
   if (redirectCookie) {

--- a/packages/meadow/src/routes/bookmarks/+layout.svelte
+++ b/packages/meadow/src/routes/bookmarks/+layout.svelte
@@ -2,6 +2,7 @@
   Bookmarks Layout — Reuses the same chrome as feed
 -->
 <script lang="ts">
+  import { page } from '$app/state';
   import { Header, Footer, type NavItem } from '@autumnsgrove/groveengine/ui/chrome';
   import { buildLoginUrl } from '@autumnsgrove/groveengine/grafts/login';
   import { Trees, Bookmark } from 'lucide-svelte';
@@ -25,7 +26,7 @@
   {navItems}
   brandTitle="Meadow"
   showSignIn={true}
-  signInHref={buildLoginUrl('/bookmarks')}
+  signInHref={buildLoginUrl(`${page.url.origin}/bookmarks`)}
   user={headerUser}
 />
 

--- a/packages/meadow/src/routes/bookmarks/+page.server.ts
+++ b/packages/meadow/src/routes/bookmarks/+page.server.ts
@@ -7,9 +7,9 @@ import { buildLoginUrl } from "@autumnsgrove/groveengine/grafts/login";
 import type { PageServerLoad } from "./$types";
 import { getFeed } from "$lib/server/feed";
 
-export const load: PageServerLoad = async ({ platform, locals }) => {
+export const load: PageServerLoad = async ({ url, platform, locals }) => {
   if (!locals.user) {
-    redirect(302, buildLoginUrl("/bookmarks"));
+    redirect(302, buildLoginUrl(`${url.origin}/bookmarks`));
   }
 
   const db = platform?.env?.DB;

--- a/packages/meadow/src/routes/bookmarks/+page.svelte
+++ b/packages/meadow/src/routes/bookmarks/+page.svelte
@@ -4,7 +4,6 @@
   Uses the same PostCard list pattern as the feed.
 -->
 <script lang="ts">
-  import { buildLoginUrl } from '@autumnsgrove/groveengine/grafts/login';
   import PostCard from '$lib/components/PostCard.svelte';
   import SEO from '$lib/components/SEO.svelte';
   import type { MeadowPost } from '$lib/types/post';

--- a/packages/meadow/src/routes/feed/+layout.svelte
+++ b/packages/meadow/src/routes/feed/+layout.svelte
@@ -2,6 +2,7 @@
   Feed Layout — Header with auth nav + Footer
 -->
 <script lang="ts">
+  import { page } from '$app/state';
   import { Header, Footer, type NavItem } from '@autumnsgrove/groveengine/ui/chrome';
   import { buildLoginUrl } from '@autumnsgrove/groveengine/grafts/login';
   import { Trees, Bookmark, Rss } from 'lucide-svelte';
@@ -39,7 +40,7 @@
   {navItems}
   brandTitle="Meadow"
   showSignIn={true}
-  signInHref={buildLoginUrl('/feed')}
+  signInHref={buildLoginUrl(`${page.url.origin}/feed`)}
   user={headerUser}
   {userHref}
 />

--- a/packages/meadow/src/routes/feed/+page.svelte
+++ b/packages/meadow/src/routes/feed/+page.svelte
@@ -74,7 +74,7 @@
   // ── Interactions (require auth) ────────────────────────────────────────
   function requireAuth(): boolean {
     if (loggedIn) return true;
-    window.location.href = buildLoginUrl('/feed');
+    window.location.href = buildLoginUrl(`${page.url.origin}/feed`);
     return false;
   }
 

--- a/packages/meadow/src/routes/feed/[id]/+page.svelte
+++ b/packages/meadow/src/routes/feed/[id]/+page.svelte
@@ -6,6 +6,7 @@
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { page } from '$app/state';
   import { buildLoginUrl } from '@autumnsgrove/groveengine/grafts/login';
   import { formatRelativeTime } from '$lib/utils/time';
   import ReactionPicker from '$lib/components/ReactionPicker.svelte';
@@ -42,7 +43,7 @@
 
   function requireAuth(): boolean {
     if (loggedIn) return true;
-    window.location.href = buildLoginUrl(`/feed/${post.id}`);
+    window.location.href = buildLoginUrl(`${page.url.origin}/feed/${post.id}`);
     return false;
   }
 

--- a/packages/plant/src/routes/auth/callback/+server.ts
+++ b/packages/plant/src/routes/auth/callback/+server.ts
@@ -183,7 +183,7 @@ export const GET: RequestHandler = async ({ url, cookies, platform }) => {
     try {
       existingOnboarding = (await db
         .prepare(
-          "SELECT id, tenant_id, profile_completed_at FROM user_onboarding WHERE email = ?",
+          "SELECT id, tenant_id, profile_completed_at FROM user_onboarding WHERE LOWER(email) = ?",
         )
         .bind(user.email.toLowerCase())
         .first()) as {
@@ -219,7 +219,7 @@ export const GET: RequestHandler = async ({ url, cookies, platform }) => {
       // Check the users table (links groveauth_id/email to tenant_id)
       const existingUser = (await db
         .prepare(
-          "SELECT tenant_id FROM users WHERE email = ? AND tenant_id IS NOT NULL",
+          "SELECT tenant_id FROM users WHERE LOWER(email) = ? AND tenant_id IS NOT NULL",
         )
         .bind(user.email.toLowerCase())
         .first()) as { tenant_id: string } | null;
@@ -243,7 +243,7 @@ export const GET: RequestHandler = async ({ url, cookies, platform }) => {
       if (!existingUser) {
         const tenant = (await db
           .prepare(
-            "SELECT subdomain FROM tenants WHERE email = ? AND active = 1",
+            "SELECT subdomain FROM tenants WHERE LOWER(email) = ? AND active = 1",
           )
           .bind(user.email.toLowerCase())
           .first()) as { subdomain: string } | null;


### PR DESCRIPTION
Meadow was passing relative paths (e.g. /feed) to buildLoginUrl(),
which broke the post-auth redirect chain in two ways:

1. Cookie double-encoding: the login page stored the redirect with
   encodeURIComponent() but the callback never decoded it, so
   "%2Ffeed" failed validation and fell back to DEFAULT_REDIRECT.

2. Relative paths resolve on login.grove.place, not meadow.grove.place,
   so even a correctly decoded "/feed" would go to the wrong origin.

Changes:
- Meadow now passes absolute URLs (page.url.origin + path) so the
  login hub redirects back to the correct origin after auth
- Login callback decodes the cookie before validation
- DEFAULT_REDIRECT changed from plant.grove.place/auth/callback to
  grove.place so existing users aren't funneled into account creation
- Plant callback uses LOWER(email) for case-insensitive lookups so
  existing users are found regardless of email casing in the DB

https://claude.ai/code/session_01M5WV9X7vMmyYr8ftwPt94Z