### PR TITLE
Replace dark mode bark colors with cream palette

### DIFF
--- a/packages/landing/src/lib/components/demos/EditorDemo.svelte
+++ b/packages/landing/src/lib/components/demos/EditorDemo.svelte
@@ -36,9 +36,9 @@ Here, my words grow at their own pace. No analytics telling me which posts *perf
 	let activeTab = $state<'split' | 'write' | 'preview'>('split');
 </script>
 
-<div class="w-full rounded-2xl overflow-hidden border border-subtle bg-white/70 dark:bg-bark-900/50 backdrop-blur-sm">
+<div class="w-full rounded-2xl overflow-hidden border border-subtle bg-white/70 dark:bg-cream-50/50 backdrop-blur-sm">
 	<!-- Toolbar -->
-	<div class="flex items-center justify-between px-3 py-2 border-b border-subtle bg-white/80 dark:bg-bark-800/60">
+	<div class="flex items-center justify-between px-3 py-2 border-b border-subtle bg-white/80 dark:bg-cream-100/60">
 		<div class="flex items-center gap-1">
 			<!-- Mode tabs -->
 			<button

--- a/packages/landing/src/routes/beyond/+page.svelte
+++ b/packages/landing/src/routes/beyond/+page.svelte
@@ -106,7 +106,7 @@
 		switch (status) {
 			case 'live': return { text: 'Live', class: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' };
 			case 'building': return { text: 'Building', class: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300' };
-			case 'planned': return { text: 'Planned', class: 'bg-cream-100 text-bark-600 dark:bg-bark-800 dark:text-cream-400' };
+			case 'planned': return { text: 'Planned', class: 'bg-cream-100 text-bark-600 dark:bg-cream-100 dark:text-cream-400' };
 			case 'early': return { text: 'Early Research', class: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300' };
 			case 'paused': return { text: 'Paused', class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' };
 			default: return { text: status, class: 'bg-cream-100 text-bark-600' };

--- a/packages/landing/src/routes/contribute/+page.svelte
+++ b/packages/landing/src/routes/contribute/+page.svelte
@@ -310,7 +310,7 @@
 			<div class="relative group">
 				<a
 					href="#{header.id}"
-					class="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-bark-800 shadow-md border border-accent/30 dark:border-accent/20 hover:bg-accent/10 dark:hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 transition-all duration-200"
+					class="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-cream-100 shadow-md border border-accent/30 dark:border-accent/20 hover:bg-accent/10 dark:hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 transition-all duration-200"
 					aria-label="Jump to {header.text}"
 					title={header.text}
 				>
@@ -319,7 +319,7 @@
 					{/if}
 				</a>
 				<div class="absolute right-full mr-3 top-1/2 -translate-y-1/2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 pointer-events-none">
-					<div class="px-3 py-1.5 rounded-lg bg-white dark:bg-bark-800 shadow-md border border-accent/20 dark:border-accent/10 text-sm font-medium text-foreground whitespace-nowrap">
+					<div class="px-3 py-1.5 rounded-lg bg-white dark:bg-cream-100 shadow-md border border-accent/20 dark:border-accent/10 text-sm font-medium text-foreground whitespace-nowrap">
 						{header.text}
 					</div>
 				</div>

--- a/packages/landing/src/routes/credits/+page.svelte
+++ b/packages/landing/src/routes/credits/+page.svelte
@@ -246,7 +246,7 @@
 							</a>
 							<a
 								href="/knowledge/help/what-is-zdr"
-								class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-cream-100 dark:bg-bark-700/50 text-xs text-foreground-muted hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
+								class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-cream-100 dark:bg-cream-200/50 text-xs text-foreground-muted hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
 								title="Zero Data Retention"
 							>
 								<Shredder class="w-3 h-3" />
@@ -271,7 +271,7 @@
 							</a>
 							<a
 								href="/knowledge/help/what-is-zdr"
-								class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-cream-100 dark:bg-bark-700/50 text-xs text-foreground-muted hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
+								class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-cream-100 dark:bg-cream-200/50 text-xs text-foreground-muted hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
 								title="Zero Data Retention"
 							>
 								<Shredder class="w-3 h-3" />
@@ -296,7 +296,7 @@
 							</a>
 							<a
 								href="/knowledge/help/what-is-zdr"
-								class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-cream-100 dark:bg-bark-700/50 text-xs text-foreground-muted hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
+								class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-cream-100 dark:bg-cream-200/50 text-xs text-foreground-muted hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
 								title="Zero Data Retention"
 							>
 								<Shredder class="w-3 h-3" />
@@ -821,7 +821,7 @@
 			{@const Icon = item.icon}
 			<a
 				href="#{item.id}"
-				class="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-bark-800 shadow-md border border-amber-200 dark:border-bark-700 hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-all duration-200 group"
+				class="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-cream-100 shadow-md border border-amber-200 dark:border-cream-200 hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-all duration-200 group"
 				aria-label="Jump to {item.text}"
 				title={item.text}
 			>
@@ -845,8 +845,8 @@
 		</button>
 
 		{#if isTocOpen}
-			<div class="absolute bottom-16 right-0 w-56 bg-white dark:bg-bark-800 rounded-xl shadow-xl border border-amber-200 dark:border-bark-700 overflow-hidden">
-				<div class="px-4 py-3 border-b border-amber-200 dark:border-bark-700 flex items-center justify-between">
+			<div class="absolute bottom-16 right-0 w-56 bg-white dark:bg-cream-100 rounded-xl shadow-xl border border-amber-200 dark:border-cream-200 overflow-hidden">
+				<div class="px-4 py-3 border-b border-amber-200 dark:border-cream-200 flex items-center justify-between">
 					<span class="font-medium text-foreground">Navigate</span>
 					<button type="button" onclick={() => isTocOpen = false} class="text-foreground-muted hover:text-foreground" aria-label="Close">
 						<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/packages/landing/src/routes/forest/+page.svelte
+++ b/packages/landing/src/routes/forest/+page.svelte
@@ -574,7 +574,7 @@
 	image="https://grove.place/api/og/forest"
 />
 
-<main class="min-h-screen flex flex-col transition-colors duration-1000 {isMidnight ? 'bg-gradient-to-b from-purple-950 via-slate-900 to-indigo-950' : isWinter ? 'bg-gradient-to-b from-slate-200 via-slate-100 to-slate-50 dark:from-bark-900 dark:via-bark-800 dark:to-bark-700' : isAutumn ? 'bg-gradient-to-b from-orange-100 via-amber-50 to-yellow-50 dark:from-bark-900 dark:via-amber-950 dark:to-orange-950' : isSpring ? 'bg-gradient-to-b from-pink-50 via-sky-50 to-lime-50 dark:from-bark-900 dark:via-pink-950 dark:to-lime-950' : 'bg-gradient-to-b from-sky-100 via-sky-50 to-emerald-50 dark:from-bark-900 dark:via-bark-800 dark:to-grove-950'}">
+<main class="min-h-screen flex flex-col transition-colors duration-1000 {isMidnight ? 'bg-gradient-to-b from-purple-950 via-slate-900 to-indigo-950' : isWinter ? 'bg-gradient-to-b from-slate-200 via-slate-100 to-slate-50 dark:from-cream-50 dark:via-cream-100 dark:to-cream-200' : isAutumn ? 'bg-gradient-to-b from-orange-100 via-amber-50 to-yellow-50 dark:from-cream-50 dark:via-amber-950 dark:to-orange-950' : isSpring ? 'bg-gradient-to-b from-pink-50 via-sky-50 to-lime-50 dark:from-cream-50 dark:via-pink-950 dark:to-lime-950' : 'bg-gradient-to-b from-sky-100 via-sky-50 to-emerald-50 dark:from-cream-50 dark:via-cream-100 dark:to-grove-950'}">
 	<Header user={data.user} />
 
 	<article class="flex-1 relative overflow-hidden">
@@ -643,7 +643,7 @@
 		</div>
 
 		<!-- Sky background gradient -->
-		<div class="absolute inset-0 transition-colors duration-1000 {isMidnight ? 'bg-gradient-to-b from-purple-900/60 via-indigo-900/30 to-transparent' : isWinter ? 'bg-gradient-to-b from-slate-300/50 via-transparent to-transparent dark:from-bark-700/30' : isAutumn ? 'bg-gradient-to-b from-orange-200/50 via-transparent to-transparent dark:from-orange-900/20' : isSpring ? 'bg-gradient-to-b from-pink-200/40 via-sky-100/30 to-transparent dark:from-pink-900/20' : 'bg-gradient-to-b from-sky-200/50 via-transparent to-transparent dark:from-sky-900/20'}"></div>
+		<div class="absolute inset-0 transition-colors duration-1000 {isMidnight ? 'bg-gradient-to-b from-purple-900/60 via-indigo-900/30 to-transparent' : isWinter ? 'bg-gradient-to-b from-slate-300/50 via-transparent to-transparent dark:from-cream-300/20' : isAutumn ? 'bg-gradient-to-b from-orange-200/50 via-transparent to-transparent dark:from-orange-900/20' : isSpring ? 'bg-gradient-to-b from-pink-200/40 via-sky-100/30 to-transparent dark:from-pink-900/20' : 'bg-gradient-to-b from-sky-200/50 via-transparent to-transparent dark:from-sky-900/20'}"></div>
 
 		<!-- Clouds (decorative) - floating across the sky -->
 		<div class="absolute top-6 left-0 opacity-70" aria-hidden="true">

--- a/packages/landing/src/routes/roadmap/+page.svelte
+++ b/packages/landing/src/routes/roadmap/+page.svelte
@@ -368,11 +368,11 @@
 	url="/roadmap"
 />
 
-<main class="min-h-screen flex flex-col bg-cream-50 dark:bg-bark-900">
+<main class="min-h-screen flex flex-col bg-cream-50 dark:bg-cream-50">
 	<Header user={data.user} />
 
 	<!-- Hero Section -->
-	<section class="relative py-16 px-6 text-center overflow-hidden bg-gradient-to-b from-cream-100 via-cream-50 to-white dark:from-bark-800 dark:via-bark-900 dark:to-bark-950">
+	<section class="relative py-16 px-6 text-center overflow-hidden bg-gradient-to-b from-cream-100 via-cream-50 to-white dark:from-cream-100 dark:via-cream-50 dark:to-cream-50">
 		<div class="max-w-3xl mx-auto relative z-10">
 			<h1 class="text-4xl md:text-5xl font-serif text-foreground mb-4">
 				The Journey Ahead
@@ -384,7 +384,7 @@
 			<!-- Quick link to version history -->
 			<a
 				href="/journey"
-				class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/80 dark:bg-bark-800/80 backdrop-blur-sm border border-divider text-sm text-foreground hover:bg-white dark:hover:bg-bark-800 transition-colors"
+				class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/80 dark:bg-cream-100/80 backdrop-blur-sm border border-divider text-sm text-foreground hover:bg-white dark:hover:bg-cream-100 transition-colors"
 			>
 				<Tag class="w-4 h-4" />
 				View the Journey
@@ -408,7 +408,7 @@
 
 	<!-- Navigation Pills -->
 	<nav
-		class="sticky top-[73px] z-30 bg-white/80 dark:bg-bark-900/80 backdrop-blur-sm border-b border-divider py-3 px-4"
+		class="sticky top-[73px] z-30 bg-white/80 dark:bg-cream-50/80 backdrop-blur-sm border-b border-divider py-3 px-4"
 		aria-label="Development phases"
 	>
 		<div class="max-w-4xl mx-auto flex flex-wrap justify-center gap-2">
@@ -419,7 +419,7 @@
 					class="px-3 py-1.5 rounded-full text-sm font-medium transition-all inline-flex items-center gap-1.5
 						{status === 'current' ? 'bg-accent text-white shadow-md' : ''}
 						{status === 'past' ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300' : ''}
-						{status === 'future' ? 'bg-cream-100 dark:bg-bark-800 text-foreground-muted hover:bg-cream-200 dark:hover:bg-bark-700' : ''}"
+						{status === 'future' ? 'bg-cream-100 dark:bg-cream-100 text-foreground-muted hover:bg-cream-200 dark:hover:bg-cream-200' : ''}"
 				>
 					{#if status === 'current'}
 						<MapPin class="w-3.5 h-3.5" />
@@ -439,7 +439,7 @@
 			id="first-frost"
 			class="relative py-20 px-6 overflow-hidden transition-colors duration-700
 				bg-gradient-to-b from-bark-200 via-cream-100 to-cream-50
-				dark:from-bark-800 dark:via-bark-850 dark:to-bark-900"
+				dark:from-cream-100 dark:via-cream-50 dark:to-cream-50"
 		>
 			<!-- Snowfall -->
 			<div class="absolute inset-0 pointer-events-none" aria-hidden="true">
@@ -466,7 +466,7 @@
 
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases['first-frost'].features as feature}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-bark-900/25 backdrop-blur-sm shadow-sm">
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-cream-50/25 backdrop-blur-sm shadow-sm">
 							<Check class="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
 							<div class="flex-1">
 								<div class="flex items-center gap-2">
@@ -499,7 +499,7 @@
 			id="thaw"
 			class="relative py-20 px-6 overflow-hidden
 				bg-gradient-to-b from-bark-200 via-sky-100 to-teal-100
-				dark:from-bark-800 dark:via-bark-850 dark:to-teal-950"
+				dark:from-cream-100 dark:via-cream-50 dark:to-teal-950"
 		>
 			<!-- Light snowfall - the thaw -->
 			<div class="absolute inset-0 pointer-events-none" aria-hidden="true">
@@ -554,7 +554,7 @@
 				<ul class="space-y-4 max-w-md mx-auto">
 					{#each phases.thaw.features as feature}
 						{@const IconComponent = getFeatureIcon(feature.icon)}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-bark-900/25 backdrop-blur-sm border-l-4 border-teal-400 shadow-sm
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-cream-50/25 backdrop-blur-sm border-l-4 border-teal-400 shadow-sm
 							{feature.internal ? 'opacity-75' : ''}">
 							<!-- Use icon lookup map with seasonal color (Thaw = teal) -->
 							<IconComponent
@@ -578,7 +578,7 @@
 										<FeatureStar />
 									{/if}
 									{#if feature.internal}
-										<span class="px-2 py-0.5 text-xs font-medium rounded bg-bark-200 dark:bg-bark-700 text-bark-700 dark:text-cream-400">Internal</span>
+										<span class="px-2 py-0.5 text-xs font-medium rounded bg-bark-200 dark:bg-cream-200 text-bark-700 dark:text-cream-400">Internal</span>
 									{/if}
 								</div>
 								<p class="text-sm text-bark-700 dark:text-cream-400">{feature.description}</p>
@@ -688,7 +688,7 @@
 							terminal: 'border-l-4 border-lime-500',
 							centennial: 'border-l-4 border-indigo-500'
 						}}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-bark-900/25 backdrop-blur-sm shadow-sm
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-cream-50/25 backdrop-blur-sm shadow-sm
 							{(borderMap as Record<string, string>)[feature.icon ?? ''] || ''}"
 						>
 							<!-- Use icon lookup map with feature-specific color -->
@@ -812,7 +812,7 @@
 							weave: 'text-cyan-500',
 							outpost: 'text-purple-500'
 						}}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-bark-900/25 backdrop-blur-sm shadow-sm">
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/80 dark:bg-cream-50/25 backdrop-blur-sm shadow-sm">
 							<!-- Use icon lookup map with feature-specific color -->
 							<IconComponent
 								class="w-5 h-5 {(colorMap as Record<string, string>)[feature.icon ?? ''] || 'text-bark-400'} mt-0.5 flex-shrink-0"
@@ -934,7 +934,7 @@
 							puzzle: 'text-purple-500',
 							wander: 'text-teal-500'
 						}}
-						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/70 dark:bg-bark-900/25 backdrop-blur-sm shadow-md border border-amber-200/50 dark:border-amber-800/30">
+						<li class="flex items-start gap-3 p-4 rounded-lg bg-white/70 dark:bg-cream-50/25 backdrop-blur-sm shadow-md border border-amber-200/50 dark:border-amber-800/30">
 							<!-- Use icon lookup map with feature-specific color (Golden Hour = amber tones) -->
 							<IconComponent
 								class="w-5 h-5 {(colorMap as Record<string, string>)[feature.icon ?? ''] || 'text-amber-500'} mt-0.5 flex-shrink-0"

--- a/packages/landing/src/routes/vision/+page.svelte
+++ b/packages/landing/src/routes/vision/+page.svelte
@@ -292,7 +292,7 @@
 			<div class="relative group">
 				<a
 					href="#{header.id}"
-					class="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-bark-800 shadow-md border border-accent/30 dark:border-accent/20 hover:bg-accent/10 dark:hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 transition-all duration-200"
+					class="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-cream-100 shadow-md border border-accent/30 dark:border-accent/20 hover:bg-accent/10 dark:hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 transition-all duration-200"
 					aria-label="Jump to {header.text}"
 					title={header.text}
 				>
@@ -303,7 +303,7 @@
 
 				<!-- Section name tooltip on hover -->
 				<div class="absolute right-full mr-3 top-1/2 -translate-y-1/2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 pointer-events-none">
-					<div class="px-3 py-1.5 rounded-lg bg-white dark:bg-bark-800 shadow-md border border-accent/20 dark:border-accent/10 text-sm font-medium text-foreground whitespace-nowrap">
+					<div class="px-3 py-1.5 rounded-lg bg-white dark:bg-cream-100 shadow-md border border-accent/20 dark:border-accent/10 text-sm font-medium text-foreground whitespace-nowrap">
 						{header.text}
 					</div>
 				</div>

--- a/packages/landing/src/routes/workshop/+page.svelte
+++ b/packages/landing/src/routes/workshop/+page.svelte
@@ -980,7 +980,7 @@
 	<Header user={data.user} />
 
 	<!-- Hero -->
-	<section class="relative py-16 px-6 text-center overflow-hidden bg-gradient-to-b from-slate-100 via-slate-50 to-white dark:from-cream-100 dark:via-cream-50 dark:to-bark-50">
+	<section class="relative py-16 px-6 text-center overflow-hidden bg-gradient-to-b from-slate-100 via-slate-50 to-white dark:from-cream-100 dark:via-cream-50 dark:to-cream-50">
 		<!-- Lanterns -->
 		<div class="absolute top-8 left-[15%] opacity-60" aria-hidden="true">
 			<Lantern class="w-8 h-12" variant="hanging" lit animate />


### PR DESCRIPTION
## Summary

Updates dark mode color scheme across multiple pages by replacing `bark-*` color classes with `cream-*` equivalents. This creates a more cohesive and lighter dark mode appearance while maintaining visual hierarchy and contrast.

## Type of Change

- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation

## Details

Systematically replaces dark mode background and component colors:

- **Main backgrounds**: `dark:bg-bark-900` → `dark:bg-cream-50`, `dark:bg-bark-800` → `dark:bg-cream-100`
- **Gradient overlays**: Dark gradients using bark tones replaced with cream palette
- **Component backgrounds**: Cards, pills, and UI elements updated to use cream colors in dark mode
- **Borders**: `dark:border-bark-*` → `dark:border-cream-*` for consistency
- **Status badges**: Internal labels and planned status indicators updated

Affected pages:
- Roadmap (`+page.svelte`)
- Credits (`+page.svelte`)
- Forest (`+page.svelte`)
- Vision (`+page.svelte`)
- Beyond (`+page.svelte`)
- Workshop (`+page.svelte`)
- Contribute (`+page.svelte`)
- Editor demo component

## Testing

Visual inspection of dark mode across all affected pages confirms proper color application and maintained contrast ratios.

https://claude.ai/code/session_01EZb8m6F8zC6nycbTpwALUF