### PR TITLE
docs: Cloudflare deployment audit and tenant app naming strategy

### DIFF
--- a/docs/plans/planned/cloudflare-deployment-safari.md
+++ b/docs/plans/planned/cloudflare-deployment-safari.md
@@ -25,36 +25,36 @@
 
 ### Cloudflare Pages Projects
 
-| # | Package | Script Name | Domain | Bindings | Complexity |
-|---|---------|-------------|--------|----------|------------|
-| 1 | `packages/engine` | `grove-lattice` | `*.grove.place` (via router) | D1, R2×3, KV×2, AI, Auth svc, Zephyr svc, DO×6 | **Very High** |
-| 2 | `packages/landing` | `grove-landing` | `grove.place` | D1, R2, KV×2, Auth svc, Zephyr svc | **High** |
-| 3 | `packages/plant` | `grove-plant` | `plant.grove.place` | D1, KV, Auth svc, Zephyr svc | **Medium** |
-| 4 | `packages/meadow` | `grove-meadow` | `meadow.grove.place` | D1, KV, Auth svc, DO×1 | **Medium** |
-| 5 | `packages/clearing` | `grove-clearing` | `status.grove.place` | D1×2 | **Low** |
-| 6 | `packages/domains` | `grove-domains` | Forage tool | D1, Auth svc | **Low** |
-| 7 | `packages/login` | `grove-login` | `login.grove.place` | Auth svc only | **Minimal** |
-| 8 | `packages/terrarium` | `grove-terrarium` | TBD | None (localStorage) | **Minimal** |
+| #   | Package              | Script Name       | Domain                       | Bindings                                       | Complexity    |
+| --- | -------------------- | ----------------- | ---------------------------- | ---------------------------------------------- | ------------- |
+| 1   | `packages/engine`    | `grove-lattice`   | `*.grove.place` (via router) | D1, R2×3, KV×2, AI, Auth svc, Zephyr svc, DO×6 | **Very High** |
+| 2   | `packages/landing`   | `grove-landing`   | `grove.place`                | D1, R2, KV×2, Auth svc, Zephyr svc             | **High**      |
+| 3   | `packages/plant`     | `grove-plant`     | `plant.grove.place`          | D1, KV, Auth svc, Zephyr svc                   | **Medium**    |
+| 4   | `packages/meadow`    | `grove-meadow`    | `meadow.grove.place`         | D1, KV, Auth svc, DO×1                         | **Medium**    |
+| 5   | `packages/clearing`  | `grove-clearing`  | `status.grove.place`         | D1×2                                           | **Low**       |
+| 6   | `packages/domains`   | `grove-domains`   | Forage tool                  | D1, Auth svc                                   | **Low**       |
+| 7   | `packages/login`     | `grove-login`     | `login.grove.place`          | Auth svc only                                  | **Minimal**   |
+| 8   | `packages/terrarium` | `grove-terrarium` | TBD                          | None (localStorage)                            | **Minimal**   |
 
 ### Cloudflare Workers
 
