### PR TITLE
feat(ui): complete remaining GlassCard prop migrations

### DIFF
--- a/libs/engine/src/routes/arbor/export/+page.svelte
+++ b/libs/engine/src/routes/arbor/export/+page.svelte
@@ -362,8 +362,13 @@
 
 	<!-- Section 2b: Completed export — download prompt -->
 	{#if activeExportId && activeStatus === "complete" && deliveryMethod === "download"}
-		<GlassCard variant="default" class="mb-6">
-			<h2><CheckCircle class="header-icon success-icon" aria-hidden="true" /> Export Ready!</h2>
+		<GlassCard
+			variant="default"
+			class="mb-6"
+			title="Export Ready!"
+			icon={CheckCircle}
+			iconClass="text-primary"
+		>
 			<p class="section-desc">Your export is bundled and ready to download.</p>
 			<Button
 				variant="primary"
@@ -395,9 +400,7 @@
 
 	<!-- Section 3: Past Exports -->
 	{#if data.pastExports.length > 0}
-		<GlassCard variant="default">
-			<h2><Clock class="header-icon" aria-hidden="true" /> Past Exports</h2>
-
+		<GlassCard variant="default" title="Past Exports" icon={Clock} iconClass="text-primary">
 			<div class="exports-list">
 				{#each data.pastExports as exp (exp.id)}
 					<div class="export-row">
@@ -642,10 +645,6 @@
 	.section-desc {
 		margin: 0 0 1rem 0;
 		color: var(--color-text-muted);
-	}
-
-	:global(.success-icon) {
-		color: var(--color-primary) !important;
 	}
 
 	/* Error Banner */

--- a/libs/engine/src/routes/arbor/settings/+page.svelte
+++ b/libs/engine/src/routes/arbor/settings/+page.svelte
@@ -5,7 +5,6 @@
 	import Spinner from "$lib/ui/components/ui/Spinner.svelte";
 	import GlassCard from "$lib/ui/components/ui/GlassCard.svelte";
 	import GlassConfirmDialog from "$lib/ui/components/ui/GlassConfirmDialog.svelte";
-	import Waystone from "$lib/ui/components/ui/Waystone.svelte";
 	import GroveTerm from "$lib/ui/components/ui/groveterm/GroveTerm.svelte";
 	import { GreenhouseStatusCard, GraftControlPanel } from "$lib/grafts/greenhouse";
 	import {
@@ -1119,11 +1118,13 @@
 		</div>
 	{/if}
 
-	<GlassCard variant="frosted" class="mb-6">
-		<div class="section-header">
-			<h2>Typography</h2>
-			<Waystone slug="custom-fonts" label="Learn about fonts" />
-		</div>
+	<GlassCard
+		variant="frosted"
+		class="mb-6"
+		title="Typography"
+		waystone="custom-fonts"
+		waystoneLabel="Learn about fonts"
+	>
 		<p class="section-description">
 			Choose the font family used across the entire site. Changes take effect immediately.
 		</p>
@@ -1246,11 +1247,13 @@
 		{/if}
 	</GlassCard>
 
-	<GlassCard variant="frosted" class="mb-6">
-		<div class="section-header">
-			<h2>Accent Color</h2>
-			<Waystone slug="choosing-a-theme" label="Learn about themes" />
-		</div>
+	<GlassCard
+		variant="frosted"
+		class="mb-6"
+		title="Accent Color"
+		waystone="choosing-a-theme"
+		waystoneLabel="Learn about themes"
+	>
 		<p class="section-description">
 			Customize the accent color used for tags and interactive elements on your blog.
 		</p>
@@ -1688,11 +1691,13 @@
 	</GlassCard>
 
 	<!-- Blazes — Custom Content Markers -->
-	<GlassCard variant="frosted" class="mb-6">
-		<div class="section-header">
-			<h2>Blazes</h2>
-			<Waystone slug="what-are-blazes" label="What are blazes?" size="sm" />
-		</div>
+	<GlassCard
+		variant="frosted"
+		class="mb-6"
+		title="Blazes"
+		waystone="what-are-blazes"
+		waystoneLabel="What are blazes?"
+	>
 		<p class="section-description">
 			Small markers that tell readers what your posts are about. The 8 default blazes are always
 			available. You can create up to 20 custom blazes for your garden.


### PR DESCRIPTION
## Summary

Completes the GlassCard prop migration from #1405 — the final 5 patterns that weren't included in the initial PR.

- **Export page (Phase 2a):** Migrate 2 manual `<h2>` + icon patterns to `title`/`icon`/`iconClass` props; remove dead `.success-icon` CSS
- **Settings page (Phase 3a):** Migrate 3 `section-header` divs with `<h2>` + `<Waystone>` to `title`/`waystone`/`waystoneLabel` props; remove unused `Waystone` import

### Visual notes
- Export icons change from 24px (`header-icon` CSS) to 20px (GlassCard `w-5 h-5`) — minor, acceptable
- Settings headings change from `<h2>` to `<h3>` — semantically correct (sub-sections under Settings `<h1>`)
- Blazes waystone loses `size="sm"` — GlassCard renders default size

Closes #1405

## Test plan
- [ ] CI passes (lint, check, test, build)
- [ ] Visual review: export page icons render with primary color
- [ ] Visual review: settings Typography/Accent Color/Blazes show waystone help markers
- [ ] Waystone popups still function correctly on settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)