### PR TITLE
feat(infra): migrate warden to Infra SDK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1324,6 +1324,9 @@ importers:
 
   workers/warden:
     dependencies:
+      '@autumnsgrove/infra':
+        specifier: workspace:*
+        version: link:../../libs/infra
       '@autumnsgrove/lattice':
         specifier: workspace:*
         version: link:../../libs/engine

--- a/workers/warden/package.json
+++ b/workers/warden/package.json
@@ -10,6 +10,7 @@
 		"tail": "wrangler tail"
 	},
 	"dependencies": {
+		"@autumnsgrove/infra": "workspace:*",
 		"@autumnsgrove/lattice": "workspace:*",
 		"hono": "^4.7.0",
 		"zod": "^3.24.0"

--- a/workers/warden/src/auth/api-key.ts
+++ b/workers/warden/src/auth/api-key.ts
@@ -5,11 +5,12 @@
  * Checks X-API-Key header against registered agent secrets.
  */
 
+import type { GroveDatabase } from "@autumnsgrove/infra";
 import type { WardenAgent } from "../types";
 
 /** Look up an agent by API key (the raw key, compared against stored hash) */
 export async function authenticateByApiKey(
-	db: D1Database,
+	db: GroveDatabase,
 	apiKey: string,
 ): Promise<WardenAgent | null> {
 	// Hash the provided key to compare against stored hash

--- a/workers/warden/src/auth/dual-auth.ts
+++ b/workers/warden/src/auth/dual-auth.ts
@@ -9,14 +9,14 @@
  */
 
 import { createMiddleware } from "hono/factory";
-import type { Env, WardenAgent } from "../types";
+import type { Env, AppVariables, WardenAgent } from "../types";
 import { authenticateByApiKey } from "./api-key";
 import { validateNonce } from "./nonce";
 import { verifySignature } from "./signature";
 import { logAuditEvent } from "../lib/logging";
 
 /** Extended Hono variables set by auth middleware */
-export type AuthVariables = {
+export type AuthVariables = AppVariables & {
 	agent: WardenAgent;
 	authMethod: "service_binding" | "challenge_response";
 };
@@ -26,7 +26,8 @@ export const dualAuth = createMiddleware<{
 	Bindings: Env;
 	Variables: AuthVariables;
 }>(async (c, next) => {
-	const db = c.env.DB;
+	const ctx = c.get("ctx");
+	const db = ctx.db;
 
 	// Path 1: API key header (service binding or direct callers)
 	const apiKey = c.req.header("X-API-Key");

--- a/workers/warden/src/routes/nonce.ts
+++ b/workers/warden/src/routes/nonce.ts
@@ -6,10 +6,10 @@
  */
 
 import { Hono } from "hono";
-import type { Env } from "../types";
+import type { Env, AppVariables } from "../types";
 import { generateNonce } from "../auth/nonce";
 
-export const nonceRoute = new Hono<{ Bindings: Env }>();
+export const nonceRoute = new Hono<{ Bindings: Env; Variables: AppVariables }>();
 
 nonceRoute.post("/", async (c) => {
 	let body: { agentId?: string };
@@ -30,7 +30,9 @@ nonceRoute.post("/", async (c) => {
 	}
 
 	// Verify agent exists and is enabled
-	const agent = await c.env.DB.prepare("SELECT id FROM warden_agents WHERE id = ? AND enabled = 1")
+	const ctx = c.get("ctx");
+	const agent = await ctx.db
+		.prepare("SELECT id FROM warden_agents WHERE id = ? AND enabled = 1")
 		.bind(body.agentId)
 		.first();
 

--- a/workers/warden/src/routes/resolve.ts
+++ b/workers/warden/src/routes/resolve.ts
@@ -35,6 +35,7 @@ resolveRoute.use("*", dualAuth);
 resolveRoute.post("/", async (c) => {
 	const agent = c.get("agent");
 	const authMethod = c.get("authMethod");
+	const ctx = c.get("ctx");
 	const startTime = Date.now();
 
 	// Reject challenge-response auth — only service-binding callers can resolve
@@ -85,7 +86,7 @@ resolveRoute.post("/", async (c) => {
 
 	if (!hasServiceScope) {
 		c.executionCtx.waitUntil(
-			logAuditEvent(c.env.DB, {
+			logAuditEvent(ctx.db, {
 				agent_id: agent.id,
 				agent_name: agent.name,
 				target_service: service,
@@ -130,7 +131,7 @@ resolveRoute.post("/", async (c) => {
 	// Audit log + usage update (fire and forget)
 	c.executionCtx.waitUntil(
 		Promise.all([
-			logAuditEvent(c.env.DB, {
+			logAuditEvent(ctx.db, {
 				agent_id: agent.id,
 				agent_name: agent.name,
 				target_service: service,
@@ -142,7 +143,7 @@ resolveRoute.post("/", async (c) => {
 				latency_ms: totalLatency,
 				error_code: null,
 			}),
-			updateAgentUsage(c.env.DB, agent.id),
+			updateAgentUsage(ctx.db, agent.id),
 		]),
 	);
 

--- a/workers/warden/src/types.ts
+++ b/workers/warden/src/types.ts
@@ -4,6 +4,13 @@
  * All Cloudflare bindings and secrets used by the Warden gateway.
  */
 
+import type { GroveContext } from "@autumnsgrove/infra";
+
+/** Hono Variables set by groveInfraMiddleware — available on all routes */
+export type AppVariables = {
+	ctx: GroveContext;
+};
+
 export interface Env {
 	// --- D1 Databases ---
 	/** Warden's own database: agent registry + audit log */


### PR DESCRIPTION
## Summary

- Wire `groveInfraMiddleware` into Warden's Hono app, injecting `GroveContext` with the primary `DB` binding
- Replace 11 raw D1 call sites across routes, auth, and logging with `GroveDatabase` (`ctx.db.execute()` and `ctx.db.prepare().bind().first()`)
- Add typed `AppVariables` to all Hono routers so `c.get("ctx")` is fully type-safe without casts

**What stays raw (by design):**
- `TENANT_DB` — secondary D1 for SecretsManager credential resolution
- `NONCES` / `RATE_LIMITS` — dual KV namespaces (SDK supports single KV; deferred until multi-namespace support)
- All secret env vars (`WARDEN_SIGNING_KEY`, service API keys, etc.)

Part of Infra SDK Phase 2 (simple workers). Third of three: meadow-poller → email-catchup → **warden**.

## Test plan

- [x] `pnpm tsc --noEmit` — zero errors
- [x] `gw ci --affected --fail-fast --diagnose` — lint, check, test, build all pass
- [ ] Deploy to staging and verify `/health`, `/nonce`, `/request`, `/resolve`, `/admin/agents` endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)