### PR TITLE
refactor(lumen): reorganize moderation model cascade to GPT-oss Safeguard

### DIFF
--- a/docs/help-center/articles/what-is-lumen.md
+++ b/docs/help-center/articles/what-is-lumen.md
@@ -77,7 +77,7 @@ The calling service doesn't need to know which model handled the request, which 
 
 You won't see "Lumen" in the Grove interface. It's infrastructure. But it powers:
 
-- **Thorn.** Content moderation for comments and community features. Lumen routes these to LlamaGuard, a purpose-built safety model.
+- **Thorn.** Content moderation for comments and community features. Lumen routes these to GPT-oss Safeguard, a purpose-built safety reasoning model.
 - **Wisp.** Writing assistance and Fireside mode. When you ask for suggestions or dictate a draft, Lumen handles the generation.
 - **Petal.** Image moderation. When you upload photos, Lumen checks them for policy compliance.
 - **Scribe.** Voice transcription. When you speak into the editor, Lumen transcribes through Cloudflare's Whisper models.
@@ -85,20 +85,20 @@ You won't see "Lumen" in the Grove interface. It's infrastructure. But it powers
 
 ## The technical details
 
-Lumen is a Cloudflare Worker that sits in front of multiple AI providers. The primary provider is OpenRouter, which gives access to DeepSeek, LlamaGuard, Gemini, and other models through a unified API. Cloudflare Workers AI serves as a fallback layer.
+Lumen is a Cloudflare Worker that sits in front of multiple AI providers. The primary provider is OpenRouter, which gives access to GPT-oss Safeguard, LlamaGuard, DeepSeek, Gemini, and other models through a unified API. Cloudflare Workers AI serves as a fallback layer for embeddings and transcription.
 
 Requests route based on task type:
 
 | Task | Primary Model | Use Case |
 |------|---------------|----------|
-| `moderation` | LlamaGuard 4 | Content safety checks |
+| `moderation` | GPT-oss Safeguard 20B | Content safety checks |
 | `generation` | DeepSeek v3.2 | Long-form writing |
 | `chat` | DeepSeek v3.2 | Conversational AI |
 | `image` | Gemini 2.5 Flash | Image analysis |
 | `embedding` | BGE-M3 | Vector search |
 | `transcription` | Whisper Large v3 | Voice-to-text |
 
-If the primary model fails, Lumen automatically tries fallback options. DeepSeek down? Try Kimi K2. LlamaGuard overloaded? Fall back to Cloudflare's local instance.
+If the primary model fails, Lumen automatically tries fallback options. GPT-oss Safeguard down? Fall back to LlamaGuard 4, then DeepSeek. All models route through OpenRouter for unified access.
 
 Everything flows through Cloudflare AI Gateway for caching, logging, and analytics.
 

