### PR TITLE
fix(auth): improve login diagnostics and harden auth initialization

### DIFF
--- a/apps/login/src/routes/+page.server.ts
+++ b/apps/login/src/routes/+page.server.ts
@@ -121,8 +121,8 @@ export const actions: Actions = {
 		}
 
 		// Better Auth responds with a redirect → Google OAuth authorization URL.
-		// Accept any redirect status (301, 302, 303, 307, 308).
-		const isRedirect = response.status >= 301 && response.status <= 308;
+		// Accept standard redirect statuses (not 304/305/306 which aren't redirects).
+		const isRedirect = [301, 302, 303, 307, 308].includes(response.status);
 		if (isRedirect) {
 			const location = response.headers.get("location");
 			if (location) {

--- a/apps/login/src/routes/api/health/+server.ts
+++ b/apps/login/src/routes/api/health/+server.ts
@@ -62,10 +62,11 @@ export const GET: RequestHandler = async ({ platform }) => {
 		if (response.ok) {
 			try {
 				const body = (await response.json()) as Record<string, unknown>;
-				(result.heartwood as Record<string, unknown>) = {
-					...(result.heartwood as Record<string, unknown>),
-					...body,
-				};
+				// Allowlist fields — avoid leaking internal details if Heartwood's payload grows
+				const hw = result.heartwood as Record<string, unknown>;
+				hw.status = body.status;
+				if (body.version != null) hw.version = body.version;
+				if (body.uptime != null) hw.uptime = body.uptime;
 			} catch {
 				// JSON parse failed but endpoint was reachable
 			}

--- a/services/heartwood/src/auth/index.ts
+++ b/services/heartwood/src/auth/index.ts
@@ -115,6 +115,9 @@ export function createAuth(env: Env, cf?: CloudflareGeolocation) {
 	// Create Drizzle instance for D1 with schema
 	const db = drizzle(env.DB, { schema });
 	const groveDb = createDbSession(env);
+	if (!env.ZEPHYR_API_KEY) {
+		console.warn("[createAuth] Missing ZEPHYR_API_KEY — magic link emails will fail");
+	}
 	const zephyr = new ZephyrClient({
 		baseUrl: env.ZEPHYR_URL || "https://grove-zephyr.m7jv4v7npb.workers.dev",
 		apiKey: env.ZEPHYR_API_KEY || "",


### PR DESCRIPTION
Add /api/health endpoint to login app for testing AUTH service binding,
widen redirect status detection (301-308), surface better error messages
for Google OAuth and magic link failures, and add defensive env var
validation in Heartwood's createAuth() to fail loudly on missing config
after monorepo migrations.

https://claude.ai/code/session_01KJU12XQo9YG3PLzYhi4F3L