### PR TITLE
feat(infra): migrate email-catchup to Infra SDK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1189,6 +1189,9 @@ importers:
 
   workers/email-catchup:
     dependencies:
+      '@autumnsgrove/infra':
+        specifier: workspace:*
+        version: link:../../libs/infra
       resend:
         specifier: ^4.8.0
         version: 4.8.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1196,6 +1199,12 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260210.0
         version: 4.20260210.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(@vitest/ui@4.0.18)(happy-dom@20.6.1)(jiti@2.4.2)(jsdom@27.4.0(@noble/hashes@2.0.1)(canvas@3.2.1))(tsx@4.21.0)
       wrangler:
         specifier: ^4.64.0
         version: 4.64.0(@cloudflare/workers-types@4.20260210.0)

--- a/workers/email-catchup/package.json
+++ b/workers/email-catchup/package.json
@@ -1,18 +1,25 @@
 {
-  "name": "grove-email-catchup",
-  "version": "1.0.0",
-  "private": true,
-  "description": "Weekly catch-up cron for Grove email infrastructure",
-  "scripts": {
-    "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
-    "tail": "wrangler tail"
-  },
-  "dependencies": {
-    "resend": "^4.8.0"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260210.0",
-    "wrangler": "^4.64.0"
-  }
+	"name": "grove-email-catchup",
+	"version": "1.0.0",
+	"private": true,
+	"description": "Weekly catch-up cron for Grove email infrastructure",
+	"scripts": {
+		"dev": "wrangler dev",
+		"deploy": "wrangler deploy",
+		"tail": "wrangler tail",
+		"test": "vitest run",
+		"test:run": "vitest run",
+		"test:watch": "vitest",
+		"check": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@autumnsgrove/infra": "workspace:*",
+		"resend": "^4.8.0"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20260210.0",
+		"typescript": "^5.7.0",
+		"vitest": "^4.0.18",
+		"wrangler": "^4.64.0"
+	}
 }

