### PR TITLE
Replace Cherry icon with NotebookText for bloom post type

### DIFF
--- a/libs/engine/src/lib/blazes/palette.ts
+++ b/libs/engine/src/lib/blazes/palette.ts
@@ -5,7 +5,7 @@
  * JIT scanner sees it at build time. Never construct class names dynamically.
  */
 
-import { Cherry, Feather } from "lucide-svelte";
+import { NotebookText, Feather } from "lucide-svelte";
 import {
 	Bell,
 	UtensilsCrossed,
@@ -59,7 +59,7 @@ import type { AutoBlazeConfig, BlazeColorClasses, LucideIcon, PostType } from ".
 export const BLAZE_CONFIG: Record<PostType, AutoBlazeConfig> = {
 	bloom: {
 		label: "Bloom",
-		icon: Cherry,
+		icon: NotebookText,
 		classes: "bg-grove-50 text-grove-700 dark:bg-grove-100/30 dark:text-grove-700",
 	},
 	note: {


### PR DESCRIPTION
## Summary

Updates the icon used for the "bloom" post type from `Cherry` to `NotebookText` in the blaze palette configuration. This change improves the semantic alignment between the icon and the post type's purpose.

## Type of Change

- [ ] Bug fix
- [x] Refactoring
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Infrastructure

## Testing

N/A - This is a simple icon substitution in the configuration. The change is purely visual and does not affect functionality.

https://claude.ai/code/session_01D1drdDPN1oKecqAqYzE1n7