### PR TITLE
fix(meadow): route login redirects through /auth/callback

### DIFF
--- a/packages/meadow/src/routes/bookmarks/+layout.svelte
+++ b/packages/meadow/src/routes/bookmarks/+layout.svelte
@@ -26,7 +26,7 @@
   {navItems}
   brandTitle="Meadow"
   showSignIn={true}
-  signInHref={buildLoginUrl(`${page.url.origin}/bookmarks`)}
+  signInHref={buildLoginUrl(`${page.url.origin}/auth/callback?returnTo=${encodeURIComponent(page.url.pathname)}`)}
   user={headerUser}
 />
 

--- a/packages/meadow/src/routes/bookmarks/+page.server.ts
+++ b/packages/meadow/src/routes/bookmarks/+page.server.ts
@@ -9,7 +9,12 @@ import { getFeed } from "$lib/server/feed";
 
 export const load: PageServerLoad = async ({ url, platform, locals }) => {
   if (!locals.user) {
-    redirect(302, buildLoginUrl(`${url.origin}/bookmarks`));
+    redirect(
+      302,
+      buildLoginUrl(
+        `${url.origin}/auth/callback?returnTo=${encodeURIComponent("/bookmarks")}`,
+      ),
+    );
   }
 
   const db = platform?.env?.DB;

--- a/packages/meadow/src/routes/feed/+layout.svelte
+++ b/packages/meadow/src/routes/feed/+layout.svelte
@@ -40,7 +40,7 @@
   {navItems}
   brandTitle="Meadow"
   showSignIn={true}
-  signInHref={buildLoginUrl(`${page.url.origin}/feed`)}
+  signInHref={buildLoginUrl(`${page.url.origin}/auth/callback?returnTo=${encodeURIComponent(page.url.pathname)}`)}
   user={headerUser}
   {userHref}
 />

--- a/packages/meadow/src/routes/feed/+page.svelte
+++ b/packages/meadow/src/routes/feed/+page.svelte
@@ -74,7 +74,8 @@
   // ── Interactions (require auth) ────────────────────────────────────────
   function requireAuth(): boolean {
     if (loggedIn) return true;
-    window.location.href = buildLoginUrl(`${page.url.origin}/feed`);
+    const callbackUrl = `${page.url.origin}/auth/callback?returnTo=${encodeURIComponent(page.url.pathname)}`;
+    window.location.href = buildLoginUrl(callbackUrl);
     return false;
   }
 

--- a/packages/meadow/src/routes/feed/[id]/+page.svelte
+++ b/packages/meadow/src/routes/feed/[id]/+page.svelte
@@ -43,7 +43,8 @@
 
   function requireAuth(): boolean {
     if (loggedIn) return true;
-    window.location.href = buildLoginUrl(`${page.url.origin}/feed/${post.id}`);
+    const callbackUrl = `${page.url.origin}/auth/callback?returnTo=${encodeURIComponent(`/feed/${post.id}`)}`;
+    window.location.href = buildLoginUrl(callbackUrl);
     return false;
   }
 


### PR DESCRIPTION
All buildLoginUrl() calls in meadow were passing the final destination
directly (e.g. meadow.grove.place/feed), bypassing the /auth/callback
route that validates the session cookie. This caused login to redirect
to login.grove.place/feed# instead of back to meadow.

Now uses the same pattern as LoginRedirectButton and other packages:
origin/auth/callback?returnTo=/path → login hub → callback → destination.

Fixes feed, feed/[id], and bookmarks routes.

https://claude.ai/code/session_01K1FSKngoEMnP8ZfTc4oLWM