### PR TITLE
fix(gw): move auto-formatting from edit-time to commit-time

### DIFF
--- a/.claude/hooks/auto-format.py
+++ b/.claude/hooks/auto-format.py
@@ -1,14 +1,29 @@
 #!/usr/bin/env python3
 # CLAUDE_HOOK_EVENT: PostToolUse
+#
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  RETIRED — This hook is no longer registered in settings.json  ║
+# ║                                                                ║
+# ║  Formatting on every Edit/Write was too aggressive for agents: ║
+# ║  • Threw off diff reviews with unexpected changes              ║
+# ║  • Constantly flipped indentation and quote styles             ║
+# ║  • Made agents confused about what they actually changed       ║
+# ║                                                                ║
+# ║  Formatting now runs at COMMIT TIME via gw:                    ║
+# ║  • gw git commit  — formats staged files before committing    ║
+# ║  • gw git ship    — formats as step 2 (already did this)      ║
+# ║  • gw git save    — formats after staging, before committing  ║
+# ║                                                                ║
+# ║  All three support --no-format to skip when needed.            ║
+# ╚══════════════════════════════════════════════════════════════════╝
+#
 """Auto-format files after Claude edits them.
 
-Runs Prettier on formattable file types after Edit or Write tool use.
-This shifts formatting LEFT — catching issues immediately instead of
-at pre-commit hook time, eliminating entire agent turns spent on
-"fix formatting and recommit" loops.
+RETIRED: This hook ran Prettier on every Edit/Write tool use. It was too
+disruptive for agent workflows — formatting now happens at commit time
+through gw git commit/ship/save instead. See the banner above.
 
-Uses `bun x prettier` for speed (10-50x faster than npx).
-Never blocks — formatting failures are silent (pre-commit hook is the safety net).
+Kept for reference. To re-enable, add this to .claude/settings.json hooks.
 """
 import json
 import os

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -162,17 +162,6 @@
     "deny": ["Bash(gw secret reveal:*)", "Bash(gw secret reveal)"]
   },
   "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/auto-format.py"
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "hooks": [

--- a/tools/grove-wrap-go/cmd/git_write.go
+++ b/tools/grove-wrap-go/cmd/git_write.go
@@ -96,6 +96,7 @@ var gitAddCmd = &cobra.Command{
 var gitCommitMessage string
 var gitCommitIssue int
 var gitCommitNoVerify bool
+var gitCommitNoFormat bool
 
 var gitCommitCmd = &cobra.Command{
 	Use:   "commit",
@@ -134,6 +135,11 @@ var gitCommitCmd = &cobra.Command{
 			if !ok {
 				return fmt.Errorf("invalid commit message: %s", errMsg)
 			}
+		}
+
+		// Format staged files before committing
+		if !gitCommitNoFormat {
+			formatStagedFiles()
 		}
 
 		gitArgs := []string{"commit", "-m", gitCommitMessage}
@@ -892,6 +898,7 @@ func init() {
 	gitCommitCmd.Flags().StringVarP(&gitCommitMessage, "message", "m", "", "Commit message (required)")
 	gitCommitCmd.Flags().IntVar(&gitCommitIssue, "issue", 0, "Link to GitHub issue number")
 	gitCommitCmd.Flags().BoolVar(&gitCommitNoVerify, "no-verify", false, "Skip pre-commit hooks")
+	gitCommitCmd.Flags().BoolVar(&gitCommitNoFormat, "no-format", false, "Skip prettier formatting")
 	gitCmd.AddCommand(gitCommitCmd)
 
 	// git push


### PR DESCRIPTION
The PostToolUse auto-format hook ran prettier on every Edit/Write,
which was too aggressive for agent workflows — it threw off diff
reviews, flipped indentation/quotes mid-work, and confused agents
about what they actually changed.

Formatting now runs at commit time through gw instead:
- gw git commit: formats staged files before committing (new)
- gw git save: formats after staging, before committing (new)
- gw git ship: already had this as step 2

All three support --no-format to skip when needed. gw git fast
and gw git wip intentionally skip formatting (speed-first paths).

https://claude.ai/code/session_0143K2WTU48XKz9sEt14ppcQ