-| # | Package | Script Name | Type | Cron | Bindings |
-|---|---------|-------------|------|------|----------|
-| 1 | `packages/heartwood` | `groveauth` | Service | `* * * * *`, `0 0 * * *` | D1×2, R2, KV, DO, Zephyr svc, Smart Placement |
-| 2 | `packages/grove-router` | `grove-router` | Service | `* * * * *` | R2×2, Scout/Auth/MC/Mycelium/OG svcs |
-| 3 | `packages/durable-objects` | `grove-durable-objects` | DO Host | — | D1×2, R2×2, KV, AI, Zephyr svc |
-| 4 | `packages/og-worker` | `grove-og` | Service | — | KV |
-| 5 | `workers/zephyr` | `grove-zephyr` | Service | — | D1, Email Render svc |
-| 6 | `workers/pulse` | `grove-pulse` | Service+Cron | `0 * * * *`, `5 0 * * *` | D1, KV |
-| 7 | `workers/email-render` | `grove-email-render` | Service | — | None (stateless) |
-| 8 | `workers/email-catchup` | `grove-email-catchup` | Cron | `0 10 * * 0` | D1, Email Render svc |
-| 9 | `landing/workers/onboarding-emails` | `grove-onboarding-emails` | Cron | `0 10 * * *` | D1 |
-| 10 | `packages/post-migrator` | `grove-post-migrator` | Cron (disabled) | — | D1, R2 |
-| 11 | `packages/workers/clearing-monitor` | `grove-clearing-monitor` | Cron | `*/5 * * * *`, `0 0 * * *` | D1, KV |
-| 12 | `packages/workers/meadow-poller` | `grove-meadow-poller` | Cron | `*/15 * * * *` | D1, KV |
-| 13 | `packages/workers/timeline-sync` | `grove-timeline-sync` | Cron | `0 1 * * *` | D1 |
-| 14 | `packages/workers/vista-collector` | `grove-vista-collector` | Cron | `*/5 * * * *`, `0 0 * * *` | D1 |
-| 15 | `packages/workers/webhook-cleanup` | `grove-webhook-cleanup` | Cron | `0 3 * * *` | D1, R2 |
+| #   | Package                             | Script Name               | Type            | Cron                       | Bindings                                      |
+| --- | ----------------------------------- | ------------------------- | --------------- | -------------------------- | --------------------------------------------- |
+| 1   | `packages/heartwood`                | `groveauth`               | Service         | `* * * * *`, `0 0 * * *`   | D1×2, R2, KV, DO, Zephyr svc, Smart Placement |
+| 2   | `packages/grove-router`             | `grove-router`            | Service         | `* * * * *`                | R2×2, Scout/Auth/MC/Mycelium/OG svcs          |
+| 3   | `packages/durable-objects`          | `grove-durable-objects`   | DO Host         | —                          | D1×2, R2×2, KV, AI, Zephyr svc                |
+| 4   | `packages/og-worker`                | `grove-og`                | Service         | —                          | KV                                            |
+| 5   | `workers/zephyr`                    | `grove-zephyr`            | Service         | —                          | D1, Email Render svc                          |
+| 6   | `workers/pulse`                     | `grove-pulse`             | Service+Cron    | `0 * * * *`, `5 0 * * *`   | D1, KV                                        |
+| 7   | `workers/email-render`              | `grove-email-render`      | Service         | —                          | None (stateless)                              |
+| 8   | `workers/email-catchup`             | `grove-email-catchup`     | Cron            | `0 10 * * 0`               | D1, Email Render svc                          |
+| 9   | `landing/workers/onboarding-emails` | `grove-onboarding-emails` | Cron            | `0 10 * * *`               | D1                                            |
+| 10  | `packages/post-migrator`            | `grove-post-migrator`     | Cron (disabled) | —                          | D1, R2                                        |
+| 11  | `packages/workers/clearing-monitor` | `grove-clearing-monitor`  | Cron            | `*/5 * * * *`, `0 0 * * *` | D1, KV                                        |
+| 12  | `packages/workers/meadow-poller`    | `grove-meadow-poller`     | Cron            | `*/15 * * * *`             | D1, KV                                        |
+| 13  | `packages/workers/timeline-sync`    | `grove-timeline-sync`     | Cron            | `0 1 * * *`                | D1                                            |
+| 14  | `packages/workers/vista-collector`  | `grove-vista-collector`   | Cron            | `*/5 * * * *`, `0 0 * * *` | D1                                            |
+| 15  | `packages/workers/webhook-cleanup`  | `grove-webhook-cleanup`   | Cron            | `0 3 * * *`                | D1, R2                                        |
 
 ---
 
@@ -70,16 +70,16 @@ The engine's `wrangler.toml` says it plainly on line 233:
 
 This is why Grove has **8 separate cron workers** — tasks that would naturally live inside the main app have been split into standalone workers:
 
