### PR TITLE
feat(infra): migrate timeline-sync and lumen to Infra SDK (Phase 3)

### DIFF
--- a/.github/scripts/affected-packages.mjs
+++ b/.github/scripts/affected-packages.mjs
@@ -157,6 +157,11 @@ const PACKAGES = {
 		hasTests: true,
 		isSvelteKit: false,
 	},
+	"workers/lumen": {
+		typecheck: "pnpm exec tsc --noEmit",
+		hasTests: true,
+		isSvelteKit: false,
+	},
 	"workers/timeline-sync": {
 		typecheck: "pnpm exec tsc --noEmit",
 		hasTests: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1233,6 +1233,9 @@ importers:
 
   workers/lumen:
     dependencies:
+      '@autumnsgrove/infra':
+        specifier: workspace:*
+        version: link:../../libs/infra
       '@autumnsgrove/lattice':
         specifier: workspace:*
         version: link:../../libs/engine
@@ -1323,6 +1326,9 @@ importers:
 
   workers/timeline-sync:
     dependencies:
+      '@autumnsgrove/infra':
+        specifier: workspace:*
+        version: link:../../libs/infra
       '@autumnsgrove/lattice':
         specifier: workspace:*
         version: link:../../libs/engine

--- a/workers/lumen/package.json
+++ b/workers/lumen/package.json
@@ -12,6 +12,7 @@
 		"test:run": "vitest run"
 	},
 	"dependencies": {
+		"@autumnsgrove/infra": "workspace:*",
 		"@autumnsgrove/lattice": "workspace:*",
 		"hono": "^4.7.0",
 		"zod": "^3.24.0"

--- a/workers/lumen/src/auth/middleware.ts
+++ b/workers/lumen/src/auth/middleware.ts
@@ -10,7 +10,7 @@
  */
 
 import { createMiddleware } from "hono/factory";
-import type { Env, LumenWorkerResponse } from "../types";
+import type { Env, LumenWorkerResponse, AppVariables } from "../types";
 
 /**
  * Constant-time string comparison to prevent timing attacks.
@@ -34,7 +34,7 @@ async function timingSafeEqual(a: string, b: string): Promise<boolean> {
 	return equal && bufA.length === bufB.length;
 }
 
-export type AuthVariables = {
+export type AuthVariables = AppVariables & {
 	/** Whether the caller authenticated successfully */
 	authenticated: boolean;
 };

--- a/workers/lumen/src/types.ts
+++ b/workers/lumen/src/types.ts
@@ -5,7 +5,17 @@
  * No `as` casts at boundaries — always validate through schemas.
  */
 
+import type { GroveContext } from "@autumnsgrove/infra";
 import { z } from "zod";
+
+// =============================================================================
+// Hono Variables
+// =============================================================================
+
+/** Variables set by groveInfraMiddleware — available on all routes */
+export type AppVariables = {
+	ctx: GroveContext;
+};
 
 // =============================================================================
 // Environment

--- a/workers/timeline-sync/package.json
+++ b/workers/timeline-sync/package.json
@@ -1,22 +1,23 @@
 {
-  "name": "grove-timeline-sync",
-  "version": "1.0.0",
-  "private": true,
-  "description": "Automated nightly timeline summary generation for all enabled tenants",
-  "scripts": {
-    "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
-    "tail": "wrangler tail",
-    "test": "vitest run",
-    "test:watch": "vitest"
-  },
-  "dependencies": {
-    "@autumnsgrove/lattice": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20251128.0",
-    "typescript": "^5.7.0",
-    "vitest": "^2.1.0",
-    "wrangler": "^4.63.0"
-  }
+	"name": "grove-timeline-sync",
+	"version": "1.0.0",
+	"private": true,
+	"description": "Automated nightly timeline summary generation for all enabled tenants",
+	"scripts": {
+		"dev": "wrangler dev",
+		"deploy": "wrangler deploy",
+		"tail": "wrangler tail",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@autumnsgrove/infra": "workspace:*",
+		"@autumnsgrove/lattice": "workspace:*"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20251128.0",
+		"typescript": "^5.7.0",
+		"vitest": "^2.1.0",
+		"wrangler": "^4.63.0"
+	}
 }

