### PR TITLE
fix(engine): show visitor's own avatar instead of site owner's

### DIFF
--- a/libs/engine/src/routes/+layout.svelte
+++ b/libs/engine/src/routes/+layout.svelte
@@ -70,14 +70,17 @@
 	}
 
 	// Map server user data to HeaderUser shape (picture → avatarUrl)
-	// Prefer custom avatar from site_settings over OAuth provider picture
+	// Only use custom avatar from site_settings when the logged-in user is the site owner.
+	// Visitors get their own OAuth picture (or default) — not the owner's avatar.
 	const headerUser = $derived(
 		data.user
 			? {
 					id: data.user.id,
 					name: data.user.name,
 					email: data.user.email,
-					avatarUrl: data.siteSettings?.avatar_url || data.user.picture,
+					avatarUrl: data.isOwner
+						? (data.siteSettings?.avatar_url || data.user.picture)
+						: data.user.picture,
 				}
 			: null,
 	);


### PR DESCRIPTION
When a visitor logged into a Grove site (e.g., to sign the guestbook),
the header displayed the site owner's custom avatar_url from site_settings
instead of the visitor's own OAuth profile picture. Gate the custom avatar
behind the existing isOwner check so visitors see their own picture.

https://claude.ai/code/session_01SHMGfLSLmLnRZRtnTJ2Emj