### PR TITLE
fix(ci): add gossamer build step to deploy workflows

### DIFF
--- a/.github/workflows/_deploy-pages.yml
+++ b/.github/workflows/_deploy-pages.yml
@@ -108,6 +108,11 @@ jobs:
         run: pnpm run build
         working-directory: libs/foliage
 
+      - name: Build gossamer
+        if: inputs.needs-engine
+        run: pnpm run build
+        working-directory: libs/gossamer
+
       - name: Build engine
         if: inputs.needs-engine
         run: pnpm run package

--- a/.github/workflows/_deploy-worker.yml
+++ b/.github/workflows/_deploy-worker.yml
@@ -103,6 +103,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build gossamer
+        if: inputs.needs-engine
+        run: pnpm run build
+        working-directory: libs/gossamer
+
       - name: Build engine
         if: inputs.needs-engine
         run: pnpm run package

--- a/libs/engine/src/routes/arbor/curios/shrines/+page.svelte
+++ b/libs/engine/src/routes/arbor/curios/shrines/+page.svelte
@@ -268,7 +268,6 @@
 						<!-- Item list -->
 						<div class="item-list" role="listbox" aria-label="Shrine content items">
 							{#each editorItems as item, i}
-								<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 								<div
 									class="item-row"
 									class:active={editingItemIndex === i}

--- a/libs/engine/vitest.config.ts
+++ b/libs/engine/vitest.config.ts
@@ -12,31 +12,34 @@ const __dirname = new URL(".", import.meta.url).pathname;
  * post-migrator package which has compatible vitest version.
  */
 export default defineConfig({
-  plugins: [svelte({ hot: false })],
-  test: {
-    globals: true,
-    environment: "happy-dom",
-    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
-    exclude: ["**/node_modules/**", "**/dist/**"],
-    setupFiles: ["./tests/utils/setup.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      exclude: ["node_modules/**", "dist/**", "**/*.d.ts", "tests/**"],
-    },
-  },
-  resolve: {
-    // Use browser condition for Svelte 5 component testing
-    // Without this, vitest imports svelte/src/index-server.js which lacks mount()
-    conditions: ["browser"],
-    alias: {
-      $lib: "/src/lib",
-      "$lib/*": "/src/lib/*",
-      // SvelteKit virtual modules need stubs for vitest
-      "$app/stores": resolve(__dirname, "tests/mocks/app-stores.ts"),
-      "$app/state": resolve(__dirname, "tests/mocks/app-state.ts"),
-      "$app/navigation": resolve(__dirname, "tests/mocks/app-navigation.ts"),
-      "$app/environment": resolve(__dirname, "tests/mocks/app-environment.ts"),
-    },
-  },
+	plugins: [svelte({ hot: false })],
+	test: {
+		globals: true,
+		environment: "happy-dom",
+		include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+		exclude: ["**/node_modules/**", "**/dist/**"],
+		setupFiles: ["./tests/utils/setup.ts"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json", "html"],
+			exclude: ["node_modules/**", "dist/**", "**/*.d.ts", "tests/**"],
+		},
+	},
+	resolve: {
+		// Use browser condition for Svelte 5 component testing
+		// Without this, vitest imports svelte/src/index-server.js which lacks mount()
+		conditions: ["browser"],
+		alias: {
+			$lib: "/src/lib",
+			"$lib/*": "/src/lib/*",
+			// SvelteKit virtual modules need stubs for vitest
+			"$app/stores": resolve(__dirname, "tests/mocks/app-stores.ts"),
+			"$app/state": resolve(__dirname, "tests/mocks/app-state.ts"),
+			"$app/navigation": resolve(__dirname, "tests/mocks/app-navigation.ts"),
+			"$app/environment": resolve(__dirname, "tests/mocks/app-environment.ts"),
+			// Workspace subpath exports can't resolve to dist/ in vitest — map to source
+			"@autumnsgrove/gossamer/svelte": resolve(__dirname, "../gossamer/src/svelte/index.ts"),
+			"@autumnsgrove/gossamer": resolve(__dirname, "../gossamer/src/index.ts"),
+		},
+	},
 });

--- a/libs/gossamer/src/svelte/GossamerClouds.svelte
+++ b/libs/gossamer/src/svelte/GossamerClouds.svelte
@@ -152,8 +152,8 @@
 		renderer.renderFromBrightnessGrid(grid);
 	}
 
-	// Measured cell width (computed from font metrics in setupRenderer)
-	let measuredCellWidth = cellSize;
+	// Measured cell width (computed from font metrics in setupRenderer, falls back to cellSize)
+	let measuredCellWidth = $state(0);
 
 	function setupRenderer(width: number, height: number): void {
 		if (!canvas) return;
@@ -175,6 +175,8 @@
 			tempCtx.font = `${cellSize}px monospace`;
 			const measured = tempCtx.measureText("M").width;
 			measuredCellWidth = Math.ceil(measured);
+		} else {
+			measuredCellWidth = cellSize;
 		}
 
 		renderer = new GossamerRenderer(canvas, {


### PR DESCRIPTION
## Summary

Fixes CI and deploy failures caused by missing gossamer build step in reusable deploy workflows.

**Root cause**: The gossamer visual overhaul (ed1bf609) added `@autumnsgrove/gossamer/svelte` imports to `GlassCard.svelte` and `Glass.svelte`. The `deploy-engine.yml` and `ci.yml` workflows correctly build gossamer via `grove-setup`, but the reusable `_deploy-pages.yml` and `_deploy-worker.yml` templates were missing this step.

**Fixes**:
- Add "Build gossamer" step before "Build engine" in both `_deploy-pages.yml` and `_deploy-worker.yml`
- Add `@autumnsgrove/gossamer` resolve aliases in engine's `vitest.config.ts` (same pattern as Reverie worker)
- Fix `state_referenced_locally` Svelte 5 lint error in `GossamerClouds.svelte`
- Remove stale `svelte-ignore` comment in shrine editor

## Test plan

- [x] Engine tests: 3 previously-failing test files now pass (BetaWelcomeDialog, ArtifactShowcase, pulse)
- [x] Gossamer tests: 95 passed, 3 skipped
- [x] Lint: 0 errors (was 2 errors)
- [ ] Deploy workflows: verify gossamer builds before engine in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)