### PR TITLE
Fix draft banner re-showing and improve touch accessibility

### DIFF
--- a/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
+++ b/packages/engine/src/lib/components/admin/MarkdownEditor.svelte
@@ -960,13 +960,13 @@
 		}
 	}
 
-	// Initialize editor on mount — untrack(content) prevents re-running on every keystroke
+	// Initialize editor on mount — untrack prevents re-running on content/ref changes.
+	// IMPORTANT: Do NOT call functions that read reactive state (like updateCursorPosition)
+	// inside this effect — it would cause init() to re-run on every keystroke, re-showing
+	// the draft banner after dismiss and breaking restore/discard on touch devices.
 	$effect(() => {
-		updateCursorPosition();
 		editorTheme.loadTheme();
 		draftManager.init(untrack(() => content));
-		// Note: editorMode is now initialized synchronously at declaration time
-		// to avoid flash of wrong mode on initial render
 
 		// Register page lifecycle handlers to prevent draft loss
 		window.addEventListener("beforeunload", handleBeforeUnload);
@@ -1632,14 +1632,10 @@
 		}
 	}
 	.draft-prompt {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
 		background: rgba(45, 60, 45, 0.98);
 		border-bottom: 1px solid #4a7c4a;
-		z-index: 98;
 		padding: 0.5rem 0.75rem;
+		flex-shrink: 0;
 	}
 	.draft-prompt-content {
 		display: flex;
@@ -1671,14 +1667,18 @@
 		gap: 0.5rem;
 	}
 	.draft-btn {
-		padding: 0.25rem 0.5rem;
+		padding: 0.5rem 0.75rem;
+		min-height: 44px;
+		min-width: 44px;
 		border-radius: 0;
-		font-size: 0.8rem;
+		font-size: 0.85rem;
 		font-family: "JetBrains Mono", "Fira Code", monospace;
 		cursor: pointer;
 		transition: color 0.1s ease;
 		background: transparent;
 		border: none;
+		-webkit-tap-highlight-color: rgba(139, 196, 139, 0.2);
+		touch-action: manipulation;
 	}
 	.draft-btn.restore {
 		color: #8bc48b;

--- a/packages/engine/src/lib/components/admin/composables/useDraftManager.svelte.ts
+++ b/packages/engine/src/lib/components/admin/composables/useDraftManager.svelte.ts
@@ -260,15 +260,26 @@ export function useDraftManager(
     }, AUTO_SAVE_DELAY);
   }
 
+  let initialized = false;
+
   function init(initialContent: string): void {
+    // Guard: only run once per component lifecycle.
+    // The mount effect can re-run if reactive dependencies sneak in;
+    // re-initializing would re-show the draft banner after dismiss.
+    if (initialized) return;
+    initialized = true;
+
+    // Always set lastSavedContent so auto-save has a correct baseline.
+    // Without this, lastSavedContent stays "" when a draft is found,
+    // causing the auto-save to think content has changed immediately.
+    lastSavedContent = initialContent;
+
     // Check for existing draft on mount
     if (draftKey) {
       const draft = loadDraft();
       if (draft && draft.content !== initialContent) {
         storedDraft = draft;
         draftRestorePrompt = true;
-      } else {
-        lastSavedContent = initialContent;
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where the draft restore banner would re-appear after being dismissed, and improves touch device accessibility for draft management buttons.

The root cause was that `updateCursorPosition()` was being called inside the mount effect, which reads reactive state and caused the effect to re-run on every keystroke. This triggered `draftManager.init()` repeatedly, re-showing the draft banner. The fix removes this call and adds a guard in `useDraftManager.init()` to ensure initialization only happens once per component lifecycle.

Additionally, the draft prompt styling is refactored from absolute positioning to flex layout for better integration with the editor layout, and draft buttons now meet WCAG touch target size requirements (44x44px minimum).

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Changes

**MarkdownEditor.svelte:**
- Removed `updateCursorPosition()` call from mount effect to prevent reactive state reads that cause re-initialization
- Updated effect comment to clarify why reactive state reads must be avoided
- Refactored `.draft-prompt` from absolute positioning to flex layout (`flex-shrink: 0`)
- Increased `.draft-btn` padding and added minimum dimensions (44x44px) for touch accessibility
- Added `-webkit-tap-highlight-color` and `touch-action: manipulation` for better touch feedback

**useDraftManager.svelte.ts:**
- Added `initialized` guard flag to prevent `init()` from running multiple times per component lifecycle
- Moved `lastSavedContent = initialContent` assignment outside the conditional block to ensure it's always set, preventing auto-save from incorrectly detecting changes when a draft is found
- Added clarifying comments explaining the guard and baseline initialization

## Testing

Existing component tests cover the draft manager initialization and restoration flow. The changes maintain backward compatibility while fixing the re-initialization bug and improving touch device usability.

https://claude.ai/code/session_01GY7YLX8bJxH7RpX9CbQ6R1