### PR TITLE
fix: sync profile photo to nav bar avatar

### DIFF
--- a/packages/engine/src/routes/+layout.svelte
+++ b/packages/engine/src/routes/+layout.svelte
@@ -77,11 +77,12 @@
 	}
 
 	// Map server user data to HeaderUser shape (picture → avatarUrl)
+	// Prefer custom avatar from site_settings over OAuth provider picture
 	const headerUser = $derived(data.user ? {
 		id: data.user.id,
 		name: data.user.name,
 		email: data.user.email,
-		avatarUrl: data.user.picture
+		avatarUrl: data.siteSettings?.avatar_url || data.user.picture
 	} : null);
 
 	// Theme is handled by themeStore in chrome components

--- a/packages/engine/src/routes/arbor/settings/+page.svelte
+++ b/packages/engine/src/routes/arbor/settings/+page.svelte
@@ -236,6 +236,8 @@
         if (result?.url) {
           avatarUrl = result.url;
           toast.success("Profile photo updated!");
+          // Refresh layout data so the nav avatar updates immediately
+          invalidateAll();
         } else {
           toast.error(
             "Upload completed but no photo URL was returned. Please try again.",
@@ -258,6 +260,8 @@
       await apiRequest("/api/settings/avatar", { method: "DELETE" });
       avatarUrl = null;
       toast.success("Profile photo removed");
+      // Refresh layout data so the nav avatar reverts immediately
+      invalidateAll();
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to remove photo",


### PR DESCRIPTION
The nav bar avatar was reading from the OAuth provider picture
(data.user.picture) which never updates after login. Custom avatars
uploaded in Settings are stored in site_settings as avatar_url, which
the root layout server already loads — but the layout component
wasn't using it.

Now the headerUser mapping prefers siteSettings.avatar_url over
the OAuth picture, and upload/clear handlers call invalidateAll()
so the nav updates instantly without a page reload.

https://claude.ai/code/session_017YfV3yYVuP9JEmk9KSmRDe