### PR TITLE
fix(garden): prevent unsaved-changes popup after save and disable view link for drafts

### DIFF
--- a/libs/engine/src/routes/arbor/garden/+page.svelte
+++ b/libs/engine/src/routes/arbor/garden/+page.svelte
@@ -87,9 +87,13 @@
         {#each data.posts as post (post.slug)}
           <tr>
             <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 transition-[border-color] max-md:px-2 max-md:py-3">
-              <a href="/garden/{post.slug}" target="_blank" rel="noopener noreferrer" aria-label="{post.title} (opens in new tab)" class="font-medium text-green-700 dark:text-green-400 no-underline hover:underline transition-colors">
-                {post.title}
-              </a>
+              {#if post.status === 'published'}
+                <a href="/garden/{post.slug}" target="_blank" rel="noopener noreferrer" aria-label="{post.title} (opens in new tab)" class="font-medium text-green-700 dark:text-green-400 no-underline hover:underline transition-colors">
+                  {post.title}
+                </a>
+              {:else}
+                <span class="font-medium text-foreground">{post.title}</span>
+              {/if}
               {#if post.description}
                 <p class="mt-1 mb-0 text-xs text-foreground-muted">{post.description}</p>
               {/if}
@@ -120,7 +124,11 @@
               </div>
             </td>
             <td class="p-4 text-left border-b border-gray-200 dark:border-gray-700 whitespace-nowrap transition-[border-color] max-md:px-2 max-md:py-3">
-              <a href="/garden/{post.slug}" target="_blank" rel="noopener noreferrer" aria-label="View {post.title} (opens in new tab)" class="text-green-700 dark:text-green-400 no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">View</a>
+              {#if post.status === 'published'}
+                <a href="/garden/{post.slug}" target="_blank" rel="noopener noreferrer" aria-label="View {post.title} (opens in new tab)" class="text-green-700 dark:text-green-400 no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">View</a>
+              {:else}
+                <span class="text-foreground-subtle text-sm mr-4 cursor-default" title="Publish this bloom to view it">View</span>
+              {/if}
               <a href="/arbor/garden/edit/{post.slug}" class="text-green-700 dark:text-green-400 no-underline text-sm mr-4 hover:underline transition-colors max-md:mr-2">Edit</a>
               <button
                 onclick={() => confirmDelete({ slug: post.slug, title: post.title })}

--- a/libs/engine/src/routes/arbor/garden/new/+page.svelte
+++ b/libs/engine/src/routes/arbor/garden/new/+page.svelte
@@ -59,6 +59,7 @@
 	/** @type {string | null} */
 	let error = $state(null);
 	let slugManuallyEdited = $state(false);
+	let navigatingAfterSave = $state(false);
 	let showGutter = $state(
 		browser ? localStorage.getItem("new-post-gutter-visible") === "true" : false,
 	);
@@ -144,6 +145,7 @@
 			});
 
 			editorRef?.clearDraft();
+			navigatingAfterSave = true;
 
 			toast.success(`Draft saved!`, {
 				description: `"${result.title}" has been saved.`,
@@ -162,6 +164,8 @@
 	// Flush draft and warn about unsaved changes on page unload
 	/** @param {BeforeUnloadEvent} e */
 	function handleBeforeUnload(e) {
+		if (navigatingAfterSave) return;
+
 		// Always flush the draft to localStorage so content survives session expiry
 		editorRef?.flushDraft();
 
@@ -174,6 +178,8 @@
 	// Guard SvelteKit client-side navigations (beforeunload only covers tab close / hard nav)
 	beforeNavigate((navigation) => {
 		editorRef?.flushDraft();
+
+		if (navigatingAfterSave) return;
 
 		if (content.trim() || title.trim()) {
 			if (!confirm("You have unsaved changes. Leave this page?")) {
@@ -217,6 +223,7 @@
 			});
 
 			editorRef?.clearDraft();
+			navigatingAfterSave = true;
 
 			toast.success(`${resolveTermString("Bloom", "Post")} published!`, {
 				description: `"${result.title}" is now live.`,


### PR DESCRIPTION
Save Draft/Publish on the new bloom page triggered the beforeNavigate
guard even though content was just saved, causing a confusing browser
popup and subsequent "slug already in use" errors on re-save. Added a
navigatingAfterSave flag that bypasses both beforeNavigate and
beforeunload guards after a successful save.

Draft blooms in the garden table had clickable View links that led to
404s since unpublished content isn't publicly accessible. The title link
and View action are now rendered as plain text for drafts with a tooltip
explaining they need to be published first.

https://claude.ai/code/session_01TB5P3br1Tzj4itwQkxRgXk