--- a/workers/timeline-sync/src/github.ts
+++ b/workers/timeline-sync/src/github.ts
@@ -5,12 +5,8 @@
  * Handles repo discovery, commit fetching, and stats enrichment.
  */
 
-import type {
-  Commit,
-  GitHubRepo,
-  GitHubCommitDetail,
-  TenantConfig,
-} from "./config";
+import type { GroveDatabase } from "@autumnsgrove/infra";
+import type { Commit, GitHubRepo, GitHubCommitDetail, TenantConfig } from "./config";
 import { USER_AGENT } from "./config";
 
 // =============================================================================
@@ -26,89 +22,84 @@ import { USER_AGENT } from "./config";
  * 2. Slow path: Discover repos via /users/{username}/repos, then query each.
  */
 export async function fetchGitHubCommits(
-  config: TenantConfig,
-  githubToken: string,
-  targetDate: string,
-  db: D1Database,
+	config: TenantConfig,
+	githubToken: string,
+	targetDate: string,
+	db: GroveDatabase,
 ): Promise<Commit[]> {
-  let repoFullNames: string[] = [];
+	let repoFullNames: string[] = [];
 
-  // Fast path: check if backfill already recorded which repos had activity
-  try {
-    const activity = await db
-      .prepare(
-        `SELECT repos_active FROM timeline_activity
+	// Fast path: check if backfill already recorded which repos had activity
+	try {
+		const activity = await db
+			.prepare(
+				`SELECT repos_active FROM timeline_activity
          WHERE tenant_id = ? AND activity_date = ?`,
-      )
-      .bind(config.tenantId, targetDate)
-      .first<{ repos_active: string }>();
+			)
+			.bind(config.tenantId, targetDate)
+			.first<{ repos_active: string }>();
 
-    if (activity?.repos_active) {
-      const repoNames = JSON.parse(activity.repos_active) as string[];
-      // Validate repos belong to this tenant's GitHub username
-      // (prevents cross-tenant data leakage from corrupted backfill data)
-      const validRepoNames = repoNames.filter((name) => {
-        // Short names shouldn't contain slashes (that would indicate wrong format)
-        if (name.includes("/")) {
-          console.warn(
-            `[${config.tenantId}] Invalid repo format in backfill: ${name}`,
-          );
-          return false;
-        }
-        return true;
-      });
-      // repos_active stores short names; we need full_name (owner/repo)
-      repoFullNames = validRepoNames.map(
-        (name) => `${config.githubUsername}/${name}`,
-      );
-      console.log(
-        `[${config.tenantId}] Fast path: using ${repoFullNames.length} repos from backfill data`,
-      );
-    }
-  } catch {
-    // Non-fatal: fall through to slow path
-  }
+		if (activity?.repos_active) {
+			const repoNames = JSON.parse(activity.repos_active) as string[];
+			// Validate repos belong to this tenant's GitHub username
+			// (prevents cross-tenant data leakage from corrupted backfill data)
+			const validRepoNames = repoNames.filter((name) => {
+				// Short names shouldn't contain slashes (that would indicate wrong format)
+				if (name.includes("/")) {
+					console.warn(`[${config.tenantId}] Invalid repo format in backfill: ${name}`);
+					return false;
+				}
+				return true;
+			});
+			// repos_active stores short names; we need full_name (owner/repo)
+			repoFullNames = validRepoNames.map((name) => `${config.githubUsername}/${name}`);
+			console.log(
+				`[${config.tenantId}] Fast path: using ${repoFullNames.length} repos from backfill data`,
+			);
+		}
+	} catch {
+		// Non-fatal: fall through to slow path
+	}
 
-  // Slow path: discover repos from GitHub API
-  if (repoFullNames.length === 0) {
-    const repos = await fetchUserRepos(
-      config.githubUsername,
-      githubToken,
-      config.reposInclude,
-      config.reposExclude,
-    );
-    repoFullNames = repos.map((r) => r.full_name);
-    console.log(
-      `[${config.tenantId}] Slow path: discovered ${repoFullNames.length} repos from GitHub API`,
-    );
-  }
+	// Slow path: discover repos from GitHub API
+	if (repoFullNames.length === 0) {
+		const repos = await fetchUserRepos(
+			config.githubUsername,
+			githubToken,
+			config.reposInclude,
+			config.reposExclude,
+		);
+		repoFullNames = repos.map((r) => r.full_name);
+		console.log(
+			`[${config.tenantId}] Slow path: discovered ${repoFullNames.length} repos from GitHub API`,
+		);
+	}
 
-  // Fetch commits from each repo for the target date
-  const allCommits: Commit[] = [];
+	// Fetch commits from each repo for the target date
+	const allCommits: Commit[] = [];
 
-  for (const repoFullName of repoFullNames) {
-    const repoName = repoFullName.split("/")[1];
+	for (const repoFullName of repoFullNames) {
+		const repoName = repoFullName.split("/")[1];
 
-    // Apply include/exclude filters (fast path repos may not be filtered yet)
-    if (config.reposInclude && !config.reposInclude.includes(repoName))
-      continue;
-    if (config.reposExclude && config.reposExclude.includes(repoName)) continue;
+		// Apply include/exclude filters (fast path repos may not be filtered yet)
+		if (config.reposInclude && !config.reposInclude.includes(repoName)) continue;
+		if (config.reposExclude && config.reposExclude.includes(repoName)) continue;
 
-    const repoCommits = await fetchRepoCommitsForDate(
-      repoFullName,
-      config.githubUsername,
-      githubToken,
-      targetDate,
-    );
-    allCommits.push(...repoCommits);
+		const repoCommits = await fetchRepoCommitsForDate(
+			repoFullName,
+			config.githubUsername,
+			githubToken,
+			targetDate,
+		);
+		allCommits.push(...repoCommits);
 
-    // Rate limit between repos (200ms)
-    if (repoFullNames.length > 1) {
-      await sleep(200);
-    }
-  }
+		// Rate limit between repos (200ms)
+		if (repoFullNames.length > 1) {
+			await sleep(200);
+		}
+	}
 
-  return allCommits;
+	return allCommits;
 }
 
 /**
@@ -119,46 +110,46 @@ export async function fetchGitHubCommits(
  * speed vs rate limiting. Much faster than sequential for many commits.
  */
 export async function fetchCommitStats(
-  commits: Commit[],
-  username: string,
-  token: string,
+	commits: Commit[],
+	username: string,
+	token: string,
 ): Promise<void> {
-  const CONCURRENCY_LIMIT = 5;
+	const CONCURRENCY_LIMIT = 5;
 
-  // Process commits in batches with concurrency limit
-  for (let i = 0; i < commits.length; i += CONCURRENCY_LIMIT) {
-    const batch = commits.slice(i, i + CONCURRENCY_LIMIT);
+	// Process commits in batches with concurrency limit
+	for (let i = 0; i < commits.length; i += CONCURRENCY_LIMIT) {
+		const batch = commits.slice(i, i + CONCURRENCY_LIMIT);
 
-    await Promise.all(
-      batch.map(async (commit) => {
-        try {
-          const response = await fetch(
-            `https://api.github.com/repos/${username}/${commit.repo}/commits/${commit.sha}`,
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-                Accept: "application/vnd.github.v3+json",
-                "User-Agent": USER_AGENT,
-              },
-            },
-          );
+		await Promise.all(
+			batch.map(async (commit) => {
+				try {
+					const response = await fetch(
+						`https://api.github.com/repos/${username}/${commit.repo}/commits/${commit.sha}`,
+						{
+							headers: {
+								Authorization: `Bearer ${token}`,
+								Accept: "application/vnd.github.v3+json",
+								"User-Agent": USER_AGENT,
+							},
+						},
+					);
 
-          if (response.ok) {
-            const detail = (await response.json()) as GitHubCommitDetail;
-            commit.additions = detail.stats?.additions ?? 0;
-            commit.deletions = detail.stats?.deletions ?? 0;
-          }
-        } catch {
-          // Non-fatal: keep 0 for this commit
-        }
-      }),
-    );
+					if (response.ok) {
+						const detail = (await response.json()) as GitHubCommitDetail;
+						commit.additions = detail.stats?.additions ?? 0;
+						commit.deletions = detail.stats?.deletions ?? 0;
+					}
+				} catch {
+					// Non-fatal: keep 0 for this commit
+				}
+			}),
+		);
 
