### PR TITLE
fix(landing): query gallery_images for tenant storage instead of empty media table

### DIFF
--- a/apps/landing/src/routes/arbor/tenants/+page.server.ts
+++ b/apps/landing/src/routes/arbor/tenants/+page.server.ts
@@ -51,7 +51,7 @@ export const load: PageServerLoad = async ({ parent, platform }) => {
   const [tenantsResult, statsResult] = await Promise.all([
     DB.prepare(
       `SELECT t.id, t.subdomain, t.display_name, t.email, t.plan,
-              COALESCE((SELECT SUM(m.size) FROM media m WHERE m.tenant_id = t.id), 0) as storage_used,
+              COALESCE((SELECT SUM(COALESCE(g.file_size, 0)) FROM gallery_images g WHERE g.tenant_id = t.id), 0) as storage_used,
               COALESCE((SELECT COUNT(*) FROM posts p WHERE p.tenant_id = t.id), 0) as post_count,
               t.custom_domain, t.theme, t.active, t.created_at, t.updated_at
        FROM tenants t
@@ -71,7 +71,7 @@ export const load: PageServerLoad = async ({ parent, platform }) => {
          COUNT(CASE WHEN plan = 'sapling' THEN 1 END) as sapling,
          COUNT(CASE WHEN plan = 'oak' THEN 1 END) as oak,
          COUNT(CASE WHEN plan = 'evergreen' THEN 1 END) as evergreen,
-         COALESCE((SELECT SUM(size) FROM media), 0) as total_storage,
+         COALESCE((SELECT SUM(COALESCE(file_size, 0)) FROM gallery_images), 0) as total_storage,
          COALESCE((SELECT COUNT(*) FROM posts), 0) as total_posts
        FROM tenants`,
     )

--- a/apps/landing/src/routes/arbor/tenants/[id]/+page.server.ts
+++ b/apps/landing/src/routes/arbor/tenants/[id]/+page.server.ts
@@ -75,12 +75,12 @@ export const load: PageServerLoad = async ({ parent, platform, params }) => {
         .bind(id)
         .first<{ count: number }>()
         .catch(() => ({ count: 0 })),
-      DB.prepare("SELECT COUNT(*) as count FROM media WHERE tenant_id = ?")
+      DB.prepare("SELECT COUNT(*) as count FROM gallery_images WHERE tenant_id = ?")
         .bind(id)
         .first<{ count: number }>()
         .catch(() => ({ count: 0 })),
       DB.prepare(
-        "SELECT COALESCE(SUM(size), 0) as total FROM media WHERE tenant_id = ?",
+        "SELECT COALESCE(SUM(COALESCE(file_size, 0)), 0) as total FROM gallery_images WHERE tenant_id = ?",
       )
         .bind(id)
         .first<{ total: number }>()


### PR DESCRIPTION
The media table is never populated by the upload flow — uploads insert into
gallery_images with file_size. The account page already uses gallery_images
for storage calculations, but the arbor tenant admin pages still queried
the empty media table, resulting in "0 B" for all storage displays.

https://claude.ai/code/session_015BiYduBTLenxrY5ZBEnr1T