-| Cron Worker | What It Does | Natural Home |
-|-------------|-------------|--------------|
-| `webhook-cleanup` | Deletes expired webhook events daily | Engine |
-| `post-migrator` | Migrates posts between storage tiers | Engine |
-| `onboarding-emails` | Sends follow-up emails to signups | Landing |
-| `clearing-monitor` | Pings health endpoints every 5min | Clearing |
-| `meadow-poller` | Fetches RSS feeds every 15min | Meadow |
-| `timeline-sync` | Generates nightly AI summaries | Engine |
-| `vista-collector` | Collects observability metrics | Landing |
-| `email-catchup` | Weekly missed email recovery | Landing or Engine |
+| Cron Worker         | What It Does                         | Natural Home      |
+| ------------------- | ------------------------------------ | ----------------- |
+| `webhook-cleanup`   | Deletes expired webhook events daily | Engine            |
+| `post-migrator`     | Migrates posts between storage tiers | Engine            |
+| `onboarding-emails` | Sends follow-up emails to signups    | Landing           |
+| `clearing-monitor`  | Pings health endpoints every 5min    | Clearing          |
+| `meadow-poller`     | Fetches RSS feeds every 15min        | Meadow            |
+| `timeline-sync`     | Generates nightly AI summaries       | Engine            |
+| `vista-collector`   | Collects observability metrics       | Landing           |
+| `email-catchup`     | Weekly missed email recovery         | Landing or Engine |
 
 If Pages apps became Workers, **up to 6 of these cron workers could be absorbed** into their parent apps, reducing the total deployment count from 23 to ~17.
 
@@ -93,7 +93,7 @@ The engine's wrangler.toml notes on line 176:
 
 > "GROVE_KEK is set as a regular Cloudflare secret because Pages doesn't support secrets_store_secrets bindings (only Workers do)."
 
-Workers can use the centralized Cloudflare Secrets Store, which is better for rotating secrets across multiple services. Currently the KEK must be set individually per-service.
+Workers can use the centralized Cloudflare Secrets Store, which is better for rotating secrets across multiple services. Currently the KEK is set as a regular Cloudflare environment secret (`wrangler secret put GROVE_KEK`) on each service that needs it — this means rotating the key requires updating it individually on every service via the Cloudflare Dashboard or CLI, with no centralized rotation or audit trail. Converting to Workers would allow binding to a single Secrets Store entry, so rotating the KEK becomes a one-place change that propagates to all consumers.
 
 ### 4. Deployment Flags
 
