### PR TITLE
feat(gw): add board-wide dispatch scope for vulture-sweep hotkey

### DIFF
--- a/tools/grove-wrap-go/cmd/gh_issue_browse.go
+++ b/tools/grove-wrap-go/cmd/gh_issue_browse.go
@@ -275,7 +275,15 @@ func (m issueBrowseModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			// Check skill hotkeys
 			if skill, ok := skillByKey[key]; ok {
+				if skillScope(skill) == ScopeBoard {
+					// Board-scoped: no issue selection needed
+					m.action = "board-skill"
+					m.actionSkill = skill.Name
+					m.quitting = true
+					return m, tea.Quit
+				}
 				if len(m.filtered) > 0 {
+					// Issue-scoped: requires a selected issue
 					m.action = "skill"
 					m.actionSkill = skill.Name
 					m.actionNum = m.filtered[m.cursor].Number
@@ -476,9 +484,14 @@ func (m issueBrowseModel) renderHelp() string {
 				if len(keyDisplay) == 1 && keyDisplay[0] >= 'A' && keyDisplay[0] <= 'Z' {
 					keyDisplay = "⇧" + strings.ToLower(keyDisplay)
 				}
+				// Board-scoped skills get a scope indicator
+				scopeTag := ""
+				if skillScope(skill) == ScopeBoard {
+					scopeTag = " [board]"
+				}
 				b.WriteString(fmt.Sprintf("    %s  %-24s %s\n",
 					browseHelpKeyStyle.Render(fmt.Sprintf("%-3s", keyDisplay)),
-					skill.Name,
+					skill.Name+scopeTag,
 					browseHintStyle.Render(skill.Purpose)))
 			}
 		}
@@ -486,6 +499,8 @@ func (m issueBrowseModel) renderHelp() string {
 
 	b.WriteString("\n")
 	b.WriteString(browseHintStyle.Render("  j/k scroll • any other key to return"))
+	b.WriteString("\n")
+	b.WriteString(browseHintStyle.Render("  [board] = no issue selection needed"))
 
 	return viewportSlice(b.String(), m.helpOffset, m.height)
 }
@@ -528,6 +543,9 @@ func runIssueBrowse(issues []browseIssue, pageSize int, fetchArgs issueFetchArgs
 
 	// Handle post-quit actions
 	switch final.action {
+	case "board-skill":
+		return launchBoardSkill(final.actionSkill)
+
 	case "skill":
 		num := fmt.Sprintf("%d", final.actionNum)
 		return launchSkillForIssue(final.actionSkill, num)

--- a/tools/grove-wrap-go/cmd/gh_issue_skills.go
+++ b/tools/grove-wrap-go/cmd/gh_issue_skills.go
@@ -13,13 +13,22 @@ import (
 	"github.com/AutumnsGrove/Lattice/tools/grove-wrap-go/internal/ui"
 )
 
+// Skill dispatch scopes control how a skill is launched from the browser.
+const (
+	// ScopeIssue is the default: requires a selected issue, optionally creates a worktree.
+	ScopeIssue = "issue"
+	// ScopeBoard launches without issue context or worktree (board-wide operations).
+	ScopeBoard = "board"
+)
+
 // skillEntry defines a skill that can be launched from the issue browser.
 type skillEntry struct {
 	Key      string
 	Name     string // slash command name (e.g., "panther-strike")
 	Purpose  string
 	Category string
-	Yolo     bool // launch with --dangerously-skip-permissions
+	Yolo     bool   // launch with --dangerously-skip-permissions
+	Scope    string // "issue" (default) or "board" — controls dispatch behavior
 }
 
 // skillCategories controls help display ordering.
@@ -38,47 +47,47 @@ var skillCategories = []string{
 // Keys j/k are reserved for navigation; conflicts resolved with shift or alternate keys.
 var skillRegistry = []skillEntry{
 	// Surgical Fixers (Issue Resolution)
-	{"p", "panther-strike", "Lock onto ONE issue, fix it fast", "Surgical Fixers", false},
-	{"m", "mole-debug", "Systematic hypothesis-driven debugging", "Surgical Fixers", false},
-	{"e", "elephant-build", "Multi-file feature implementation", "Surgical Fixers", false},
-	{"r", "lynx-repair", "Address PR review feedback", "Surgical Fixers", false},
+	{"p", "panther-strike", "Lock onto ONE issue, fix it fast", "Surgical Fixers", false, ""},
+	{"m", "mole-debug", "Systematic hypothesis-driven debugging", "Surgical Fixers", false, ""},
+	{"e", "elephant-build", "Multi-file feature implementation", "Surgical Fixers", false, ""},
+	{"r", "lynx-repair", "Address PR review feedback", "Surgical Fixers", false, ""},
 
 	// Exploration & Planning
-	{"a", "eagle-architect", "System architecture from 10,000 feet", "Exploration", false},
-	{"b", "bloodhound-scout", "Track code through the codebase", "Exploration", false},
-	{"g", "groundhog-surface", "Surface and validate assumptions", "Exploration", false},
+	{"a", "eagle-architect", "System architecture from 10,000 feet", "Exploration", false, ""},
+	{"b", "bloodhound-scout", "Track code through the codebase", "Exploration", false, ""},
+	{"g", "groundhog-surface", "Surface and validate assumptions", "Exploration", false, ""},
 
 	// Enhancement & Optimization
-	{"f", "fox-optimize", "Hunt performance bottlenecks", "Enhancement", false},
-	{"d", "deer-sense", "Audit accessibility barriers", "Enhancement", false},
-	{"c", "chameleon-adapt", "Theme/design with glassmorphism", "Enhancement", false},
-	{"t", "beaver-build", "Write robust tests", "Enhancement", false},
-	{"y", "bear-migrate", "Data migration with patient strength", "Enhancement", false},
+	{"f", "fox-optimize", "Hunt performance bottlenecks", "Enhancement", false, ""},
+	{"d", "deer-sense", "Audit accessibility barriers", "Enhancement", false, ""},
+	{"c", "chameleon-adapt", "Theme/design with glassmorphism", "Enhancement", false, ""},
+	{"t", "beaver-build", "Write robust tests", "Enhancement", false, ""},
+	{"y", "bear-migrate", "Data migration with patient strength", "Enhancement", false, ""},
 
 	// Compliance & Quality
-	{"i", "crane-audit", "PR compliance audit for Grove SDK standards", "Compliance", false},
+	{"i", "crane-audit", "PR compliance audit for Grove SDK standards", "Compliance", false, ""},
 
 	// Security & Hardening
-	{"s", "spider-weave", "Auth integration and route security", "Security", false},
-	{"u", "turtle-harden", "Defense-in-depth protection layers", "Security", false},
-	{"x", "raccoon-audit", "Security sweep and secret cleanup", "Security", false},
-	{"h", "hawk-survey", "Full application security assessment", "Security", false},
+	{"s", "spider-weave", "Auth integration and route security", "Security", false, ""},
+	{"u", "turtle-harden", "Defense-in-depth protection layers", "Security", false, ""},
+	{"x", "raccoon-audit", "Security sweep and secret cleanup", "Security", false, ""},
+	{"h", "hawk-survey", "Full application security assessment", "Security", false, ""},
 
 	// Reasoning & Documentation
-	{"w", "crow-reason", "Critical reasoning, devil's advocate", "Reasoning", false},
-	{"o", "owl-archive", "Documentation and user-facing text", "Reasoning", false},
-	{"n", "swan-design", "Technical specs with diagrams", "Reasoning", false},
+	{"w", "crow-reason", "Critical reasoning, devil's advocate", "Reasoning", false, ""},
+	{"o", "owl-archive", "Documentation and user-facing text", "Reasoning", false, ""},
+	{"n", "swan-design", "Technical specs with diagrams", "Reasoning", false, ""},
 
 	// Multi-Animal Chains (Gatherings — shift keys)
-	{"G", "gathering-feature", "Full lifecycle: explore → build → test → doc", "Gatherings", false},
-	{"S", "gathering-security", "Spider → Raccoon → Turtle pipeline", "Gatherings", false},
-	{"U", "gathering-ui", "Chameleon → Deer pipeline", "Gatherings", false},
-	{"A", "gathering-architecture", "Eagle → Crow → Swan → Elephant", "Gatherings", false},
-	{"M", "gathering-migration", "Bear → Bloodhound pipeline", "Gatherings", false},
+	{"G", "gathering-feature", "Full lifecycle: explore → build → test → doc", "Gatherings", false, ""},
+	{"S", "gathering-security", "Spider → Raccoon → Turtle pipeline", "Gatherings", false, ""},
+	{"U", "gathering-ui", "Chameleon → Deer pipeline", "Gatherings", false, ""},
+	{"A", "gathering-architecture", "Eagle → Crow → Swan → Elephant", "Gatherings", false, ""},
+	{"M", "gathering-migration", "Bear → Bloodhound pipeline", "Gatherings", false, ""},
 
-	// Board Management
-	{"J", "vulture-sweep", "Clean up stale/closed issues", "Board Mgmt", false},
-	{"l", "safari-explore", "Systematically review a collection", "Board Mgmt", false},
+	// Board Management (board-scoped skills skip issue selection and worktree creation)
+	{"J", "vulture-sweep", "Clean up stale/closed issues", "Board Mgmt", false, ScopeBoard},
+	{"l", "safari-explore", "Systematically review a collection", "Board Mgmt", false, ""},
 }
 
 // skillByKey provides O(1) lookup from hotkey to skill entry.
@@ -151,6 +160,33 @@ func suggestSkills(labels []string) []string {
 		}
 	}
 	return suggestions
+}
+
+// skillScope returns the effective scope for a skill entry.
+// Empty string defaults to ScopeIssue for backward compatibility.
+func skillScope(s *skillEntry) string {
+	if s.Scope == "" {
+		return ScopeIssue
+	}
+	return s.Scope
+}
+
+// launchBoardSkill launches a board-scoped skill without issue context or
+// worktree creation. Board skills operate on the entire issue board (e.g.,
+// vulture-sweep scans all open issues for staleness/completion).
+func launchBoardSkill(skillName string) error {
+	root := effectiveRoot()
+	prompt := fmt.Sprintf("/%s", skillName)
+	ui.Info(fmt.Sprintf("Launching board-scoped skill %q from %s", skillName, root))
+	args := claudeArgs(skillName, prompt)
+	exitCode, launchErr := gwexec.RunStreamingInDir(root, "claude", args...)
+	if launchErr != nil {
+		return fmt.Errorf("failed to launch claude: %w", launchErr)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("claude exited with code %d", exitCode)
+	}
+	return nil
 }
 
 // launchSkillForIssue creates a worktree (if auto_worktree is enabled) and
@@ -260,38 +296,62 @@ func launchSkillForPR(skillName string, prNumber int, headBranch string) error {
 // --- issue launch ---
 
 var issueLaunchCmd = &cobra.Command{
-	Use:   "launch <number>",
-	Short: "Launch a skill against an issue",
-	Long:  "Create a worktree and launch Claude with a skill for the given issue.",
-	Args:  cobra.ExactArgs(1),
+	Use:   "launch [number]",
+	Short: "Launch a skill against an issue (or board-wide)",
+	Long: `Create a worktree and launch Claude with a skill for the given issue.
+Board-scoped skills (e.g., vulture-sweep) don't require an issue number.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		skillName, _ := cmd.Flags().GetString("skill")
+
+		// Resolve skill name (allow short names like "mole" → "mole-debug")
+		resolved, err := resolveSkillName(skillName)
+		if err != nil {
+			return err
+		}
+		skillName = resolved
+
+		entry := skillByName[skillName]
+
+		// Board-scoped skills don't need an issue number
+		if skillScope(entry) == ScopeBoard {
+			if len(args) > 0 {
+				ui.Warning("Board-scoped skill " + skillName + " ignores issue number")
+			}
+			return launchBoardSkill(skillName)
+		}
+
+		// Issue-scoped skills require a number
+		if len(args) == 0 {
+			return fmt.Errorf("issue-scoped skill %q requires an issue number: gw gh issue launch <number> --skill %s", skillName, skillName)
+		}
 		number := args[0]
 		if err := validateGHNumber(number); err != nil {
 			return err
 		}
-
-		skillName, _ := cmd.Flags().GetString("skill")
-
-		// Allow short names (e.g., "mole" matches "mole-debug")
-		if _, ok := skillByName[skillName]; !ok {
-			// Try prefix match
-			var match *skillEntry
-			for i := range skillRegistry {
-				if strings.HasPrefix(skillRegistry[i].Name, skillName) {
-					if match != nil {
-						return fmt.Errorf("ambiguous skill %q — matches %q and %q", skillName, match.Name, skillRegistry[i].Name)
-					}
-					match = &skillRegistry[i]
-				}
-			}
-			if match == nil {
-				return fmt.Errorf("unknown skill %q — available skills:\n%s", skillName, listSkillNames())
-			}
-			skillName = match.Name
-		}
-
 		return launchSkillForIssue(skillName, number)
 	},
+}
+
+// resolveSkillName resolves a skill name, supporting prefix matching.
+// Returns the resolved name and any error (ambiguity or not found).
+func resolveSkillName(name string) (string, error) {
+	if _, ok := skillByName[name]; ok {
+		return name, nil
+	}
+	var match *skillEntry
+	for i := range skillRegistry {
+		if strings.HasPrefix(skillRegistry[i].Name, name) {
+			if match != nil {
+				return "", fmt.Errorf("ambiguous skill %q — matches %q and %q", name, match.Name, skillRegistry[i].Name)
+			}
+			match = &skillRegistry[i]
+		}
+	}
+	if match != nil {
+		return match.Name, nil
+	}
+	return "", fmt.Errorf("unknown skill %q — available skills:\n%s", name, listSkillNames())
 }
 
 // listSkillNames returns a formatted list of all available skill names.

--- a/tools/grove-wrap-go/cmd/gh_pr_browse.go
+++ b/tools/grove-wrap-go/cmd/gh_pr_browse.go
@@ -361,7 +361,15 @@ func (m prBrowseModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			// Check skill hotkeys
 			if skill, ok := skillByKey[key]; ok {
+				if skillScope(skill) == ScopeBoard {
+					// Board-scoped: no PR selection needed
+					m.action = "board-skill"
+					m.actionSkill = skill.Name
+					m.quitting = true
+					return m, tea.Quit
+				}
 				if len(m.filtered) > 0 {
+					// Issue-scoped: requires a selected PR
 					pr := m.filtered[m.cursor]
 					m.action = "skill"
 					m.actionSkill = skill.Name
@@ -548,9 +556,13 @@ func (m prBrowseModel) renderHelp() string {
 				if len(keyDisplay) == 1 && keyDisplay[0] >= 'A' && keyDisplay[0] <= 'Z' {
 					keyDisplay = "⇧" + strings.ToLower(keyDisplay)
 				}
+				scopeTag := ""
+				if skillScope(skill) == ScopeBoard {
+					scopeTag = " [board]"
+				}
 				b.WriteString(fmt.Sprintf("    %s  %-24s %s\n",
 					browseHelpKeyStyle.Render(fmt.Sprintf("%-3s", keyDisplay)),
-					skill.Name,
+					skill.Name+scopeTag,
 					browseHintStyle.Render(skill.Purpose)))
 			}
 		}
@@ -558,6 +570,8 @@ func (m prBrowseModel) renderHelp() string {
 
 	b.WriteString("\n")
 	b.WriteString(browseHintStyle.Render("  j/k scroll • any other key to return"))
+	b.WriteString("\n")
+	b.WriteString(browseHintStyle.Render("  [board] = no issue/PR selection needed"))
 
 	return viewportSlice(b.String(), m.helpOffset, m.height)
 }
@@ -603,6 +617,9 @@ func runPRBrowse(prs []browsePR, pageSize int, fetchArgs prFetchArgs) error {
 
 	// Handle post-quit actions
 	switch final.action {
+	case "board-skill":
+		return launchBoardSkill(final.actionSkill)
+
 	case "skill":
 		pr := final.actionPR
 		// Need head branch — fetch if not already populated


### PR DESCRIPTION
## Summary

- Introduces a **board-scoped dispatch category** for skills that operate on the entire issue board rather than a single issue
- Vulture-sweep (`⇧J`) now launches without requiring a selected issue or worktree — it scans the full board for stale/completed/consolidatable issues
- `gw gh issue launch --skill vulture-sweep` works without an issue number argument
- Both issue and PR browsers support the new dispatch path
- Help overlay shows `[board]` tag on board-scoped skills

Closes #1421

## Changes

| File | Change |
|------|--------|
| `gh_issue_skills.go` | Add `Scope` field + `ScopeIssue`/`ScopeBoard` constants, `launchBoardSkill()`, `skillScope()` helper, updated `issueLaunchCmd` to support optional number arg |
| `gh_issue_browse.go` | Board-scoped hotkeys bypass issue selection, `"board-skill"` post-quit action |
| `gh_pr_browse.go` | Same board-scope handling + help legend |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 8 test packages)
- [x] `gw update --source` installs updated binary
- [ ] `gw gh issue list` → press `⇧J` → launches vulture-sweep without issue context
- [ ] `gw gh issue launch --skill vulture-sweep` → works without number argument
- [ ] `gw gh issue launch --skill panther-strike 1421` → still works (issue-scoped path unchanged)
- [ ] Help overlay (`?`) shows `[board]` tag on vulture-sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)