### PR TITLE
fix(plant): fix Stripe webhook failures — signature rotation, config gating, sanitizer

### DIFF
--- a/apps/plant/src/lib/errors.ts
+++ b/apps/plant/src/lib/errors.ts
@@ -165,6 +165,35 @@ export const PLANT_ERRORS = {
   },
 
   // ─────────────────────────────────────────────────────────────────────────
+  // Webhook Errors (060-079)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  WEBHOOK_SIGNATURE_INVALID: {
+    code: "PLANT-060",
+    category: "bug" as const,
+    userMessage: "Payment notification could not be verified.",
+    adminMessage:
+      "Stripe webhook signature verification failed. Check STRIPE_WEBHOOK_SECRET matches Stripe Dashboard > Developers > Webhooks > Signing secret.",
+  },
+
+  WEBHOOK_PROCESSING_FAILED: {
+    code: "PLANT-061",
+    category: "bug" as const,
+    userMessage: "Payment notification processing failed.",
+    adminMessage:
+      "Webhook event handler threw an error. Check webhook_events table for error details.",
+  },
+
+  WEBHOOK_EMAIL_DEGRADED: {
+    code: "PLANT-062",
+    category: "bug" as const,
+    userMessage:
+      "Payment processed but confirmation email could not be sent.",
+    adminMessage:
+      "ZEPHYR_API_KEY is not configured. Webhook billing updates succeed but notification emails are skipped. Set ZEPHYR_API_KEY in Cloudflare Dashboard > Pages > grove-plant > Settings > Environment variables.",
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
   // Internal Errors (080-099)
   // ─────────────────────────────────────────────────────────────────────────
 

--- a/apps/plant/src/lib/server/stripe.ts
+++ b/apps/plant/src/lib/server/stripe.ts
@@ -223,7 +223,7 @@ export async function verifyWebhookSignature(
       const eqIdx = part.indexOf("=");
       if (eqIdx === -1) continue;
       const key = part.slice(0, eqIdx).trim();
-      const value = part.slice(eqIdx + 1);
+      const value = part.slice(eqIdx + 1).trim();
       if (key === "t") timestamp = value;
       if (key === "v1") v1Signatures.push(value);
     }

--- a/libs/engine/src/lib/utils/webhook-sanitizer.ts
+++ b/libs/engine/src/lib/utils/webhook-sanitizer.ts
@@ -310,6 +310,9 @@ const STRIPE_OBJECT_WHITELIST = new Set([
 	"interval",
 	"interval_count",
 
+	// Subscription line items (deep-sanitized below)
+	"items",
+
 	// Timestamps
 	"created",
 	"livemode",


### PR DESCRIPTION
Three bugs causing webhook delivery failures:

1. Signature verification only checked the LAST v1 signature in the header.
   During Stripe signing secret rotation, Stripe sends multiple v1 signatures
   (one per active secret). The reduce() approach overwrote earlier values,
   so if our stored secret matched the old key, verification always failed
   with 401. Now parses ALL v1 signatures and accepts any match.

2. ZEPHYR_API_KEY was required upfront for ALL webhook events, but only
   invoice.paid and invoice.payment_failed need email. If Zephyr was
   misconfigured, checkout completions and subscription updates also
   returned 500. Now only DB and webhook secret are required globally;
   email handlers gracefully skip when Zephyr isn't configured.

3. sanitizeWebhookPayload() expected Lemon Squeezy format ({meta, data})
   and returned null for every Stripe event ({id, type, data: {object}}).
   Added sanitizeStripeWebhookPayload() with a Stripe-aware whitelist
   that properly strips PII (email, address, card details) while keeping
   identifiers, status, financial data, and metadata.

https://claude.ai/code/session_013CQ7ZvaY94jyxYZzhQoMUF