@@ -128,6 +128,7 @@ workersAnalyticsEngineAdaptiveGroups(
 ```
 
 This is the **Workers-specific analytics dataset**. It returns per-`scriptName` metrics:
+
 - Request count (total, success, error)
 - Error rate
 - Latency percentiles (p50, p95, p99)
@@ -135,7 +136,7 @@ This is the **Workers-specific analytics dataset**. It returns per-`scriptName` 
 
 ### The Gap: Pages Projects in the Analytics API
 
-Pages Functions do run on Workers behind the scenes, and they *do* appear in the Cloudflare Analytics API. But there are differences:
+Pages Functions do run on Workers behind the scenes, and they _do_ appear in the Cloudflare Analytics API. But there are differences:
 
 1. **Script name mismatch**: Pages projects may appear with their internal Pages project name rather than the `name` field in wrangler.toml. The `SERVICE_REGISTRY` lists `grove-engine` as the script name, but the actual Pages project is `grove-lattice`. This mismatch means Vista might collect data under the wrong name — or miss it entirely.
 
@@ -146,6 +147,7 @@ Pages Functions do run on Workers behind the scenes, and they *do* appear in the
 ### What Conversion Would Fix
 
 If all Pages became Workers:
+
 - Every deployment would have a consistent `scriptName` in the Workers Analytics API
 - Vista's `collectWorkerMetrics()` would capture all deployments uniformly
 - The `SERVICE_REGISTRY` entries would map 1:1 to actual Cloudflare Worker script names
@@ -162,6 +164,7 @@ If all Pages became Workers:
 **Character**: The beating heart of Grove. Every tenant site, every blog post, every admin panel — it all flows through here. The most complex deployment in the system, straining against Pages limitations.
 
 **Why convert**:
+
 - **Smart Placement** — This is the most D1-heavy app in the ecosystem (shared `grove-engine-db`, 2 KV namespaces, 3 R2 buckets, 6 DO bindings). Smart placement could reduce p50 latency meaningfully for all tenant page loads.
 - **Absorb cron workers** — Could absorb `webhook-cleanup`, `post-migrator`, and `timeline-sync`. That's 3 fewer deployments to maintain.
 - **Secrets Store** — The GROVE_KEK workaround (regular secret instead of secrets store) goes away.
@@ -172,6 +175,7 @@ If all Pages became Workers:
 **Conversion complexity**: **Medium-High**. Largest codebase, most bindings, needs careful testing of the SvelteKit adapter swap. The CSRF config (`checkOrigin: false` with custom hooks) must be verified post-conversion.
 
 **Workers it could absorb**:
+
 - `grove-webhook-cleanup` (daily cron → engine cron)
 - `grove-post-migrator` (daily cron → engine cron, currently disabled)
 - `grove-timeline-sync` (daily cron → engine cron)
@@ -181,14 +185,16 @@ If all Pages became Workers:
 **Character**: The public face of Grove and the admin nerve center. Home to Arbor (admin panel) and Vista (observability dashboard). Ironic that the observability dashboard can't fully observe itself.
 
 **Why convert**:
+
 - **Self-observability** — Landing hosts Vista but isn't monitored as cleanly as Workers are. Converting makes the observer a first-class citizen in its own system.
-- **Absorb cron workers** — Could absorb `onboarding-emails` (daily email sequences). That worker lives *inside* the landing package already (`packages/landing/workers/onboarding-emails/`).
+- **Absorb cron workers** — Could absorb `onboarding-emails` (daily email sequences). That worker lives _inside_ the landing package already (`packages/landing/workers/onboarding-emails/`).
 - **Smart Placement** — Landing reads from D1 for admin operations and signup data.
 - **`--var` flags** — Currently notes that Pages deploy "doesn't support --var flags" and secrets must be set via dashboard. Workers fix this.
 
 **Conversion complexity**: **Medium**. Simpler bindings than engine. The onboarding-emails worker absorption is especially clean since it's already co-located.
 
 **Workers it could absorb**:
+
 - `grove-onboarding-emails` (daily cron → landing cron)
 
 ### Tier 2: Convert These (Medium Value)
@@ -198,6 +204,7 @@ If all Pages became Workers:
 **Character**: Where Wanderers become Rooted. Stripe integration, subscription management, signup flows. Every millisecond of latency here affects conversion rates.
 
 **Why convert**:
+
 - **Smart Placement** — Stripe webhook processing is DB-heavy (write subscription records, update tenant tiers). Lower D1 latency directly impacts payment reliability.
 - **Cron potential** — Could run subscription health checks, expiry reminders.
 - **Secrets management** — Multiple Stripe secrets (5+) that could use Secrets Store.
@@ -209,6 +216,7 @@ If all Pages became Workers:
 **Character**: Where the community gathers. Notes, votes, reactions, a living feed of creativity.
 
 **Why convert**:
+
 - **Absorb meadow-poller** — The `grove-meadow-poller` cron (every 15 min) is Meadow's companion. As a Worker with cron triggers, Meadow could handle its own feed polling.
 - **Smart Placement** — Feed queries are D1-heavy (joins across posts, users, votes).
 - **DO consistency** — Already binds to ThresholdDO; as a Worker, the binding semantics are cleaner.
@@ -216,6 +224,7 @@ If all Pages became Workers:
 **Conversion complexity**: **Low-Medium**. Moderate bindings. Poller absorption is straightforward.
 
 **Workers it could absorb**:
+
 - `grove-meadow-poller` (15-min cron → meadow cron)
 
 #### 5. Clearing (`grove-clearing`) — The Status Page
@@ -223,12 +232,14 @@ If all Pages became Workers:
 **Character**: The lighthouse. When things go wrong, Clearing shows the way. When things go right, it proves it.
 
 **Why convert**:
+
 - **Absorb clearing-monitor** — The `grove-clearing-monitor` cron (every 5 min) is literally Clearing's dedicated health checker. They share the same D1 database. Natural fit.
 - **Smart Placement** — Reads from 2 D1 databases.
 
 **Conversion complexity**: **Low**. Simple bindings. Monitor absorption is the main win.
 
 **Workers it could absorb**:
+
 - `grove-clearing-monitor` (5-min cron → clearing cron)
 
 ### Tier 3: Evaluate Later (Low Value)
@@ -278,19 +289,20 @@ No backend at all. Uses localStorage exclusively. Zero bindings. No D1, no KV, n
 
 If Tier 1 + 2 conversions happen, this is how cron workers collapse:
 
-| Current Worker | Absorbed Into | Cron Schedule | Status |
-|---------------|---------------|---------------|--------|
-| `grove-webhook-cleanup` | Engine | `0 3 * * *` | Active |
-| `grove-post-migrator` | Engine | `0 3 * * *` | Disabled |
-| `grove-timeline-sync` | Engine | `0 1 * * *` | Active |
-| `grove-onboarding-emails` | Landing | `0 10 * * *` | Active |
-| `grove-meadow-poller` | Meadow | `*/15 * * * *` | Active |
-| `grove-clearing-monitor` | Clearing | `*/5 * * * *`, `0 0 * * *` | Active |
+| Current Worker            | Absorbed Into | Cron Schedule              | Status   |
+| ------------------------- | ------------- | -------------------------- | -------- |
+| `grove-webhook-cleanup`   | Engine        | `0 3 * * *`                | Active   |
+| `grove-post-migrator`     | Engine        | `0 3 * * *`                | Disabled |
+| `grove-timeline-sync`     | Engine        | `0 1 * * *`                | Active   |
+| `grove-onboarding-emails` | Landing       | `0 10 * * *`               | Active   |
+| `grove-meadow-poller`     | Meadow        | `*/15 * * * *`             | Active   |
+| `grove-clearing-monitor`  | Clearing      | `*/5 * * * *`, `0 0 * * *` | Active   |
 
 **Result**: 6 fewer standalone deployments. Total goes from 23 → 17.
 
 Workers that remain standalone (they serve different domains or have unique concerns):
-- `grove-vista-collector` — Collects from *all* services, shouldn't be embedded in one
+
+- `grove-vista-collector` — Collects from _all_ services, shouldn't be embedded in one
 - `grove-email-catchup` — Weekly cron, could go in Engine or Zephyr
 - `grove-pulse` — Webhook receiver for GitHub, standalone is fine
 - `grove-email-render` — Stateless renderer, called by multiple services
@@ -302,6 +314,7 @@ Workers that remain standalone (they serve different domains or have unique conc
 ### Phase 1: Registry Alignment (Do Now)
 
 Update `SERVICE_REGISTRY` in `types.ts` to accurately reflect current script names:
+
 - Verify `grove-engine` vs `grove-lattice` script name in Cloudflare Analytics
 - Add missing Pages projects that aren't currently tracked (Landing, Plant, Clearing, Domains, Login)
 - Add workers that exist but aren't in the registry (Zephyr, Pulse, OG Worker, Email Render, Email Catchup, Timeline Sync, Webhook Cleanup)
@@ -309,6 +322,7 @@ Update `SERVICE_REGISTRY` in `types.ts` to accurately reflect current script nam
 ### Phase 2: Unified Analytics (After Conversion)
 
 Once Pages are converted to Workers:
+
 - All deployments appear consistently in `workersAnalyticsEngineAdaptiveGroups`
 - Vista's Workers dashboard covers everything — no blind spots
 - Health checks remain the same (URL-based pings)
@@ -316,6 +330,7 @@ Once Pages are converted to Workers:
 ### Phase 3: Tail Worker Logging (Future)
 
 Add a `grove-vista-tail` worker as a `tail_consumer` on all Worker deployments:
+
 - Receives real-time `console.log`, `console.error`, and exception events
 - Writes structured logs to D1 or streams to external logging
 - Vista gets a real-time log viewer for every service
@@ -384,29 +399,29 @@ Built via `vite build` → `.svelte-kit/cloudflare/` → deployed as Pages.
 
 Some `src/lib/` modules exist solely to serve routes — never exported:
 
-| Module | Files | Lines | Purpose |
-|--------|-------|-------|---------|
-| `sentinel/` | 7 | ~3,964 | Content safety/moderation pipeline |
-| `durable-objects/` | 4 | — | Local DO helpers for routes |
-| `scribe/` | 2 | — | Writing/content helpers |
-| `types/` | 3 | — | Shared route TypeScript types |
-| `git/` | 2 | — | Git-related utilities |
+| Module             | Files | Lines  | Purpose                            |
+| ------------------ | ----- | ------ | ---------------------------------- |
+| `sentinel/`        | 7     | ~3,964 | Content safety/moderation pipeline |
+| `durable-objects/` | 4     | —      | Local DO helpers for routes        |
+| `scribe/`          | 2     | —      | Writing/content helpers            |
+| `types/`           | 3     | —      | Shared route TypeScript types      |
+| `git/`             | 2     | —      | Git-related utilities              |
 
 Sentinel alone is ~4k lines of sophisticated safety infrastructure that only 2 routes touch. It lives in the library directory but has nothing to do with being a library.
 
 ### The mismatch
 
-The name "engine" implies a library — a thing that powers other things. And it IS that: `@autumnsgrove/lattice` is imported everywhere. But it's also the live application that *is the product*. Two identities:
+The name "engine" implies a library — a thing that powers other things. And it IS that: `@autumnsgrove/lattice` is imported everywhere. But it's also the live application that _is the product_. Two identities:
 
-| Concern | Library | App |
-|---------|---------|-----|
-| **Name** | `@autumnsgrove/lattice` | `grove-lattice` |
-| **Purpose** | Provide shared infrastructure | Serve tenant sites |
-| **Build** | `svelte-package` → `dist/` | `vite build` → `.svelte-kit/cloudflare/` |
-| **Deploy** | Published to npm (consumed at build time) | Deployed to Cloudflare Pages (runs at request time) |
-| **Consumers** | 10 packages | Every Wanderer with a `*.grove.place` blog |
-| **Changes** | Must be backwards-compatible | Can ship breaking route changes freely |
-| **Testing** | Unit tests for exports | Integration tests for routes + API |
+| Concern       | Library                                   | App                                                 |
+| ------------- | ----------------------------------------- | --------------------------------------------------- |
+| **Name**      | `@autumnsgrove/lattice`                   | `grove-lattice`                                     |
+| **Purpose**   | Provide shared infrastructure             | Serve tenant sites                                  |
+| **Build**     | `svelte-package` → `dist/`                | `vite build` → `.svelte-kit/cloudflare/`            |
+| **Deploy**    | Published to npm (consumed at build time) | Deployed to Cloudflare Pages (runs at request time) |
+| **Consumers** | 10 packages                               | Every Wanderer with a `*.grove.place` blog          |
+| **Changes**   | Must be backwards-compatible              | Can ship breaking route changes freely              |
+| **Testing**   | Unit tests for exports                    | Integration tests for routes + API                  |
 
 ### Why this matters for the conversion
 
@@ -421,15 +436,16 @@ If we split the engine into **library** + **app**, the Pages-to-Workers conversi
 
 Both halves are Lattice. Things grow on a lattice — one lattice is static (the library you import), one is live (the deployment serving `*.grove.place`). We don't need a new Grove name. We need clear words:
 
-| | **Lattice** (the library) | **The engine** (the deployment) |
-|---|---|---|
-| Package | `@autumnsgrove/lattice` | `grove-lattice` |
-| Lives at | `libs/engine/src/lib/` | `libs/engine/src/routes/` |
-| Build | `svelte-package` → `dist/` | `vite build` → `.svelte-kit/cloudflare/` |
-| Consumed by | 10+ packages at build time | Every Wanderer at request time |
-| Future home | `libs/lattice/` | `apps/engine/` |
+|             | **Lattice** (the library)  | **The engine** (the deployment)          |
+| ----------- | -------------------------- | ---------------------------------------- |
+| Package     | `@autumnsgrove/lattice`    | `grove-lattice`                          |
+| Lives at    | `libs/engine/src/lib/`     | `libs/engine/src/routes/`                |
+| Build       | `svelte-package` → `dist/` | `vite build` → `.svelte-kit/cloudflare/` |
+| Consumed by | 10+ packages at build time | Every Wanderer at request time           |
+| Future home | `libs/engine/`             | `apps/engine/`                           |
 
 In conversation:
+
 - "**Lattice** exports the component" = the library
 - "**The engine** serves the route" = the deployment
 - "**Lattice** provides it, **the engine** renders it"
@@ -438,13 +454,13 @@ The split happens in directory structure, not in branding. When the time comes:
 
 ```
 libs/
-├── lattice/          ← The library (static lattice)
+├── engine/           ← The library (static lattice, @autumnsgrove/lattice)
 │   ├── src/lib/      ← All exported modules (539 files)
 │   ├── package.json  ← @autumnsgrove/lattice, exports only
 │   └── (no routes, no wrangler.toml, no svelte.config.js)
 
 apps/
-├── engine/           ← The deployment (live lattice)
+├── engine/           ← The deployment (live lattice, grove-lattice)
 │   ├── src/
 │   │   ├── routes/   ← All 262 route files
 │   │   └── lib/      ← Internal-only modules (sentinel, DO helpers, types)
@@ -463,21 +479,21 @@ This split is the prerequisite step before converting to a Worker. The library d
 
 ### By the numbers
 
-| Metric | Count |
-|--------|-------|
-| Total deployments | 23 |
-| Cloudflare Pages | 8 |
-| Cloudflare Workers | 15 |
-| Workers — HTTP services | 7 |
-| Workers — Cron only | 8 |
-| Cron workers absorbable | 6 |
-| Post-conversion total | ~17 |
-| Vista-monitored today | 11 (SERVICE_REGISTRY) |
-| Vista-unmonitored today | 12 |
+| Metric                  | Count                 |
+| ----------------------- | --------------------- |
+| Total deployments       | 23                    |
+| Cloudflare Pages        | 8                     |
+| Cloudflare Workers      | 15                    |
+| Workers — HTTP services | 7                     |
+| Workers — Cron only     | 8                     |
+| Cron workers absorbable | 6                     |
+| Post-conversion total   | ~17                   |
+| Vista-monitored today   | 11 (SERVICE_REGISTRY) |
+| Vista-unmonitored today | 12                    |
 
 ### Recommended trek order
 
-1. **Engine split (library + app), then app to Worker** — Highest value, most bindings, best observability + latency gains. Split `libs/engine` into `libs/lattice` + `apps/engine`, then convert the app.
+1. **Engine split (library + app), then app to Worker** — Highest value, most bindings, best observability + latency gains. Split `libs/engine` into `libs/engine` (library only) + `apps/engine` (deployment), then convert the app. Both directories keep the `engine` name to avoid another round of mass renames — the package name `@autumnsgrove/lattice` and the deploy name `grove-lattice` stay as-is.
 2. **Landing** — Second-highest value, hosts Vista, absorbs onboarding-emails. Validates the pattern scales.
 3. **Meadow** — Absorbs meadow-poller, gains smart placement.
 4. **Clearing** — Absorbs clearing-monitor, simple conversion.

--- a/docs/plans/planned/tenant-app-naming-journey.md
+++ b/docs/plans/planned/tenant-app-naming-journey.md
@@ -8,6 +8,7 @@
 ## What IS This Thing?
 
 The thing we're distinguishing:
+
 - The live SvelteKit deployment serving `*.grove.place`
 - 262 route files, 127 API handlers, 80+ curio endpoints
 - Contains Arbor (admin panel), Sentinel (safety), all public pages
@@ -28,7 +29,7 @@ the API call. It's the medium through which every part of the grove becomes real
 ### Round 1: Bower (Rejected)
 
 First candidate. A bower grows on a lattice — the metaphor was perfect.
-But the word doesn't *roll* in the grove. Too archaic. Catches in the throat.
+But the word doesn't _roll_ in the grove. Too archaic. Catches in the throat.
 
 The Wayfinder's verdict: "Bower is explicitly not allowed. I dislike the name
 greatly and it doesn't roll well for the grove."
@@ -63,21 +64,23 @@ different context. One you build with, one you visit.
 
 No new Grove name needed. Just clear words:
 
-| | **Lattice** (the library) | **The engine** (the deployment) |
-|---|---|---|
-| Package | `@autumnsgrove/lattice` | `grove-lattice` |
-| Lives at | `libs/engine/src/lib/` | `libs/engine/src/routes/` |
-| Build | `svelte-package` → `dist/` | `vite build` → `.svelte-kit/cloudflare/` |
-| Consumed by | 10+ packages at build time | Every Wanderer at request time |
-| Future home | `libs/lattice/` | `apps/engine/` |
+|             | **Lattice** (the library)  | **The engine** (the deployment)          |
+| ----------- | -------------------------- | ---------------------------------------- |
+| Package     | `@autumnsgrove/lattice`    | `grove-lattice`                          |
+| Lives at    | `libs/engine/src/lib/`     | `libs/engine/src/routes/`                |
+| Build       | `svelte-package` → `dist/` | `vite build` → `.svelte-kit/cloudflare/` |
+| Consumed by | 10+ packages at build time | Every Wanderer at request time           |
+| Future home | `libs/engine/`             | `apps/engine/`                           |
 
 In conversation:
+
 - "**Lattice** exports the component" = the library
 - "**The engine** serves the route" = the deployment
 - "**Lattice** provides it, **the engine** renders it"
 
 When the physical split happens:
-- `libs/lattice/` — the library (static lattice, `@autumnsgrove/lattice`)
+
+- `libs/engine/` — the library (static lattice, `@autumnsgrove/lattice`)
 - `apps/engine/` — the deployment (live lattice, `grove-lattice`)
 
 Both are lattice. One you build with, one you visit.
@@ -88,13 +91,13 @@ Both are lattice. One you build with, one you visit.
 
 For the record, the names explored during the walk:
 
-| Name | Relationship to Lattice | Why Not |
-|------|------------------------|---------|
-| **Bower** | A bower grows on a lattice/trellis | Too archaic, doesn't roll well |
-| **Glade** | Open clearing where light reaches ground | An absence, not a structure; too similar to Clearing |
-| **Hollow** | Sheltered depression in landscape | "Hollow" means empty |
-| **Thicket** | Dense, living cluster of growth | Good name, but the whole premise was wrong — we don't need a new name |
-| **Stand** | A forestry unit of trees | Too many non-forest meanings |
+| Name        | Relationship to Lattice                  | Why Not                                                               |
+| ----------- | ---------------------------------------- | --------------------------------------------------------------------- |
+| **Bower**   | A bower grows on a lattice/trellis       | Too archaic, doesn't roll well                                        |
+| **Glade**   | Open clearing where light reaches ground | An absence, not a structure; too similar to Clearing                  |
+| **Hollow**  | Sheltered depression in landscape        | "Hollow" means empty                                                  |
+| **Thicket** | Dense, living cluster of growth          | Good name, but the whole premise was wrong — we don't need a new name |
+| **Stand**   | A forestry unit of trees                 | Too many non-forest meanings                                          |
 
 The walk was valuable. We explored the space thoroughly enough to realize
 the right answer wasn't a name at all — it was clarity about what we


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for two interconnected planning efforts:

1. **Cloudflare Deployment Safari** (`cloudflare-deployment-safari.md`) — A complete audit of all 23 Grove deployments across Cloudflare Pages and Workers, identifying capability gaps, observability blind spots, and a prioritized conversion strategy to migrate Pages apps to Workers for better performance, operational efficiency, and monitoring.

2. **Tenant App Naming Journey** (`tenant-app-naming-journey.md`) — Documentation of the naming decision for the engine/library split. The conclusion: **no new name is needed.** Both halves are Lattice — one you build with (`libs/engine/`, the library), one you visit (`apps/engine/`, the deployment). The walk through Bower, Glade, Thicket, and others was valuable but revealed the right answer was clarity about what we already have, not a new identity.

## Key Findings

### Deployment Landscape
- 23 total deployments: 8 Cloudflare Pages + 15 Cloudflare Workers
- 8 standalone cron workers exist solely because Pages doesn't support cron triggers
- Vista observability dashboard monitors only 11 of 23 deployments (SERVICE_REGISTRY gap)

### Pages Limitations Documented
- No cron trigger support (forcing 8 separate worker deployments)
- No Smart Placement for D1 latency optimization
- No Secrets Store bindings (workarounds in place for GROVE_KEK)
- No `--var` flag support in deployment (manual dashboard configuration required)
- No infrastructure-as-code route configuration

### Conversion Strategy
**Tier 1 (High Value):**
- Engine (absorb 3 cron workers, enable smart placement, fix Vista observability)
- Landing (absorb onboarding-emails cron, self-observability)

**Tier 2 (Medium Value):**
- Plant, Meadow, Clearing (each absorbs 1 cron worker, gains smart placement)

**Result:** Reduce from 23 deployments to ~17 by consolidating 6 cron workers into their parent applications.

### Architectural Insight
The Engine package is currently two things: a 539-file shared library (`@autumnsgrove/lattice`) and a 262-route live deployment. The split establishes:
- **Lattice** — The component library (`libs/engine/`, stays as npm package, no deployment)
- **The engine** — The tenant application deployment (`apps/engine/`, 262 routes, 127 API handlers, 80+ curio endpoints)

Both directories keep the `engine` name to avoid another mass rename.

## Type of Change

- [x] Documentation
- [x] Planning/Architecture

## Testing

N/A — These are planning and documentation artifacts, not code changes.