-    // Rate limit between batches (100ms)
-    if (i + CONCURRENCY_LIMIT < commits.length) {
-      await sleep(100);
-    }
-  }
+		// Rate limit between batches (100ms)
+		if (i + CONCURRENCY_LIMIT < commits.length) {
+			await sleep(100);
+		}
+	}
 }
 
 // =============================================================================
@@ -169,40 +160,40 @@ export async function fetchCommitStats(
  * Fetch user's repositories, filtered by include/exclude lists.
  */
 async function fetchUserRepos(
-  username: string,
-  token: string,
-  includeRepos: string[] | null,
-  excludeRepos: string[] | null,
+	username: string,
+	token: string,
+	includeRepos: string[] | null,
+	excludeRepos: string[] | null,
 ): Promise<GitHubRepo[]> {
-  const response = await fetch(
-    `https://api.github.com/users/${username}/repos?per_page=100&sort=pushed&type=owner`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github.v3+json",
-        "User-Agent": USER_AGENT,
-      },
-    },
-  );
+	const response = await fetch(
+		`https://api.github.com/users/${username}/repos?per_page=100&sort=pushed&type=owner`,
+		{
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github.v3+json",
+				"User-Agent": USER_AGENT,
+			},
+		},
+	);
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch repos: ${response.status}`);
-  }
+	if (!response.ok) {
+		throw new Error(`Failed to fetch repos: ${response.status}`);
+	}
 
-  let repos = (await response.json()) as GitHubRepo[];
+	let repos = (await response.json()) as GitHubRepo[];
 
-  // Filter by include/exclude
-  if (includeRepos) {
-    repos = repos.filter((r) => includeRepos.includes(r.name));
-  }
-  if (excludeRepos) {
-    repos = repos.filter((r) => !excludeRepos.includes(r.name));
-  }
+	// Filter by include/exclude
+	if (includeRepos) {
+		repos = repos.filter((r) => includeRepos.includes(r.name));
+	}
+	if (excludeRepos) {
+		repos = repos.filter((r) => !excludeRepos.includes(r.name));
+	}
 
-  // Exclude forks by default
-  repos = repos.filter((r) => !r.fork);
+	// Exclude forks by default
+	repos = repos.filter((r) => !r.fork);
 
-  return repos;
+	return repos;
 }
 
 /**
@@ -210,77 +201,75 @@ async function fetchUserRepos(
  * Uses the Commits API which has no 90-day limit.
  */
 async function fetchRepoCommitsForDate(
-  repoFullName: string,
-  authorUsername: string,
-  token: string,
-  date: string,
+	repoFullName: string,
+	authorUsername: string,
+	token: string,
+	date: string,
 ): Promise<Commit[]> {
-  const commits: Commit[] = [];
-  let page = 1;
-  const perPage = 100;
+	const commits: Commit[] = [];
+	let page = 1;
+	const perPage = 100;
 
-  const sinceDate = `${date}T00:00:00Z`;
-  const untilDate = `${date}T23:59:59Z`;
+	const sinceDate = `${date}T00:00:00Z`;
+	const untilDate = `${date}T23:59:59Z`;
 
-  while (true) {
-    const url = new URL(`https://api.github.com/repos/${repoFullName}/commits`);
-    url.searchParams.set("author", authorUsername);
-    url.searchParams.set("since", sinceDate);
-    url.searchParams.set("until", untilDate);
-    url.searchParams.set("per_page", String(perPage));
-    url.searchParams.set("page", String(page));
+	while (true) {
+		const url = new URL(`https://api.github.com/repos/${repoFullName}/commits`);
+		url.searchParams.set("author", authorUsername);
+		url.searchParams.set("since", sinceDate);
+		url.searchParams.set("until", untilDate);
+		url.searchParams.set("per_page", String(perPage));
+		url.searchParams.set("page", String(page));
 
-    const response = await fetch(url.toString(), {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github.v3+json",
-        "User-Agent": USER_AGENT,
-      },
-    });
+		const response = await fetch(url.toString(), {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github.v3+json",
+				"User-Agent": USER_AGENT,
+			},
+		});
 