--- a/libs/engine/src/lib/lumen/client.ts
+++ b/libs/engine/src/lib/lumen/client.ts
@@ -337,7 +337,7 @@ export class LumenClient {
 
   /**
    * Check content for safety.
-   * Uses OpenRouter (LlamaGuard 4) with Cloudflare AI fallback.
+   * Uses OpenRouter: GPT-oss Safeguard 20B → LlamaGuard 4 → DeepSeek V3.2.
    */
   async moderate(
     request: LumenModerationRequest,

--- a/libs/engine/src/lib/lumen/config.test.ts
+++ b/libs/engine/src/lib/lumen/config.test.ts
@@ -56,6 +56,7 @@ describe("Model Definitions", () => {
     expect(MODELS.GEMINI_FLASH).toContain("gemini");
 
     // Moderation
+    expect(MODELS.GPT_OSS_SAFEGUARD).toContain("gpt-oss-safeguard");
     expect(MODELS.LLAMAGUARD_4).toContain("llama-guard");
 
     // Embeddings
@@ -155,17 +156,26 @@ describe("Task-Specific Configuration", () => {
   });
 
   describe("Moderation Task", () => {
-    it("should use LlamaGuard 4 as primary", () => {
-      expect(TASK_REGISTRY.moderation.primaryModel).toBe(MODELS.LLAMAGUARD_4);
+    it("should use GPT-oss Safeguard as primary", () => {
+      expect(TASK_REGISTRY.moderation.primaryModel).toBe(
+        MODELS.GPT_OSS_SAFEGUARD,
+      );
     });
 
-    it("should have Cloudflare fallbacks", () => {
+    it("should have LlamaGuard 4 and DeepSeek V3 as fallbacks", () => {
       const fallbacks = TASK_REGISTRY.moderation.fallbackChain;
-      const hasCFFallback = fallbacks.some(
-        (f) => f.provider === "cloudflare-ai",
-      );
 
-      expect(hasCFFallback).toBe(true);
+      expect(fallbacks[0].model).toBe(MODELS.LLAMAGUARD_4);
+      expect(fallbacks[1].model).toBe(MODELS.DEEPSEEK_V3);
+    });
+
+    it("should use all-OpenRouter cascade", () => {
+      expect(TASK_REGISTRY.moderation.primaryProvider).toBe("openrouter");
+
+      const fallbacks = TASK_REGISTRY.moderation.fallbackChain;
+      for (const fallback of fallbacks) {
+        expect(fallback.provider).toBe("openrouter");
+      }
     });
 
     it("should use temperature 0 for consistency", () => {
@@ -302,6 +312,7 @@ describe("getModelsForProvider", () => {
 
     expect(models).toContain(MODELS.DEEPSEEK_V3);
     expect(models).toContain(MODELS.CLAUDE_HAIKU);
+    expect(models).toContain(MODELS.GPT_OSS_SAFEGUARD);
     expect(models).toContain(MODELS.LLAMAGUARD_4);
     expect(models).toContain(MODELS.BGE_M3);
   });
@@ -310,7 +321,6 @@ describe("getModelsForProvider", () => {
     const models = getModelsForProvider("cloudflare-ai");
 
     expect(models).toContain(MODELS.CF_BGE_BASE);
-    expect(models).toContain(MODELS.CF_LLAMAGUARD_3);
   });
 
   it("should deduplicate models", () => {

--- a/libs/engine/src/lib/lumen/router.ts
+++ b/libs/engine/src/lib/lumen/router.ts
@@ -282,8 +282,8 @@ export async function executeEmbedding(
 }
 
 /**
- * Execute a moderation request with fallback chain
- * Tries OpenRouter (LlamaGuard 4) first, falls back to Cloudflare AI
+ * Execute a moderation request with fallback chain.
+ * GPT-oss Safeguard 20B → LlamaGuard 4 12B → DeepSeek V3.2 (all OpenRouter).
  */
 export async function executeModeration(
   content: string,

--- a/libs/engine/src/lib/lumen/types.ts
+++ b/libs/engine/src/lib/lumen/types.ts
@@ -16,7 +16,7 @@
  * Each task has a primary provider and fallback chain configured in config.ts.
  */
 export type LumenTask =
-  | "moderation" // Content safety → LlamaGuard (CF Workers AI)
+  | "moderation" // Content safety → GPT-oss Safeguard (OpenRouter)
   | "generation" // Text generation → DeepSeek (OpenRouter)
   | "summary" // Summarization → DeepSeek (OpenRouter)
   | "embedding" // Vector embeddings → bge-base (CF Workers AI)

--- a/libs/engine/src/lib/thorn/moderate.ts
+++ b/libs/engine/src/lib/thorn/moderate.ts
@@ -19,7 +19,10 @@ import type { ThornResult, ThornOptions } from "./types.js";
  * Moderate text content using Lumen's moderation task.
  *
  * Flow:
- * 1. Send content to Lumen's moderation task (LlamaGuard 4 → LlamaGuard 3 → ShieldGemma)
+ * 1. Send content to Lumen's moderation task
+ *    Primary: GPT-oss Safeguard 20B (policy-based safety reasoning with confidence scores)
+ *    Fallback: LlamaGuard 4 12B (binary safe/unsafe classification)
+ *    Last resort: DeepSeek V3.2 (general-purpose with policy prompt)
  * 2. Map the moderation result through Thorn's threshold configuration
  * 3. Return a decision based on content type and category confidence
  *


### PR DESCRIPTION
Replace LlamaGuard 4 as primary moderation model with GPT-oss Safeguard
20B, a specialized safety reasoning model that provides policy-based
classification with real confidence scores. The new three-layer cascade:

1. GPT-oss Safeguard 20B (specialized safety, $0.075/$0.30 per M tokens)
2. LlamaGuard 4 12B (binary safety classifier, fallback)
3. DeepSeek V3.2 (general-purpose, last resort)

Key changes:
- Add GROVE_MODERATION_POLICY prompt for policy-based models
- OpenRouter moderate() now handles both policy-based and LlamaGuard formats
- LlamaGuard S-codes mapped to Grove's native category taxonomy
- All moderation models route through OpenRouter (no more CF fallback)
- Update specs, help center docs, and tests to match new cascade

The previous setup used LlamaGuard 4 as primary, which returns binary
safe/unsafe with hardcoded 1.0 confidence — effectively bypassing Thorn's
graduated threshold system. GPT-oss Safeguard returns actual confidence
scores, enabling the threshold engine to work as designed.

https://claude.ai/code/session_01JhM1c5UEW5TCRq6auqH9T5