### PR TITLE
feat(login): migrate Google OAuth and magic link to server-side form actions

### DIFF
--- a/packages/login/src/routes/+page.svelte
+++ b/packages/login/src/routes/+page.svelte
@@ -57,7 +57,10 @@
 			if (result.error) {
 				throw new Error(result.error.message || 'Passkey sign-in failed');
 			}
-			// Session cookie is set — redirect to destination
+			// Session cookie is set — redirect to destination.
+			// Reset loading state before navigating: no-op when navigation proceeds normally,
+			// but keeps UI unblocked if window.location.href is a no-op (sandboxed/test env).
+			passkeyLoading = false;
 			window.location.href = redirectTo;
 		} catch (err) {
 			if (err instanceof Error && err.name === 'NotAllowedError') {
@@ -106,7 +109,7 @@
 				<div>
 					<p class="text-foreground font-medium">Check your email</p>
 					<p class="text-sm text-foreground-muted mt-1">
-						We sent a magic link to <strong class="text-foreground">{form.email}</strong>
+						We sent a magic link to <strong class="text-foreground">{form?.email}</strong>
 					</p>
 				</div>
 				<a


### PR DESCRIPTION
Google OAuth and email magic link sign-in now run entirely in the
Cloudflare Worker isolate via SvelteKit form actions. No client-side
JavaScript is required for either flow.

Changes:
- Add +page.server.ts with `google` and `email` form actions
- `google` action: calls Heartwood via service binding, forwards
  Better Auth's oauth_state cookie, throws redirect(302) to Google
- `email` action: calls Heartwood magic link endpoint, returns
  { emailSent, email } on success for the confirmation UI
- Redirect cookie (grove_auth_redirect) is now set HttpOnly —
  previously required document.cookie because no server action existed
- +page.svelte: replace onclick handlers and authClient.signIn.social/
  magicLink with <form method="POST"> elements and use:enhance
- Passkey auth remains client-side (WebAuthn requires navigator.credentials)
- "Use a different method" is now an <a> tag (works without JS)

https://claude.ai/code/session_01KMBxRWkELtweBSZ565rk4x