-    if (!response.ok) {
-      if (response.status === 409) {
-        // Empty repository
-        break;
-      }
-      console.warn(
-        `Failed to fetch commits for ${repoFullName}: ${response.status}`,
-      );
-      break;
-    }
+		if (!response.ok) {
+			if (response.status === 409) {
+				// Empty repository
+				break;
+			}
+			console.warn(`Failed to fetch commits for ${repoFullName}: ${response.status}`);
+			break;
+		}
 
-    const pageCommits = (await response.json()) as GitHubCommitDetail[];
+		const pageCommits = (await response.json()) as GitHubCommitDetail[];
 
-    if (pageCommits.length === 0) {
-      break;
-    }
+		if (pageCommits.length === 0) {
+			break;
+		}
 
-    const repoName = repoFullName.split("/")[1];
+		const repoName = repoFullName.split("/")[1];
 
-    for (const commit of pageCommits) {
-      commits.push({
-        sha: commit.sha,
-        message: commit.commit.message,
-        repo: repoName,
-        timestamp: commit.commit.author.date,
-        additions: 0,
-        deletions: 0,
-      });
-    }
+		for (const commit of pageCommits) {
+			commits.push({
+				sha: commit.sha,
+				message: commit.commit.message,
+				repo: repoName,
+				timestamp: commit.commit.author.date,
+				additions: 0,
+				deletions: 0,
+			});
+		}
 
