### PR TITLE
Fix GroveArchipelago tree cache reactivity with $state

### DIFF
--- a/apps/landing/src/routes/grove/components/GroveArchipelago.svelte
+++ b/apps/landing/src/routes/grove/components/GroveArchipelago.svelte
@@ -41,7 +41,9 @@
 	const currentFrame = $derived(frames[frameIndex] ?? null);
 
 	// Cache previous frame's tree IDs to avoid full re-layout each frame
-	let cachedPrevTreeIds = new Set<string>();
+	// MUST be $state so that $derived(newTreeIds/dyingTreeIds) re-evaluate
+	// when the $effect below updates the cache after each frame change.
+	let cachedPrevTreeIds = $state(new Set<string>());
 	let lastFrameIndex = -1;
 
 	// Build island layouts from current frame


### PR DESCRIPTION
## Summary

Fix a reactivity issue in GroveArchipelago where the cached tree IDs were not properly triggering re-evaluation of derived values. The `cachedPrevTreeIds` variable is now declared with `$state` so that dependent `$derived` values (`newTreeIds` and `dyingTreeIds`) properly re-evaluate when the cache is updated after each frame change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Infrastructure

## Testing

The fix ensures that derived tree ID calculations properly respond to cache updates. Existing component rendering and frame transitions will validate the fix works correctly.

https://claude.ai/code/session_01Gmso7nyyz2Ta6qBmDe4pkN