### PR TITLE
fix(engine,grove-agent): audit follow-up hardening

### DIFF
--- a/libs/engine/src/lib/curios/shrines/index.test.ts
+++ b/libs/engine/src/lib/curios/shrines/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
 	generateShrineId,
+	isValidShrineId,
 	isValidShrineType,
 	isValidSize,
 	isValidFrameStyle,
@@ -60,9 +61,35 @@ describe("generateShrineId", () => {
 		expect(id).toMatch(/^shrine_/);
 	});
 
+	it("generates IDs using crypto hex suffix", () => {
+		const id = generateShrineId();
+		expect(id).toMatch(/^shrine_[a-z0-9]+_[a-f0-9]{12}$/);
+	});
+
 	it("generates unique IDs", () => {
 		const ids = new Set(Array.from({ length: 10 }, () => generateShrineId()));
 		expect(ids.size).toBe(10);
+	});
+
+	it("generates IDs that pass validation", () => {
+		const id = generateShrineId();
+		expect(isValidShrineId(id)).toBe(true);
+	});
+});
+
+describe("isValidShrineId", () => {
+	it("accepts valid shrine IDs", () => {
+		expect(isValidShrineId("shrine_abc123_0a1b2c3d4e5f")).toBe(true);
+	});
+
+	it("rejects non-shrine-prefixed strings", () => {
+		expect(isValidShrineId("curio_abc_def")).toBe(false);
+		expect(isValidShrineId("")).toBe(false);
+	});
+
+	it("rejects strings with invalid characters", () => {
+		expect(isValidShrineId("shrine_<script>_abcdef")).toBe(false);
+		expect(isValidShrineId("shrine_abc_ABCDEF")).toBe(false);
 	});
 });
 
@@ -179,6 +206,21 @@ describe("parseContents", () => {
 
 	it("returns empty array for empty string", () => {
 		expect(parseContents("")).toEqual([]);
+	});
+
+	it("strips prototype-polluting keys from content data", () => {
+		const json = JSON.stringify([
+			{
+				type: "text",
+				x: 10,
+				y: 20,
+				data: { text: "safe", __proto__: "malicious", constructor: "evil" },
+			},
+		]);
+		const result = parseContents(json);
+		expect(result[0].data).toEqual({ text: "safe" });
+		expect(result[0].data).not.toHaveProperty("__proto__");
+		expect(result[0].data).not.toHaveProperty("constructor");
 	});
 });
 