-    if (pageCommits.length < perPage) {
-      break;
-    }
+		if (pageCommits.length < perPage) {
+			break;
+		}
 
-    page++;
+		page++;
 
-    // Rate limit between pages
-    await sleep(100);
-  }
+		// Rate limit between pages
+		await sleep(100);
+	}
 
-  return commits;
+	return commits;
 }
 
 function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Summary

Phase 3 of the Infra SDK migration — two medium-complexity workers:

- **timeline-sync**: `createCloudflareContext()` wraps `CURIO_DB` as primary `ctx.db`. ~8 call sites converted across `index.ts`, `generator.ts`, `github.ts`, `context.ts`. `env.DB` stays raw for SecretsManager (expects native `D1Database`).
- **lumen**: `groveInfraMiddleware` wires `GroveContext` onto all Hono routes. `AuthVariables` extends new `AppVariables` type. All functional bindings (`env.DB` → LumenClient, `env.AI`, `env.WARDEN`, `env.RATE_LIMITS`) stay raw — the migration is structural for consistency + observer telemetry.
- Registers `workers/lumen` in CI affected-packages matrix (`hasTests: true`, 8 test files).

## What stays raw (by design)

| Binding | Worker | Reason |
|---------|--------|--------|
| `env.DB` | timeline-sync | SecretsManager constructor expects `D1Database` |
| `env.DB` | lumen | Passed to `createLumenClient()` which owns D1 internally |
| `env.AI` | lumen | Workers AI — Cloudflare-specific |
| `env.WARDEN` | both | Service binding |
| `env.RATE_LIMITS` | lumen | Already wrapped by Threshold SDK |
| `env.LUMEN` | timeline-sync | Service binding |

## Test plan

- [x] `pnpm exec tsc --noEmit` passes for both workers
- [x] `pnpm vitest run` passes for lumen (75 tests) — no test changes needed
- [x] `pnpm vitest run` passes for infra SDK (232 tests)
- [x] `gw dev ci --affected --fail-fast --diagnose` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)