--- a/workers/email-catchup/tests/catchup.test.ts
+++ b/workers/email-catchup/tests/catchup.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Email Catch-up Worker — Tests
+ *
+ * Tests the core D1 operations: overdue user discovery, stage updates,
+ * sequence completion marking, and error handling.
+ *
+ * Uses the Infra SDK mock context for D1 access. Resend and email-render
+ * are mocked at the module boundary since they stay as raw access.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockContext, type MockDatabase } from "@autumnsgrove/infra/testing";
+
+// ---------------------------------------------------------------------------
+// Mock Resend — prevent real API calls
+// ---------------------------------------------------------------------------
+
+vi.mock("resend", () => ({
+	Resend: vi.fn().mockImplementation(function (this: any) {
+		this.emails = {
+			send: vi.fn().mockResolvedValue({ data: { id: "mock-email-id" }, error: null }),
+		};
+	}),
+}));
+
+// Mock fetch for email-render worker calls
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ---------------------------------------------------------------------------
+// Helper: build test env with mock D1 via Infra SDK
+// ---------------------------------------------------------------------------
+
+function createTestEnv() {
+	const ctx = createMockContext();
+
+	// Build raw D1 mock that createContext() will wrap
+	const mockD1 = buildMockD1(ctx.db);
+
+	const env = {
+		DB: mockD1,
+		RESEND_API_KEY: "re_test_key",
+		EMAIL_RENDER_URL: "https://email-render.test",
+		EMAIL_RENDER: undefined as Fetcher | undefined,
+	};
+
+	return { env, ctx, mockD1 };
+}
+
+/**
+ * Build a raw D1-shaped mock that delegates to the SDK's MockDatabase.
+ * This lets us use `ctx.db.whenQuery()` to pre-configure responses while
+ * the worker's `createContext()` wraps the raw D1 binding.
+ */
+function buildMockD1(db: MockDatabase) {
+	return {
+		prepare: vi.fn((sql: string) => ({
+			all: vi.fn(async () => {
+				const result = await db.execute(sql);
+				return { results: result.results, meta: result.meta };
+			}),
+			bind: vi.fn((...params: unknown[]) => ({
+				all: vi.fn(async () => {
+					const result = await db.execute(sql, params);
+					return { results: result.results, meta: result.meta };
+				}),
+				first: vi.fn(async () => {
+					const result = await db.execute(sql, params);
+					return result.results[0] ?? null;
+				}),
+				run: vi.fn(async () => {
+					const result = await db.execute(sql, params);
+					return result.meta;
+				}),
+			})),
+			run: vi.fn(async () => {
+				const result = await db.execute(sql);
+				return result.meta;
+			}),
+		})),
+		batch: vi.fn(async () => []),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let worker: any;
+
+describe("email-catchup", () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		mockFetch.mockReset();
+		worker = await import("../worker.js");
+	});
+
+	describe("overdue user discovery", () => {
+		it("returns empty result when no overdue users exist", async () => {
+			const { env, ctx } = createTestEnv();
+			// No whenQuery → execute returns empty results by default
+
+			const result = await worker.default.scheduled({} as ScheduledEvent, env, {
+				waitUntil: vi.fn(),
+			} as unknown as ExecutionContext);
+
+			expect(result.overdueFound).toBe(0);
+			expect(result.emailsSent).toBe(0);
+			expect(result.errors).toHaveLength(0);
+		});
+
+		it("discovers overdue users and attempts email send", async () => {
+			const { env, ctx } = createTestEnv();
+
+			// Pre-seed overdue user
+			ctx.db.whenQuery("SELECT * FROM email_signups", [
+				{
+					id: 1,
+					email: "test@example.com",
+					name: "Test User",
+					created_at: "2026-01-01T00:00:00Z",
+					audience_type: "wanderer",
+					sequence_stage: 0,
+					last_email_at: "2026-01-01T00:00:00Z",
+				},
+			]);
+
+			// Mock email-render response
+			mockFetch.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						html: "<p>Welcome!</p>",
+						text: "Welcome!",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			);
+
+			const result = await worker.default.scheduled({} as ScheduledEvent, env, {
+				waitUntil: vi.fn(),
+			} as unknown as ExecutionContext);
+
+			expect(result.overdueFound).toBe(1);
+			// DB was queried for overdue users
+			expect(ctx.db.calls.length).toBeGreaterThanOrEqual(1);
+			expect(ctx.db.calls[0].sql).toContain("email_signups");
+		});
+	});
+
+	describe("sequence completion", () => {
+		it("marks completed sequences via UPDATE queries", async () => {
+			const { env, ctx } = createTestEnv();
+			// No overdue users (empty default), but markCompletedSequences still runs
+
+			const result = await worker.default.scheduled({} as ScheduledEvent, env, {
+				waitUntil: vi.fn(),
+			} as unknown as ExecutionContext);
+
+			// Should have executed the 3 completion UPDATE queries
+			const updateCalls = ctx.db.calls.filter((c) => c.sql.includes("UPDATE email_signups"));
+			expect(updateCalls.length).toBe(3);
+
+			// Each targets a different audience_type
+			expect(updateCalls[0].sql).toContain("wanderer");
+			expect(updateCalls[1].sql).toContain("promo");
+			expect(updateCalls[2].sql).toContain("rooted");
+
+			// Changes default to 0, so completed = 0
+			expect(result.sequencesCompleted).toBe(0);
+		});
+	});
+
+	describe("error handling", () => {
+		it("continues processing when email send fails for one user", async () => {
+			const { env, ctx } = createTestEnv();
+
+			// Pre-seed two overdue users
+			ctx.db.whenQuery("SELECT * FROM email_signups", [
+				{
+					id: 1,
+					email: "fail@example.com",
+					name: "Failing User",
+					created_at: "2026-01-01T00:00:00Z",
+					audience_type: "wanderer",
+					sequence_stage: 0,
+					last_email_at: "2026-01-01T00:00:00Z",
+				},
+				{
+					id: 2,
+					email: "ok@example.com",
+					name: "OK User",
+					created_at: "2026-01-01T00:00:00Z",
+					audience_type: "wanderer",
+					sequence_stage: 0,
+					last_email_at: "2026-01-01T00:00:00Z",
+				},
+			]);
+
+			// First render call fails, second succeeds
+			mockFetch
+				.mockResolvedValueOnce(new Response("Internal Server Error", { status: 500 }))
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ html: "<p>Hi</p>", text: "Hi" }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					}),
+				);
+
+			const result = await worker.default.scheduled({} as ScheduledEvent, env, {
+				waitUntil: vi.fn(),
+			} as unknown as ExecutionContext);
+
+			expect(result.overdueFound).toBe(2);
+			// First user's email render failed (returned null), so it was skipped — not an error
+			// Second user should have succeeded
+			expect(result.errors).toHaveLength(0);
+		});
+	});
+
+	describe("config validation", () => {
+		it("returns error when RESEND_API_KEY is missing", async () => {
+			const { env } = createTestEnv();
+			env.RESEND_API_KEY = "";
+
+			const result = await worker.default.scheduled({} as ScheduledEvent, env, {
+				waitUntil: vi.fn(),
+			} as unknown as ExecutionContext);
+
+			expect(result).toEqual({ error: "RESEND_API_KEY not configured" });
+		});
+
+		it("returns error when EMAIL_RENDER_URL is missing", async () => {
+			const { env } = createTestEnv();
+			env.EMAIL_RENDER_URL = "";
+
+			const result = await worker.default.scheduled({} as ScheduledEvent, env, {
+				waitUntil: vi.fn(),
+			} as unknown as ExecutionContext);
+
+			expect(result).toEqual({ error: "EMAIL_RENDER_URL not configured" });
+		});
+	});
+});

--- a/workers/email-catchup/tsconfig.json
+++ b/workers/email-catchup/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022"],
+		"types": ["@cloudflare/workers-types"],
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true
+	},
+	"include": ["*.ts", "tests/**/*.ts"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Add `createContext()` factory wrapping raw D1 into `GroveContext` with observer logging
- Replace 6 raw D1 call sites with `ctx.db.execute()` across `processOverdueEmails` and `markCompletedSequences`
- Add new test suite (6 tests) covering overdue discovery, sequence completion, and error handling
- Add `tsconfig.json`, vitest, and test scripts (worker had no test infrastructure before)

Part of Infra SDK Phase 2 (simple workers). Second of three: meadow-poller → **email-catchup** → warden.

## Test plan

- [x] All 6 new tests pass
- [x] `pnpm tsc --noEmit` — zero errors
- [x] `gw ci --affected --fail-fast --diagnose` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)