### PR TITLE
Update Blooms icon from cherry to notebook-text

### DIFF
--- a/apps/landing/src/lib/utils/icons.ts
+++ b/apps/landing/src/lib/utils/icons.ts
@@ -188,6 +188,7 @@ import {
   // Curios - cabinet of wonders
   Amphora,
   NotebookPen,
+  NotebookText,
   Shell,
   // Wander - immersive discovery
   Earth,
@@ -404,6 +405,7 @@ export const toolIcons = {
   // Curios - cabinet of wonders
   amphora: Amphora, // Curios - main icon (cabinet of curiosities)
   "notebook-pen": NotebookPen, // Curios - Guestbook
+  "notebook-text": NotebookText, // Blooms - individual pieces of writing
   shell: Shell, // Curios - Artifacts
   // Forests - community aggregation
   trees: Trees, // Forests - main icon (many trees together)
@@ -525,7 +527,7 @@ export const toolIcons = {
   "refresh-cw": RefreshCw, // Zephyr - retry with backoff
   // Garden & Blooms - core terminology
   flower: Flower, // Garden - collection of blooms
-  cherry: Cherry, // Blooms - individual pieces of writing
+  cherry: Cherry, // Cherry trees (nature theming)
   zap: Zap, // Verge - remote AI coding
 } as const;
 

--- a/apps/landing/src/routes/workshop/+page.svelte
+++ b/apps/landing/src/routes/workshop/+page.svelte
@@ -165,7 +165,7 @@
 					description:
 						"A bloom is a flower opening—a moment of expression, color, and beauty. It's what your grove produces. Every piece you write is a bloom. Something that grew from your thinking, opened when it was ready, and now stands in your garden for others to see.",
 					status: "live",
-					icon: "cherry",
+					icon: "notebook-text",
 					domain: "{you}.grove.place/garden/{slug}",
 					integration: "Individual pieces of writing in your garden",
 					spec: "/knowledge/specs/grove-garden-bloom-spec",
@@ -700,7 +700,7 @@
 						},
 						{
 							name: "Blooms",
-							icon: "cherry",
+							icon: "notebook-text",
 							description: "RSS syndicated posts",
 							href: "/knowledge/help/what-are-blooms",
 						},


### PR DESCRIPTION
## Summary

Updates the icon representation for "Blooms" (individual pieces of writing in a garden) from the `cherry` icon to the more semantically appropriate `notebook-text` icon. This change includes:

1. Adding `NotebookText` to the icon imports
2. Registering `notebook-text` in the `toolIcons` mapping with a comment indicating it's used for Blooms
3. Updating the comment for `cherry` to reflect its use for nature theming rather than Blooms
4. Updating two UI references to use the new `notebook-text` icon for Blooms

This provides better visual semantics—a notebook icon more clearly represents "pieces of writing" than a cherry icon.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring
- [ ] Infrastructure

## Testing

No testing needed—this is a straightforward icon mapping update with no functional logic changes. The icon is purely presentational.

https://claude.ai/code/session_01Hji6i7jAbEn9f7KqJDKh8B