--- a/libs/engine/src/lib/curios/shrines/index.ts
+++ b/libs/engine/src/lib/curios/shrines/index.ts
@@ -145,7 +145,16 @@ export const MAX_SHRINES_PER_TENANT = 50;
 import { stripHtml } from "../sanitize";
 
 export function generateShrineId(): string {
-	return `shrine_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+	const bytes = new Uint8Array(6);
+	crypto.getRandomValues(bytes);
+	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+	return `shrine_${Date.now().toString(36)}_${hex}`;
+}
+
+const SHRINE_ID_PATTERN = /^shrine_[a-z0-9]+_[a-f0-9]+$/;
+
+export function isValidShrineId(id: string): boolean {
+	return typeof id === "string" && SHRINE_ID_PATTERN.test(id);
 }
 
 export function isValidShrineType(type: string): type is ShrineType {
@@ -197,9 +206,12 @@ export function parseContents(json: string): ShrineContentItem[] {
 }
 
 /** Sanitize user-provided text fields in content item data to prevent XSS */
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 function sanitizeContentData(data: Record<string, unknown>): Record<string, unknown> {
 	const clean: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(data)) {
+		if (DANGEROUS_KEYS.has(key)) continue;
 		if (typeof value === "string") {
 			clean[key] = stripHtml(value);
 		} else {

--- a/libs/engine/src/routes/arbor/curios/shrines/+page.server.ts
+++ b/libs/engine/src/routes/arbor/curios/shrines/+page.server.ts
@@ -3,6 +3,7 @@ import { fail } from "@sveltejs/kit";
 import { ARBOR_ERRORS, logGroveError } from "$lib/errors";
 import {
 	generateShrineId,
+	isValidShrineId,
 	isValidShrineType,
 	isValidSize,
 	isValidFrameStyle,
@@ -201,6 +202,14 @@ export const actions: Actions = {
 
 		const formData = await request.formData();
 		const shrineId = formData.get("shrineId") as string;
+
+		if (!isValidShrineId(shrineId)) {
+			return fail(400, {
+				error: ARBOR_ERRORS.INVALID_INPUT.userMessage,
+				error_code: ARBOR_ERRORS.INVALID_INPUT.code,
+			});
+		}
+
 		const isPublished = formData.get("isPublished") === "true" ? 0 : 1;
 
 		try {
@@ -236,6 +245,13 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const shrineId = formData.get("shrineId") as string;
 
+		if (!isValidShrineId(shrineId)) {
+			return fail(400, {
+				error: ARBOR_ERRORS.INVALID_INPUT.userMessage,
+				error_code: ARBOR_ERRORS.INVALID_INPUT.code,
+			});
+		}
+
 		try {
 			await db
 				.prepare(`DELETE FROM shrines WHERE id = ? AND tenant_id = ?`)
@@ -267,7 +283,7 @@ export const actions: Actions = {
 		const shrineId = formData.get("shrineId") as string;
 		const contentsRaw = formData.get("contents") as string;
 
-		if (!shrineId || !contentsRaw) {
+		if (!isValidShrineId(shrineId) || !contentsRaw) {
 			return fail(400, {
 				error: ARBOR_ERRORS.FIELD_REQUIRED.userMessage,
 				error_code: ARBOR_ERRORS.FIELD_REQUIRED.code,
@@ -319,7 +335,7 @@ export const actions: Actions = {
 		const shrineId = formData.get("shrineId") as string;
 		const shrineType = formData.get("shrineType") as string;
 
-		if (!shrineId || !isValidShrineType(shrineType)) {
+		if (!isValidShrineId(shrineId) || !isValidShrineType(shrineType)) {
 			return fail(400, {
 				error: ARBOR_ERRORS.INVALID_INPUT.userMessage,
 				error_code: ARBOR_ERRORS.INVALID_INPUT.code,

--- a/libs/grove-agent/src/init.test.ts
+++ b/libs/grove-agent/src/init.test.ts
@@ -7,28 +7,18 @@ describe("groveInit", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("logs agent initialization with config details", () => {
+	it("does not log during construction (workerd lazy .name constraint)", () => {
 		const logger = new AgentLogger("TestAgent", "inst_1");
 		const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
 
 		groveInit({ log: logger }, { name: "TestAgent", description: "A test" });
 
-		expect(spy).toHaveBeenCalledOnce();
-		const entry = JSON.parse(spy.mock.calls[0][0] as string);
-		expect(entry.message).toBe("Grove agent initializing");
-		expect(entry.name).toBe("TestAgent");
-		expect(entry.description).toBe("A test");
+		expect(spy).not.toHaveBeenCalled();
 	});
 
-	it("handles missing description gracefully", () => {
+	it("accepts config without description", () => {
 		const logger = new AgentLogger("TestAgent", "inst_1");
-		const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
 
-		groveInit({ log: logger }, { name: "TestAgent" });
-
-		expect(spy).toHaveBeenCalledOnce();
-		const entry = JSON.parse(spy.mock.calls[0][0] as string);
-		expect(entry.name).toBe("TestAgent");
-		expect(entry.description).toBeUndefined();
+		expect(() => groveInit({ log: logger }, { name: "TestAgent" })).not.toThrow();
 	});
 });


### PR DESCRIPTION
## Summary

Follow-up fixes from the shrines curio security audit (#1326).

- **Crypto IDs**: Replace `Math.random()` with `crypto.getRandomValues()` for shrine ID generation
- **ID format validation**: New `isValidShrineId()` guard on all 4 mutating actions (togglePublish, remove, updateContents, loadTemplate)
- **Prototype pollution**: `sanitizeContentData()` now skips `__proto__`, `constructor`, `prototype` keys
- **Test alignment**: `grove-agent/init.test.ts` updated to match intentional no-log behavior (workerd lazy `.name` constraint)

## Test plan

- [x] grove-agent: 19/19 tests passing (was 17/19)
- [x] engine shrines: 38/38 tests passing (new: crypto ID format, ID validation, prototype pollution guard)
- [x] svelte-check: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)