### PR TITLE
feat(skills): migrate four gatherings to conductor pattern

### DIFF
--- a/.claude/skills/gathering-architecture/SKILL.md
+++ b/.claude/skills/gathering-architecture/SKILL.md
@@ -5,7 +5,7 @@ description: The drum sounds. Eagle, Crow, Swan, and Elephant gather for system 
 
 # Gathering Architecture 🌲🦅
 
-The drum echoes high in the canopy. The Eagle soars above, seeing the forest's patterns. The Crow perches nearby, tilting its head at what others won't question. The Swan glides across the lake, elegant designs taking form. The Elephant moves below, building what was envisioned. Together they transform a clearing into a cathedral of code—systems that stand for seasons.
+The drum echoes high in the canopy. The conductor stands below, orchestrating each animal's entrance. The Eagle soars in fresh air, seeing patterns without bias. The Crow arrives separately, challenging with no sympathy for the architect. The Swan receives a strengthened design, not a compromised one. The Elephant builds from a spec it trusts. Four isolated minds, four intentional models, one cathedral of code.
 
 ## When to Summon
 
@@ -13,45 +13,31 @@ The drum echoes high in the canopy. The Eagle soars above, seeing the forest's p
 - Major architectural decisions
 - Refactoring core infrastructure
 - Creating platforms that other features build upon
-- When vision, design, and implementation must align
+- When vision, challenge, specification, and implementation must flow in sequence
 
----
-
-## Grove Tools for This Gathering
-
-Use `gw` and `gf` throughout. Quick reference for architecture work:
-
-```bash
-# Orientation — understand the project before designing
-gw context
-
-# Explore the existing architecture
-gf --agent search "pattern"         # Find code patterns
-gf --agent class "ServiceName"      # Find class/component definitions
-gf --agent routes                   # Map route structure
-
-# Understand dependencies and change impact
-gf --agent deps                     # Dependency graph
-gf --agent impact "module"          # Blast radius of changes
-```
+**IMPORTANT:** This gathering is a **conductor**. It never designs, challenges, specifies, or builds directly. It dispatches subagents — one per animal — each with isolated context and an intentional model. The conductor only manages handoffs and gate checks.
 
 ---
 
 ## The Gathering
 
 ```
-SUMMON → ORGANIZE → EXECUTE → VALIDATE → COMPLETE
-   ↓         ↲          ↲          ↲          ↓
-Receive  Dispatch   Animals    Verify   Architecture
-Request  Animals    Work       Design   Defined
+SUMMON → DISPATCH → GATE → DISPATCH → GATE → DISPATCH → GATE → DISPATCH → GATE → CHORUS
+  ↓         ↓        ↓        ↓        ↓        ↓        ↓        ↓        ↓        ↓
+Spec     Eagle    Check     Crow    Check     Swan    Check   Elephant  Check    Final
+(self)   (opus)    ✓      (sonnet)   ✓      (opus)    ✓      (opus)     ✓     Verify
 ```
 
-### Animals Mobilized
+### Animals Dispatched
 
-1. **🦅 Eagle** — Design system architecture from 10,000 feet
-2. **🐦‍⬛ Crow** — Challenge the design before it's cast in code
-3. **🦢 Swan** — Write detailed technical specifications
-4. **🐘 Elephant** — Implement the architectural foundation
+| Order | Animal      | Model  | Role                           | Fresh Eyes?                                               |
+| ----- | ----------- | ------ | ------------------------------ | --------------------------------------------------------- |
+| 1     | 🦅 Eagle    | opus   | Design high-level architecture | Yes — sees only the system spec                           |
+| 2     | 🐦‍⬛ Crow     | sonnet | Challenge the design           | Yes — sees architecture doc only, not Eagle's reasoning   |
+| 3     | 🦢 Swan     | opus   | Write detailed specification   | Yes — sees strengthened architecture (Eagle + Crow fixes) |
+| 4     | 🐘 Elephant | opus   | Build the foundation           | Yes — sees only Swan's spec                               |
+
+**Reference:** Load `references/conductor-dispatch.md` for exact subagent prompts and handoff formats
 
 ---
 
@@ -59,7 +45,7 @@ Request  Animals    Work       Design   Defined
 
 _The drum sounds. The canopy rustles..._
 
-Receive and parse the request:
+The conductor receives the architecture request and prepares the dispatch plan:
 
 **Clarify the System:**
 
@@ -71,201 +57,234 @@ Receive and parse the request:
 **Nature Metaphor:**
 
 > "Every architecture needs a nature metaphor. What does this system resemble?
->
-> - Heartwood (core that holds everything)
-> - Wisp (gentle guiding light)
-> - Porch (place to gather and talk)
-> - Something else?"
-
-**Confirm:**
-
-> "I'll mobilize an architecture gathering for: **[system description]**
->
-> This will involve:
->
-> - 🦅 Eagle designing the high-level architecture
-> - 🐦‍⬛ Crow challenging the design before it's cast in spec
-> - 🦢 Swan writing the detailed specification
-> - 🐘 Elephant implementing the foundation
->
-> Proceed with the gathering?"
-
----
-
-### Phase 2: ORGANIZE
-
-_The birds circle. The elephant waits below..._
-
-Dispatch in sequence:
-
-**Dispatch Order:**
-
-```
-Eagle ──→ Crow ──→ Swan ──→ Elephant
-  │         │        │           │
-  │         │        │           │
-Design   Challenge  Write      Build
-System   Design    Spec       Foundation
-```
-
-**Dependencies:**
-
-- Eagle must complete before Crow (needs architecture to challenge)
-- Crow must complete before Swan (design strengthened before specifying)
-- Swan must complete before Elephant (needs detailed spec)
+> Heartwood (core), Wisp (gentle guide), Porch (gathering place), or something else?"
 
 **Infrastructure Abstractions:**
 
 - Use `GroveDatabase`/`GroveStorage`/`GroveKV`/`GroveServiceBus` from Server SDK for portability
 - Use Amber SDK (FileManager, QuotaManager) for user file management — not raw R2
-- Use Rootwork utilities at all data boundaries (forms, KV, webhooks, catch blocks)
+- Use Rootwork utilities at all data boundaries
+
+**Confirm with the human, then proceed.**
+
+**Output:** System specification, dispatch plan confirmed.
 
 ---
 
-### Phase 3: EXECUTE
+### Phase 2: DESIGN (Eagle)
 
-_The architecture takes form from sky to earth..._
-
-Execute each phase by loading and running each animal's dedicated skill:
-
----
-
-**🦅 EAGLE — DESIGN**
-
-Load skill: `eagle-architect`
-
-Execute the full Eagle workflow focused on [the system being designed].
-Handoff: architecture overview (system boundaries, component interactions, technology choices, scale constraints, nature metaphor, ADRs) → Swan for specification
-
----
-
-**🐦‍⬛ CROW — CHALLENGE**
-
-Load skill: `crow-reason`
-
-Execute the Crow in Red Team mode against the Eagle's architecture overview. Challenge assumptions, find weak points, stress-test boundaries. The Crow's Roost summary feeds into the Swan — design decisions are strengthened before they're cast in spec.
-Handoff: strengthened architecture with Roost summary (challenges resolved, risks acknowledged) → Swan for specification
-
----
-
-**🦢 SWAN — SPECIFY**
-
-Load skill: `swan-design`
-
-Execute the full Swan workflow using the Eagle's architecture overview, strengthened by the Crow's challenges.
-Handoff: complete technical specification (API contracts, database schema, flow diagrams, implementation checklist) → Elephant for foundation building
-
----
-
-**🐘 ELEPHANT — BUILD**
-
-Load skill: `elephant-build`
-
-Execute the full Elephant workflow using the Swan's technical specification as the build plan.
-Handoff: working foundation (core infrastructure, base modules, API skeleton, database migrations, essential tests) → VALIDATE phase
-
----
-
-### Phase 4: VALIDATE
-
-_The structure stands. Each animal verifies their work..._
-
-**Validation Checklist:**
-
-- [ ] Eagle: Architecture addresses all requirements
-- [ ] Crow: Design challenged and strengthened
-- [ ] Swan: Specification is complete and implementable
-- [ ] Elephant: Foundation is solid and tested
-
-**Review Points:**
+_The conductor signals. The Eagle rises..._
 
 ```
-After Eagle:
-  → Review architecture with stakeholders
-  → Confirm boundaries and trade-offs
-  → Approve before Crow challenges
-
-After Crow:
-  → Review Roost summary
-  → Confirm which challenges are resolved vs accepted risks
-  → Approve strengthened design before Swan begins
-
-After Swan:
-  → Review spec for completeness
-  → Verify all sections present
-  → Confirm implementation ready
-
-After Elephant:
-  → Test foundation thoroughly
-  → Verify patterns established
-  → Confirm next features can build upon it
+Agent(eagle, model: opus)
+  Input:  system specification only
+  Reads:  eagle-architect/SKILL.md + references (MANDATORY)
+  Output: architecture overview document
 ```
+
+Dispatch an **opus subagent** to design the architecture. The Eagle receives ONLY the system specification. It reads its own skill file and executes its full workflow.
+
+**What the Eagle produces:**
+
+- System boundaries and component interactions
+- Technology choices with rationale
+- Scale constraints and growth strategy
+- Data flow diagrams
+- Architecture Decision Records (ADRs)
+- Nature metaphor for the system
+
+**Handoff to conductor:** Architecture overview document (structured, not conversational).
+
+**Gate check:** Architecture document exists with: system boundaries, component diagram, technology choices, ADRs. If incomplete, resume Eagle with specific questions.
 
 ---
 
-### Phase 5: COMPLETE
+### Phase 3: CHALLENGE (Crow)
 
-_The gathering ends. Architecture stands ready..._
+_The Crow perches. It tilts its head at what others won't question..._
+
+```
+Agent(crow, model: sonnet)
+  Input:  architecture document ONLY (not Eagle's reasoning process)
+  Reads:  crow-reason/SKILL.md (MANDATORY)
+  Output: challenge report + strengthened design recommendations
+```
+
+Dispatch a **sonnet subagent** in Red Team mode against the Eagle's architecture. The Crow receives ONLY the architecture document — NOT the Eagle's internal reasoning. This isolation is intentional: the Crow should challenge the design on its own merits, not be persuaded by the architect's justifications.
+
+**What the Crow challenges:**
+
+- Assumptions that aren't proven
+- Single points of failure
+- Complexity that could be simpler
+- Scale claims without evidence
+- Missing failure modes
+- Operational burden on a small team
+
+**Handoff to conductor:** Challenge report (Roost summary) with specific recommendations. The conductor then decides which challenges require Eagle revision.
+
+**Gate check:** Crow produced challenges with specific, actionable recommendations (not vague concerns). If challenges reveal fundamental design issues, resume Eagle with the Crow's findings for revision.
+
+**Iteration:** If Eagle needs revision:
+
+1. Resume Eagle with Crow's specific findings
+2. Eagle produces revised architecture
+3. Optionally resume Crow for re-challenge (max 2 iterations)
+
+---
+
+### Phase 4: SPECIFY (Swan)
+
+_The Swan glides. Elegance meets precision..._
+
+```
+Agent(swan, model: opus)
+  Input:  strengthened architecture (Eagle's doc + resolved Crow challenges)
+  Reads:  swan-design/SKILL.md + references (MANDATORY)
+  Output: complete technical specification
+```
+
+Dispatch an **opus subagent** to write the detailed specification. The Swan receives the architecture document as strengthened by the Crow's challenges — it sees the resolved design, not the debate.
+
+**What the Swan produces:**
+
+- API contracts (request/response formats)
+- Database schema with relationships
+- Flow diagrams for key operations
+- Implementation checklist ordered by dependency
+- Error handling patterns (Signpost codes)
+- Configuration and deployment requirements
+
+**Handoff to conductor:** Complete technical specification document.
+
+**Gate check:** Specification has: API contracts, database schema, flow diagrams, implementation checklist. If missing sections, resume Swan.
+
+---
+
+### Phase 5: BUILD (Elephant)
+
+_The ground trembles. The Elephant arrives..._
+
+```
+Agent(elephant, model: opus)
+  Input:  Swan's technical specification ONLY
+  Reads:  elephant-build/SKILL.md + references (MANDATORY)
+  Output: built foundation + file list
+```
+
+Dispatch an **opus subagent** to build the architectural foundation. The Elephant receives ONLY the Swan's specification — not the Eagle's vision doc or Crow's challenges. The spec is the single source of truth for building.
+
+**What the Elephant builds:**
+
+- Database migrations and schema
+- Core services and business logic
+- API route skeletons with proper error handling
+- Type definitions
+- Essential tests for the foundation
+- Configuration files
+
+**Cross-cutting standards (NON-NEGOTIABLE):**
+
+- Signpost error codes on all error paths
+- Rootwork type safety at all boundaries
+- Engine-first pattern (check before duplicating)
+
+**Handoff to conductor:** File list (every file created/modified), implementation summary, any deviations from spec.
+
+**Gate check:**
+
+```bash
+pnpm install
+gw dev ci --affected --fail-fast --diagnose
+```
+
+Must compile and pass. If it fails, resume Elephant with the error.
+
+---
+
+### Phase 6: CHORUS
+
+_Dawn breaks. The architecture stands..._
+
+The conductor runs final verification and presents the summary:
+
+```bash
+gw dev ci --affected --fail-fast --diagnose
+```
 
 **Completion Report:**
 
-```markdown
-## 🌲 GATHERING ARCHITECTURE COMPLETE
+```
+🌲 GATHERING ARCHITECTURE COMPLETE
 
-### System: [Name]
+System: [Name]
 
-### Animals Mobilized
+DISPATCH LOG
+  🦅 Eagle (opus)      — [architecture designed, X ADRs written]
+  🐦‍⬛ Crow (sonnet)   — [Y challenges raised, Z resolved]
+  🦢 Swan (opus)        — [specification written, N sections]
+  🐘 Elephant (opus)    — [foundation built, M files across P packages]
 
-🦅 Eagle → 🐦‍⬛ Crow → 🦢 Swan → 🐘 Elephant
+GATE LOG
+  After Eagle:    ✅ architecture document complete
+  After Crow:     ✅ challenges resolved, design strengthened
+  After Swan:     ✅ specification complete with all sections
+  After Elephant: ✅ compiles clean, foundation tested
+  Final CI:       ✅ gw dev ci --affected passes
 
-### Architecture Decisions
+ARTIFACTS
+  Architecture: [doc path]
+  Specification: [spec path]
+  Foundation: [code locations]
+  Tests: [test locations]
 
-- **Pattern:** [e.g., Event-driven microservices]
-- **Scale Target:** [e.g., 10k concurrent users]
-- **Key Trade-offs:** [summary]
-
-### Artifacts Created
-
-- Architecture Overview (`docs/architecture/[system].md`)
-- Technical Specification (`docs/specs/[system]-spec.md`)
-- ADRs ([list])
-- Foundation Code ([location])
-- Base Tests ([location])
-
-### Ready for
-
-- Feature development on this foundation
-- Team onboarding using the spec
-- Future architecture reviews
-
-### Time Elapsed
-
-[Duration]
-
-_The forest has a new landmark._ 🌲
+The forest has a new landmark.
 ```
 
 ---
 
-## Example Gathering
+## Conductor Rules
 
-**User:** "/gathering-architecture Design the notification system"
+### Never Do Animal Work
 
-**Gathering execution:**
+The conductor dispatches. It does not design, challenge, specify, or build.
 
-1. 🌲 **SUMMON** — "Mobilizing for: Notification system. Send email, push, SMS to users. Scale: millions of notifications/day."
+### Fresh Eyes Are a Feature
 
-2. 🌲 **ORGANIZE** — "Sequence: Eagle (architecture) → Crow (challenge) → Swan (spec) → Elephant (foundation)"
+Crow sees only the architecture document, not Eagle's reasoning. Elephant sees only Swan's spec, not the debate history. This isolation produces better results at every stage.
 
-3. 🌲 **EXECUTE** —
-   - 🦅 Eagle: "Event-driven: App emits events → Queue → Workers → Providers. Scales horizontally."
-   - 🐦‍⬛ Crow: "Red Team mode. Challenged: operational complexity for small team, eventual consistency with account deletion, microservice gravity. Strengthened: modular monolith with clean service boundary, extract later."
-   - 🦢 Swan: "Complete spec incorporating Crow's strengthened position, with flow diagrams, API contracts, provider adapter interface"
-   - 🐘 Elephant: "Event bus, queue infrastructure, base notification service, database schema"
+### Gate Every Transition
 
-4. 🌲 **VALIDATE** — "Architecture handles scale, spec complete, foundation tested"
+Verify output between every animal. Architecture must be complete before challenge. Challenges must be resolved before specification. Spec must be complete before building.
 
-5. 🌲 **COMPLETE** — "Notification platform ready for feature development"
+### Resume, Don't Restart
+
+If a gate check fails or Crow reveals fundamental design issues, **resume** the relevant agent. Don't spawn new ones.
+
+---
+
+## Anti-Patterns
+
+**The conductor does NOT:**
+
+- Design architecture itself (dispatch Eagle)
+- Soften Crow's challenges (pass them to Eagle unfiltered)
+- Let Elephant see the design debate (only the final spec)
+- Skip the Crow phase ("the design looks fine")
+- Let agents skip reading their skill file
+- Continue after a gate failure
+
+---
+
+## Quick Decision Guide
+
+| Scope                            | Strategy                                        |
+| -------------------------------- | ----------------------------------------------- |
+| New system, full design needed   | All four: Eagle → Crow → Swan → Elephant        |
+| Spec exists, need implementation | Elephant only (with spec as input)              |
+| Design review, no implementation | Eagle → Crow → Swan (skip Elephant)             |
+| Quick design, team will build    | Eagle → Crow (skip Swan + Elephant)             |
+| Large foundation (20+ files)     | Multi-Elephant dispatch (see gathering-feature) |
 
 ---
 

--- a/.claude/skills/gathering-architecture/references/conductor-dispatch.md
+++ b/.claude/skills/gathering-architecture/references/conductor-dispatch.md
@@ -1,0 +1,334 @@
+# Gathering Architecture — Conductor Dispatch Reference
+
+Each animal is dispatched as a subagent with a specific prompt, model, and input. The conductor fills the templates below, verifies gate checks, and manages handoffs.
+
+---
+
+## Dispatch Template (Common Structure)
+
+Every subagent prompt follows this structure:
+
+```
+You are the {ANIMAL} in an architecture gathering.
+
+BEFORE DOING ANYTHING: Read your skill file at `.claude/skills/{skill-name}/SKILL.md`.
+If it has references/, read those too. Follow your skill's workflow exactly.
+
+## Your Mission
+{mission}
+
+## Your Input
+{structured_input}
+
+## Constraints
+- You MUST read your skill file first — it defines your workflow
+- {animal_specific_constraints}
+- Use `gw` for all git operations, `gf` for codebase search
+- Infrastructure: prefer Server SDK abstractions (GroveDatabase, GroveStorage, GroveKV)
+- Boundaries: use Rootwork utilities (parseFormData, safeJsonParse) at trust boundaries
+
+## Output Format
+When complete, provide a structured summary:
+- {animal_specific_output}
+```
+
+---
+
+## 1. Eagle Dispatch
+
+**Model:** `opus`
+**Subagent type:** `general-purpose`
+
+```
+You are the EAGLE in an architecture gathering. Your job: design the system architecture from 10,000 feet.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/eagle-architect/SKILL.md` and its references/.
+Follow the full SOAR → SURVEY → MAP → BLUEPRINT → LAND workflow.
+
+## Your Mission
+Design the architecture for this system:
+
+{system_spec}
+
+## Constraints
+- You MUST read your skill file first
+- Design for the CURRENT requirements — not hypothetical futures
+- Prefer simplicity (modular monolith > microservices for small teams)
+- Use Server SDK infrastructure abstractions for portability
+- Consider Cloudflare-first: Workers, D1 (SQLite), KV, R2
+- Use `gf` to explore existing architecture patterns in the codebase
+
+## Output Format
+ARCHITECTURE OVERVIEW:
+- System name: [name + nature metaphor]
+- Problem statement: [what this solves]
+- System boundaries: [what's inside, what's outside]
+- Components: [each with responsibility + interactions]
+- Data flow: [how data moves through the system]
+- Technology choices: [with rationale]
+- Scale constraints: [current + growth]
+- ADRs: [key decisions with trade-offs]
+- Risks: [known unknowns]
+```
+
+**Gate check after return:**
+
+- Architecture document has system boundaries? ✅/❌
+- Components defined with clear responsibilities? ✅/❌
+- ADRs include trade-offs (not just decisions)? ✅/❌
+- Technology choices have rationale? ✅/❌
+
+If incomplete, resume Eagle with specific questions.
+
+---
+
+## 2. Crow Dispatch
+
+**Model:** `sonnet`
+**Subagent type:** `general-purpose`
+
+```
+You are the CROW in an architecture gathering. Your job: challenge this design before it's cast in code.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/crow-reason/SKILL.md`.
+Execute in RED TEAM mode — your job is to find weaknesses.
+
+## Your Mission
+Challenge this architecture. Find what's wrong, what's missing, and what will break.
+
+## Architecture to Challenge
+{architecture_document}
+
+## Challenge Domains
+- Assumptions: What is assumed but not proven?
+- Failure modes: What happens when components fail? Are there single points of failure?
+- Complexity: Is this simpler than it could be? Is a small team going to drown in operational overhead?
+- Scale: Do the scale claims hold? What breaks at 10x?
+- Security: Are there obvious security gaps in the architecture?
+- Alternatives: Was a simpler approach considered and dismissed too quickly?
+- Operational cost: What's the day-to-day burden of running this?
+
+## Constraints
+- You MUST read your skill file first
+- Be ADVERSARIAL. Don't praise — challenge.
+- Every challenge must have a SPECIFIC recommendation (not just "consider this")
+- Prioritize challenges by severity
+- Do NOT design a replacement — strengthen this one
+
+## Output Format
+ROOST SUMMARY:
+- Critical challenges: [issues that could sink the project]
+- Important challenges: [issues that will cause pain if unaddressed]
+- Minor concerns: [things to watch but not block on]
+- For each challenge:
+  - What: [the problem]
+  - Why it matters: [impact]
+  - Recommendation: [specific action to take]
+- Strengths acknowledged: [2-3 things the design gets right]
+```
+
+**IMPORTANT:** The Crow receives the **architecture document only** — NOT the Eagle's internal reasoning or decision process. The Crow should challenge the design on its merits, not be persuaded by the architect's justifications.
+
+**Gate check after return:**
+
+- Crow produced specific, actionable challenges? ✅/❌
+- Challenges include recommendations (not just concerns)? ✅/❌
+- Critical challenges identified (or explicitly none found)? ✅/❌
+
+**If critical challenges found:** Resume Eagle with the challenges. Eagle revises. Optionally resume Crow for re-challenge (max 2 Eagle-Crow iterations).
+
+---
+
+## 3. Swan Dispatch
+
+**Model:** `opus`
+**Subagent type:** `general-purpose`
+
+```
+You are the SWAN in an architecture gathering. Your job: write the definitive technical specification.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/swan-design/SKILL.md` and its references/.
+Follow the full GLIDE → FORM → REFINE → PRESENT → APPROVE workflow.
+
+## Your Mission
+Write a complete technical specification for this system.
+
+## Strengthened Architecture
+{architecture_document_with_resolved_challenges}
+
+## Challenge Resolution
+{crow_challenges_and_how_they_were_resolved}
+
+## What You MUST Produce
+A specification document written to an appropriate file path with:
+1. API contracts (endpoints, request/response formats, error codes)
+2. Database schema (tables, relationships, indexes, migration plan)
+3. Flow diagrams (key operations, error flows, auth flows)
+4. Implementation checklist (ordered by dependency)
+5. Error handling patterns (which Signpost catalog, which helpers)
+6. Configuration requirements (env vars, secrets, wrangler.toml)
+7. Testing strategy (what to test, how)
+
+## Constraints
+- You MUST read your skill file first
+- Write in Grove voice: warm, clear, welcoming
+- Specification MUST be written to an actual file — not just in your response
+- Use ASCII art for diagrams (not external tools)
+- Every API endpoint must specify its error codes
+- Database schema must include indexes and constraints
+- Use `gf` to check existing spec formats in docs/specs/
+
+## Output Format
+SPECIFICATION REPORT:
+- Spec file: [path where spec was written]
+- Sections completed: [list]
+- API endpoints: [count]
+- Database tables: [count]
+- Flow diagrams: [count]
+- Implementation checklist items: [count]
+```
+
+**Gate check after return:**
+
+- Spec file exists with actual content? ✅/❌
+- API contracts include error codes? ✅/❌
+- Database schema includes indexes? ✅/❌
+- Implementation checklist is ordered by dependency? ✅/❌
+
+If missing sections, resume Swan.
+
+---
+
+## 4. Elephant Dispatch
+
+**Model:** `opus`
+**Subagent type:** `general-purpose`
+
+```
+You are the ELEPHANT in an architecture gathering. Your job: build the architectural foundation.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/elephant-build/SKILL.md` and its references/.
+Follow the full TRUMPET → GATHER → BUILD → TEST → CELEBRATE workflow.
+
+## Your Mission
+Build the foundation for this system from the specification:
+
+{specification_document_path}
+
+Read the specification file at that path. It is your single source of truth.
+
+## Cross-Cutting Standards (NON-NEGOTIABLE)
+- ALL error paths use Signpost codes: buildErrorJson (API), throwGroveError (pages)
+- ALL form inputs validated with parseFormData() + Zod schema
+- ALL JSON/KV reads use safeJsonParse() with Zod schema
+- ALL catch blocks use isRedirect()/isHttpError() type guards
+- NO `as any` or unsafe casts at trust boundaries
+- Engine-first: check @autumnsgrove/lattice before creating utilities
+- Reference: AgentUsage/error_handling.md, AgentUsage/rootwork_type_safety.md
+
+## Constraints
+- You MUST read your skill file first
+- Build ONLY what the specification demands
+- Follow the implementation checklist order from the spec
+- Create test stubs but do NOT write full test suites
+- Use `gw` for all git operations, `gf` for codebase search
+
+## Output Format
+BUILD MANIFEST:
+- Files created: [list with paths]
+- Files modified: [list with paths + summary]
+- Database migrations: [files]
+- API endpoints: [routes implemented]
+- Key decisions: [any deviations from spec, with rationale]
+- Open questions: [anything unresolved]
+```
+
+**Gate check after return:**
+
+```bash
+pnpm install
+gw dev ci --affected --fail-fast --diagnose
+```
+
+Must compile and pass. If it fails, resume the Elephant with the error.
+
+---
+
+## Handoff Data Formats
+
+### Architecture Document (Eagle → Crow)
+
+```
+SYSTEM: [name]
+BOUNDARIES: [inside/outside]
+COMPONENTS: [list with responsibilities]
+DATA_FLOW: [description]
+TECHNOLOGY: [choices with rationale]
+ADRS: [decisions with trade-offs]
+```
+
+Note: Crow receives the document only. NOT Eagle's reasoning.
+
+### Strengthened Architecture (Eagle + Crow → Swan)
+
+```
+ARCHITECTURE: [Eagle's document]
+CHALLENGES_RESOLVED: [Crow's findings + how they were addressed]
+RISKS_ACCEPTED: [Crow's findings accepted as known risks]
+```
+
+### Specification Path (Swan → Elephant)
+
+```
+SPEC_FILE: [path to specification document]
+```
+
+The Elephant reads the spec file directly. It doesn't receive the Eagle-Crow debate.
+
+---
+
+## Eagle-Crow Iteration
+
+When Crow raises critical challenges:
+
+### Resume Eagle for Revision
+
+```
+The Crow has challenged your architecture. These critical issues need addressing:
+
+CRITICAL CHALLENGES:
+{crow_critical_challenges}
+
+Please revise your architecture to address these specific challenges.
+Do NOT rewrite from scratch — strengthen what you have.
+
+Provide:
+- Revised architecture document
+- For each challenge: how you addressed it or why it's an accepted risk
+```
+
+### Resume Crow for Re-Challenge (optional)
+
+```
+The Eagle has revised the architecture based on your challenges.
+
+REVISIONS:
+{eagle_revisions}
+
+Re-evaluate ONLY the revised sections. Are the fixes sound? Any new concerns?
+```
+
+Maximum 2 Eagle-Crow iterations. If unresolved, escalate to human.
+
+---
+
+## Error Recovery
+
+| Failure                           | Action                                                              |
+| --------------------------------- | ------------------------------------------------------------------- |
+| Eagle produces vague architecture | Resume with: "Specify system boundaries and component interactions" |
+| Crow produces vague challenges    | Resume with: "Each challenge needs a specific recommendation"       |
+| Swan writes stub spec             | Resume with: "Specification must have real content in all sections" |
+| Elephant deviates from spec       | Check if deviation is justified; if not, resume with spec section   |
+| Gate check fails (CI broken)      | Resume Elephant with error output                                   |
+| Crow finds fundamental flaw       | Resume Eagle with finding, iterate (max 2 cycles)                   |

--- a/.claude/skills/gathering-migration/SKILL.md
+++ b/.claude/skills/gathering-migration/SKILL.md
@@ -5,7 +5,7 @@ description: The drum sounds. Bear and Bloodhound gather for safe migration. Use
 
 # Gathering Migration 🌲🐻🐕
 
-The drum echoes through the valleys. The Bloodhound sniffs the terrain first, understanding every path, connection, and dependency. Then the Bear wakes from long slumber, gathering strength for the journey ahead. Together they move mountains safely — nothing lost, nothing broken, everything finding its new home. Whether it's database tables, component APIs, icon libraries, or document formats, no single animal can both map the territory AND carry the load.
+The drum echoes through the valleys. The conductor stands at the pass, orchestrating two very different strengths. The Bloodhound arrives first with fresh eyes — no assumptions about what's connected, just a nose for dependencies. Then the Bear wakes, receiving a map it didn't draw — no shortcuts, no "I already know where things are." Together they move mountains safely, each with isolated context, each trusting only what it verified itself.
 
 ## When to Summon
 
@@ -15,58 +15,36 @@ The drum echoes through the valleys. The Bloodhound sniffs the terrain first, un
 - Component or API migrations spanning many files
 - Icon, asset, or content migrations with downstream dependencies
 - Any migration where you need to understand the territory before moving
-- User says "migrate" and the scope touches multiple files or systems
-- User calls `/gathering-migration`
 
----
-
-## Grove Tools for This Gathering
-
-Use `gw` and `gf` throughout. Quick reference:
-
-```bash
-# Find references, dependencies, and affected code
-gf --agent search "pattern"       # Find references to affected items
-gf grep "import.*OldThing"        # Track imports and usage
-
-# Commit completed migrations
-gw git ship --write -a -m "feat: migrate description"
-```
+**IMPORTANT:** This gathering is a **conductor**. It never scouts or migrates directly. It dispatches subagents — one per animal — each with isolated context and an intentional model. The conductor only manages handoffs and gate checks.
 
 ---
 
 ## The Gathering
 
 ```
-SUMMON → ORGANIZE → EXECUTE → VALIDATE → COMPLETE
-   ↓         ↲          ↲          ↲          ↓
-Receive  Dispatch   Animals    Verify   Migration
-Request  Animals    Work       Results  Complete
+SUMMON → DISPATCH → GATE → DISPATCH → GATE → VERIFY
+  ↓         ↓        ↓        ↓        ↓        ↓
+Spec    Bloodhound  Check    Bear    Check    Final
+(self)   (haiku)     ✓     (opus)    ✓     Verify
 ```
 
-### Animals Mobilized
+### Animals Dispatched
 
-1. **🐕 Bloodhound** (`bloodhound-scout`) — Scout the codebase, map dependencies and relationships
-2. **🐻 Bear** (`bear-migrate`) — Migrate with patient strength using the appropriate domain guide
+| Order | Animal        | Model | Role                              | Fresh Eyes?                                         |
+| ----- | ------------- | ----- | --------------------------------- | --------------------------------------------------- |
+| 1     | 🐕 Bloodhound | haiku | Scout dependencies, map territory | Yes — sees only the migration spec                  |
+| 2     | 🐻 Bear       | opus  | Execute migration safely          | Yes — sees only territory map, not scouting process |
 
-### Dependencies
-
-```
-Bloodhound ──→ Bear
-     │            │
-Scout          Migrate
-Territory      Safely
-```
-
-Bloodhound must complete before Bear. The territory map becomes the Bear's migration plan.
+**Reference:** Load `references/conductor-dispatch.md` for exact subagent prompts and handoff formats
 
 ---
 
 ### Phase 1: SUMMON
 
-*The drum sounds. The animals gather at the clearing...*
+_The drum sounds. The valley listens..._
 
-Receive and parse the request:
+The conductor receives the migration request and prepares the dispatch plan:
 
 **Clarify the Migration:**
 
@@ -75,80 +53,85 @@ Receive and parse the request:
 - What downstream dependencies exist?
 - What does "undo" look like if something goes wrong?
 
-**Scope Check:**
+**Determine the Bear's domain guide:**
 
-> "I'll mobilize a migration gathering for: **[migration description]**
->
-> This will involve:
->
-> - 🐕 Bloodhound scouting the codebase
->   - Map dependencies and relationships
->   - Find all references to affected items
->   - Identify integration points and edge cases
->   - Document current patterns
-> - 🐻 Bear migrating with the appropriate domain guide
->   - Preserve original state before touching anything
->   - Transform in manageable chunks
->   - Validate after each phase
->   - Verify complete migration
->
-> Proceed with the gathering?"
+| Migration Type                         | Domain Guide           |
+| -------------------------------------- | ---------------------- |
+| Database schema, tables, D1/SQLite     | `domain-database.md`   |
+| Component props, API upgrades, imports | `domain-components.md` |
+| Icons, assets, documents, file formats | `domain-content.md`    |
+| Config, conventions, dependencies      | `domain-general.md`    |
+
+**Confirm with the human, then proceed.**
+
+**Output:** Migration specification, domain guide identified, dispatch plan confirmed.
 
 ---
 
-### Phase 2: ORGANIZE
+### Phase 2: SCOUT (Bloodhound)
 
-*The animals prepare for the journey...*
+_The conductor signals. The Bloodhound puts its nose to the ground..._
 
-Dispatch in sequence:
+```
+Agent(bloodhound, model: haiku)
+  Input:  migration specification only
+  Reads:  bloodhound-scout/SKILL.md (MANDATORY)
+  Output: territory map
+```
 
-- Bloodhound begins scouting: find every reference, dependency, and edge case
-- Bear waits for the territory map before waking
-- Determine which Bear domain guide applies (database, components, content, or general)
+Dispatch a **haiku subagent** to scout the codebase. The Bloodhound receives ONLY the migration specification — no pre-analysis, no assumptions. It reads its own skill file and executes its full SCENT → TRACK → HUNT → REPORT → RETURN workflow.
 
-**Handoff protocol:** Bloodhound produces a territory map → Bear uses it as its WAKE/GATHER foundation
+**What the Bloodhound maps:**
 
-**Output:** Scout dispatched, domain guide identified
+- Every reference to the items being migrated
+- Dependency relationships (what depends on what)
+- Downstream consumers
+- Edge cases and unusual usage patterns
+- Current state counts (how many items, how many references)
 
----
+**Handoff to conductor:** Territory map (affected files, dependency graph, edge cases, current state counts, risk assessment).
 
-### Phase 3: EXECUTE
-
-*The paths are known. The migration begins...*
-
-Execute each animal's full workflow by loading their dedicated skill:
-
----
-
-**🐕 BLOODHOUND — SCOUT**
-
-Load skill: `bloodhound-scout`
-
-Execute the full Bloodhound SCENT → TRACK → HUNT → REPORT → RETURN workflow focused on the migration target: find every reference, map relationships, identify edge cases, and document the current state.
-
-Handoff: complete territory map (dependency map, affected files, edge cases, risk assessment) → Bear
+**Gate check:** Territory map has: file lists, dependency relationships, item counts, edge cases identified. If incomplete, resume Bloodhound with specific questions.
 
 ---
 
-**🐻 BEAR — MIGRATE**
+### Phase 3: MIGRATE (Bear)
 
-Load skill: `bear-migrate`
+_The Bear wakes. It receives a map it didn't draw..._
 
-Execute the full Bear WAKE → GATHER → MOVE → HIBERNATE → VERIFY workflow, using:
-- The Bloodhound's territory map as the migration plan foundation
-- The appropriate domain guide from `bear-migrate/references/`:
-  - `domain-database.md` — for schema changes, table migrations, D1/SQLite
-  - `domain-components.md` — for prop changes, API upgrades, import rewrites
-  - `domain-content.md` — for icons, assets, documents, file formats
-  - `domain-general.md` — for config, conventions, dependencies, anything else
+```
+Agent(bear, model: opus)
+  Input:  migration spec + territory map (from Bloodhound)
+  Reads:  bear-migrate/SKILL.md + references/{domain-guide} (MANDATORY)
+  Output: migration results + file list
+```
 
-Handoff: migration complete (transformed items, validation reports, updated codebase) → VALIDATE phase
+Dispatch an **opus subagent** to execute the migration. The Bear receives the spec and the Bloodhound's territory map — NOT the Bloodhound's scouting process, just its structured output.
+
+**What the Bear does:**
+
+- Preserve original state (branch, backup, or snapshot)
+- Execute migration in manageable chunks
+- Validate after each chunk
+- Verify item counts match (source vs destination)
+- Run integrity checks (references resolve, imports work, no orphans)
+
+**Handoff to conductor:** Migration results (items migrated, items skipped, validation reports), file list.
+
+**Gate check:**
+
+```bash
+pnpm install
+gw dev ci --affected --fail-fast --diagnose
+```
+
+Must compile and pass. If it fails, resume Bear with the error.
 
 ---
 
-### Phase 4: VALIDATE
+### Phase 4: VERIFY
 
-*The journey ends. Both animals confirm safe arrival...*
+_The journey ends. The conductor confirms safe arrival..._
 
 **Validation Checklist:**
 
@@ -158,118 +141,78 @@ Handoff: migration complete (transformed items, validation reports, updated code
 - [ ] Bear: Original state preserved (branch, backup, or snapshot)
 - [ ] Bear: Item counts match (source vs destination)
 - [ ] Bear: Integrity checks pass (references resolve, imports work, no orphans)
-- [ ] Bear: Spot check confirms transformation correctness
-- [ ] Bear: Tests pass (`gw ci --affected` or relevant suite)
-- [ ] Bear: Rollback verified or documented
-
-**Domain-Specific Checks:**
-
-The Bear's domain guide (loaded in EXECUTE) defines the specific verification patterns — SQL queries for databases, `svelte-check` for components, visual inspection for icons, etc. Defer to the domain guide rather than hardcoding checks here.
-
----
-
-### Phase 5: COMPLETE
-
-*The gathering disperses. Everything found its new home...*
+- [ ] Bear: Tests pass (`gw dev ci --affected`)
+- [ ] Bear: Rollback path documented
 
 **Completion Report:**
 
-```markdown
-## 🌲 GATHERING MIGRATION COMPLETE
+```
+🌲 GATHERING MIGRATION COMPLETE
 
-### Migration: [Description]
+Migration: [Description]
 
-### Animals Mobilized
+DISPATCH LOG
+  🐕 Bloodhound (haiku) — [territory mapped, X files identified, Y dependencies found]
+  🐻 Bear (opus)         — [Z items migrated, domain guide: {guide}]
 
-🐕 Bloodhound → 🐻 Bear
+GATE LOG
+  After Bloodhound: ✅ territory map complete
+  After Bear:       ✅ compiles clean, migration verified
+  Final CI:         ✅ gw dev ci --affected passes
 
-### Territory Mapped (Bloodhound)
+MIGRATION RESULTS
+  Items migrated: [count]
+  Items skipped: [count, reason]
+  Item count match: ✅ [source] = [dest]
+  Integrity checks: ✅
+  Rollback: [branch/backup location]
 
-- Items affected: [count] [type]
-- Dependencies found: [count]
-- Files referencing migrated items: [count]
-- Edge cases identified: [list]
-
-### Migration Executed (Bear)
-
-- Domain guide used: [database / components / content / general]
-- Items migrated: [count]
-- Items skipped (intentional): [count] — [reason]
-- Duration: [time]
-- Errors: [count]
-
-### Validation Results
-
-- Item count match: ✅ [source] = [dest]
-- Integrity checks: ✅
-- Tests passing: ✅ [suite]
-- Spot check: ✅ [N samples verified]
-
-### Rollback Status
-
-- Original preserved at: [branch / backup / snapshot]
-- Rollback path: [how to undo]
-
-### Files Updated
-
-- [list of changed files or summary]
-
-_Everything found its new home._ 🌲
+Everything found its new home.
 ```
 
 ---
 
-## Examples
+## Conductor Rules
 
-### Example 1: Database Migration
+### Never Do Animal Work
 
-**User:** "/gathering-migration Move user preferences from users table to separate table"
+The conductor dispatches. It does not scout dependencies or execute migrations.
 
-**Gathering flow:**
+### Fresh Eyes Are a Feature
 
-1. 🌲 **SUMMON** — "Mobilizing for: Split user preferences. Move theme, notifications from users table to user_preferences table."
+The Bear receives the territory map, not the Bloodhound's scouting process. It trusts the map but verifies what it finds during migration.
 
-2. 🌲 **ORGANIZE** — "Bloodhound scouts → Bear migrates with `domain-database.md`"
+### Gate Every Transition
 
-3. 🌲 **EXECUTE** —
-   - 🐕 Bloodhound: "Found 15,423 users. 234 have theme set. 12 have notifications disabled. Referenced in dashboard, settings, 3 API routes."
-   - 🐻 Bear: "Backup created. Migrated in 16 batches. All rows accounted for. FK constraints maintained."
+Territory map must be complete before Bear starts. CI must pass after Bear finishes.
 
-4. 🌲 **VALIDATE** — "15,423 source = 15,423 dest. No orphans. All tests pass."
+### Resume, Don't Restart
 
-5. 🌲 **COMPLETE** — "Preferences migrated. Code updated. Backup retained."
-
-### Example 2: Icon System Migration
-
-**User:** "/gathering-migration Migrate all inline Lucide icon imports to use the icon registry pattern"
-
-**Gathering flow:**
-
-1. 🌲 **SUMMON** — "Mobilizing for: Icon import migration. Replace per-file Lucide imports with centralized icon registry lookups."
-
-2. 🌲 **ORGANIZE** — "Bloodhound scouts icon usage → Bear migrates with `domain-content.md`"
-
-3. 🌲 **EXECUTE** —
-   - 🐕 Bloodhound: "Found 47 files importing from @lucide/svelte. 31 unique icons used. 3 files use dynamic icon selection. 2 barrel re-exports in ui/index.ts."
-   - 🐻 Bear: "Feature branch created. Migrated 44 files to registry pattern. 3 dynamic-icon files handled manually. All svelte-check passes."
-
-4. 🌲 **VALIDATE** — "47 source files, 44 migrated + 3 manual = 47 accounted. Zero remaining @lucide/svelte imports. Visual spot check on 5 pages — all icons render."
-
-5. 🌲 **COMPLETE** — "Icon registry migration complete. Bundle size reduced. Branch ready for review."
+If a gate check fails, resume the failing agent. The Bear especially benefits from resumption — it has the migration context and can fix issues faster than starting fresh.
 
 ---
 
-## Integration with Other Gatherings
+## Anti-Patterns
 
-**Precedes:** `gathering-feature` — Migrations often unblock new features built on the new pattern
+**The conductor does NOT:**
 
-**Follows:** `gathering-architecture` — Architecture decisions often require migrations to implement
-
-**Animals available for extension:**
-- `beaver-build` — Add regression tests after migration
-- `fox-optimize` — Profile performance if migration touches hot paths
-- `deer-sense` — Audit accessibility if migrating UI components
+- Scout the codebase itself
+- Execute migration steps directly
+- Let Bear start without a complete territory map
+- Skip count validation (source must equal destination)
+- Skip rollback documentation
 
 ---
 
-*When no single animal suffices, the gathering answers.* 🌲🐾
+## Quick Decision Guide
+
+| Migration Scope                      | Strategy                                 |
+| ------------------------------------ | ---------------------------------------- |
+| Simple rename (< 5 files)            | Bear only (no Bloodhound needed)         |
+| Cross-cutting migration (5-50 files) | Standard: Bloodhound → Bear              |
+| Large migration (50+ files)          | Bloodhound → Bear with chunked execution |
+| Unknown scope ("migrate X")          | Always start with Bloodhound             |
+
+---
+
+_When no single animal suffices, the gathering answers._ 🌲🐾

--- a/.claude/skills/gathering-migration/references/conductor-dispatch.md
+++ b/.claude/skills/gathering-migration/references/conductor-dispatch.md
@@ -1,0 +1,164 @@
+# Gathering Migration — Conductor Dispatch Reference
+
+Each animal is dispatched as a subagent with a specific prompt, model, and input. The conductor fills the templates below, verifies gate checks, and manages handoffs.
+
+---
+
+## 1. Bloodhound Dispatch
+
+**Model:** `haiku`
+**Subagent type:** `general-purpose`
+
+```
+You are the BLOODHOUND in a migration gathering. Your job: scout the codebase and map every dependency.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/bloodhound-scout/SKILL.md`.
+Follow the full SCENT → TRACK → HUNT → REPORT → RETURN workflow.
+
+## Your Mission
+Scout the codebase to map the territory for this migration:
+
+{migration_spec}
+
+## What to Map
+- Every reference to the items being migrated (imports, usages, type references)
+- Dependency relationships (what depends on what, in what order)
+- Downstream consumers (who will break if migration is incomplete)
+- Edge cases (unusual usage patterns, dynamic references, barrel exports)
+- Current state counts (how many items exist, how many files reference them)
+- Test files that reference migrated items
+
+## Constraints
+- READ-ONLY. Do not create or modify any files.
+- Use `gf` commands for all codebase search.
+- Be EXHAUSTIVE — a missed reference means a broken migration.
+- Count everything. The Bear will use your counts to verify completeness.
+
+## Output Format
+TERRITORY MAP:
+- Items to migrate: [count, list]
+- Files referencing migrated items: [count, list with paths]
+- Dependency order: [what must migrate first]
+- Edge cases: [unusual patterns that need special handling]
+- Current state counts: [items: N, references: M, test files: P]
+- Risk assessment: [what could go wrong]
+- Suggested migration chunks: [how to split the work safely]
+```
+
+**Gate check after return:**
+
+- Territory map has item counts? ✅/❌
+- All references found (not just first few)? ✅/❌
+- Dependency order specified? ✅/❌
+- Edge cases identified? ✅/❌
+
+If incomplete, resume Bloodhound with: "You found X references but the codebase likely has more. Check {specific locations}."
+
+---
+
+## 2. Bear Dispatch
+
+**Model:** `opus`
+**Subagent type:** `general-purpose`
+
+```
+You are the BEAR in a migration gathering. Your job: execute the migration safely.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/bear-migrate/SKILL.md` and `references/{domain_guide}`.
+Follow the full WAKE → GATHER → MOVE → HIBERNATE → VERIFY workflow.
+
+## Your Mission
+Execute this migration:
+
+{migration_spec}
+
+## Territory Map (from Bloodhound scout)
+{territory_map}
+
+## Domain Guide
+Use the `{domain_guide}` reference from your skill for domain-specific patterns.
+
+## Migration Rules (NON-NEGOTIABLE)
+- PRESERVE original state before touching anything (document the rollback path)
+- MIGRATE in the dependency order the Bloodhound specified
+- VALIDATE counts after each chunk: migrated + skipped must equal source count
+- VERIFY integrity: all imports resolve, no orphaned references, tests still pass
+- STOP if counts don't match — investigate before continuing
+
+## Cross-Cutting Standards
+- Use Signpost error codes if adding/modifying error paths
+- Use Rootwork utilities at trust boundaries
+- Engine-first: import from @autumnsgrove/lattice before creating utilities
+- Use `gw` for all git operations, `gf` for codebase search
+
+## Constraints
+- You MUST read your skill file and domain guide first
+- Follow the Bloodhound's territory map — it found the references, trust the map
+- If you find references the Bloodhound missed, migrate them AND note them
+- Do NOT skip items without documenting why
+
+## Output Format
+MIGRATION REPORT:
+- Items migrated: [count]
+- Items skipped: [count, with reasons for each]
+- Missed references found: [any the Bloodhound didn't catch]
+- Count validation: source=[N], migrated=[M], skipped=[S], M+S=[N]? ✅/❌
+- Integrity checks: imports resolve? ✅/❌, tests pass? ✅/❌, no orphans? ✅/❌
+- Rollback path: [how to undo this migration]
+- Files created: [list with paths]
+- Files modified: [list with paths + summary]
+- Files deleted: [list with paths, if any]
+```
+
+**Gate check after return:**
+
+```bash
+pnpm install
+gw dev ci --affected --fail-fast --diagnose
+```
+
+Must compile and pass. Count validation must show source = migrated + skipped.
+
+If CI fails, resume Bear with the error output.
+If counts don't match, resume Bear with: "Count mismatch: source={N} but migrated+skipped={M+S}. Find the missing items."
+
+---
+
+## Handoff Data Formats
+
+### Territory Map (Bloodhound → Bear)
+
+```
+ITEMS_TO_MIGRATE: [count, list]
+FILES_AFFECTED: [count, paths]
+DEPENDENCY_ORDER: [what migrates first → last]
+EDGE_CASES: [unusual patterns]
+COUNTS: items=[N], references=[M], tests=[P]
+SUGGESTED_CHUNKS: [how to split]
+```
+
+The Bear receives this structured output. NOT the Bloodhound's scouting reasoning.
+
+### Migration Report (Bear → conductor)
+
+```
+MIGRATED: [count]
+SKIPPED: [count, reasons]
+COUNT_MATCH: ✅/❌
+INTEGRITY: ✅/❌
+ROLLBACK: [path/method]
+FILES: [created, modified, deleted]
+```
+
+---
+
+## Error Recovery
+
+| Failure                             | Action                                                           |
+| ----------------------------------- | ---------------------------------------------------------------- |
+| Bloodhound misses references        | Bear finds them during migration — note in report                |
+| Bear's count doesn't match          | Resume Bear: "Find the missing items at {suggested locations}"   |
+| CI fails after migration            | Resume Bear with error output                                    |
+| Bear finds structural issue         | Pause migration, escalate to human for architectural decision    |
+| Migration too large for one session | Bear documents progress, conductor resumes later with checkpoint |
+| Agent doesn't read skill file       | Resume with: "You MUST read your skill file first"               |

--- a/.claude/skills/gathering-security/SKILL.md
+++ b/.claude/skills/gathering-security/SKILL.md
@@ -5,7 +5,7 @@ description: The drum sounds. Spider, Raccoon, and Turtle gather for complete se
 
 # Gathering Security 🌲🕷️🦝🐢
 
-The drum echoes in the shadows. The Spider weaves intricate webs of authentication, each strand placed with precision. The Raccoon rummages through every corner, finding what doesn't belong, cleaning what could harm. The Turtle moves with ancient patience, layering defense upon defense, testing every plate of the shell. Together they secure the forest — doors locked tight, secrets safe, paths protected, and the ground itself hardened against anything that comes.
+The drum echoes in the shadows. But this time, the conductor stands at the clearing's edge — not doing the work, but orchestrating it. Each animal arrives with fresh eyes, reads its own instructions, and works with full adversarial attention. The Spider weaves auth with precision. The Raccoon rummages with suspicion. The Turtle hardens with patience. Three isolated minds, zero shared sympathy, one fortress built right.
 
 ## When to Summon
 
@@ -18,37 +18,28 @@ The drum echoes in the shadows. The Spider weaves intricate webs of authenticati
 - Building a new feature that handles sensitive data
 - Hardening existing code for defense in depth
 
----
-
-## Grove Tools for This Gathering
-
-Use `gw` and `gf` throughout. Quick reference for security work:
-
-```bash
-# Find security-relevant code patterns
-gf --agent search "sanitize|escape|validate"  # Security patterns
-gf --agent auth                     # Find auth code and middleware
-
-# Verify security changes don't break anything
-gw ci --affected --diagnose         # Run CI on affected packages
-```
+**IMPORTANT:** This gathering is a **conductor**. It never writes code or fixes vulnerabilities directly. It dispatches subagents — one per animal — each with isolated context and an intentional model. The conductor only manages handoffs and gate checks.
 
 ---
 
 ## The Gathering
 
 ```
-SUMMON --> ORGANIZE --> EXECUTE --> VALIDATE --> COMPLETE
-   |          |           |           |            |
-Receive   Dispatch     Animals     Verify      Security
-Request   Animals      Work        Check       Hardened
+SUMMON → DISPATCH → GATE → DISPATCH → GATE → DISPATCH → GATE → FORTIFY
+  ↓         ↓        ↓        ↓        ↓        ↓        ↓        ↓
+Spec     Spider    Check   Raccoon   Check    Turtle   Check   Final
+(self)   (opus)     ✓     (sonnet)    ✓      (opus)    ✓     Verify
 ```
 
-### Animals Mobilized
+### Animals Dispatched
 
-1. **🕷️ Spider** — Weave authentication webs with patient precision
-2. **🦝 Raccoon** — Rummage for security risks and cleanup
-3. **🐢 Turtle** — Harden with layered, defense-in-depth protection
+| Order | Animal     | Model  | Role                            | Fresh Eyes?                                       |
+| ----- | ---------- | ------ | ------------------------------- | ------------------------------------------------- |
+| 1     | 🕷️ Spider  | opus   | Weave authentication            | Yes — sees only the security spec                 |
+| 2     | 🦝 Raccoon | sonnet | Audit secrets, vulns, dead code | Yes — sees only file list from Spider             |
+| 3     | 🐢 Turtle  | opus   | Adversarial hardening           | Yes — sees file list only, not Spider's reasoning |
+
+**Reference:** Load `references/conductor-dispatch.md` for exact subagent prompts and handoff formats
 
 ---
 
@@ -56,7 +47,7 @@ Request   Animals      Work        Check       Hardened
 
 _The drum sounds. The shadows shift..._
 
-Receive and parse the request:
+The conductor receives the security request and prepares the dispatch plan:
 
 **Clarify the Security Work:**
 
@@ -67,41 +58,8 @@ Receive and parse the request:
 - Post-incident cleanup?
 - Pre-production hardening?
 
-**Error Codes as Security Posture:**
-All errors MUST use Signpost codes — this is a security requirement, not just a convention:
-
-- All server errors use codes from the appropriate catalog (`API_ERRORS`, `AUTH_ERRORS`, etc.)
-- `userMessage` is always generic and warm — no technical details leak to clients
-- `adminMessage` is detailed — stays in server logs only
-- Auth errors NEVER reveal user existence ("Invalid credentials" — not "user not found")
-- `logGroveError()` for all server errors — never `console.error` alone
-
-**Scope Check:**
-
-> "I'll mobilize a security gathering for: **[security work]**
->
-> This will involve:
->
-> - 🕷️ Spider weaving authentication
->   - OAuth/PKCE flow
->   - Session management
->   - Route protection
->   - Token handling
-> - 🦝 Raccoon auditing security
->   - Secret scanning
->   - Vulnerability check
->   - Dependency audit
->   - Dead code removal
-> - 🐢 Turtle hardening defenses
->   - Input/output validation
->   - Security headers & CSP
->   - Defense-in-depth enforcement
->   - Exotic attack vector testing
->   - Hardening report
->
-> Proceed with the gathering?"
-
 **Selective Mobilization:**
+
 Not every gathering needs all three animals:
 
 | Situation                            | Animals Needed                                    |
@@ -112,282 +70,269 @@ Not every gathering needs all three animals:
 | Secrets leak / incident response     | Raccoon → Spider (rotate creds) → Turtle (verify) |
 | Pre-production deploy                | Raccoon → Turtle                                  |
 
+**Error Codes as Security Posture:**
+
+All errors MUST use Signpost codes — this is a security requirement, not just a convention:
+
+- All server errors use codes from the appropriate catalog (`API_ERRORS`, `AUTH_ERRORS`, etc.)
+- `userMessage` is always generic and warm — no technical details leak to clients
+- `adminMessage` is detailed — stays in server logs only
+- Auth errors NEVER reveal user existence ("Invalid credentials" — not "user not found")
+- `logGroveError()` for all server errors — never `console.error` alone
+
+**Confirm with the human, then proceed.**
+
+**Output:** Security specification, animal roster, dispatch plan confirmed.
+
 ---
 
-### Phase 2: ORGANIZE
+### Phase 2: WEAVE (Spider)
 
-_The animals take their positions in the shadows..._
-
-Dispatch in sequence:
-
-**Full Dispatch Order:**
+_The conductor signals. The Spider descends from the canopy..._
 
 ```
-Spider ──→ Raccoon ──→ Turtle
-   │          │            │
-   │          │            │
-Weave      Audit       Harden
-Auth       Secrets     Defenses
+Agent(spider, model: opus)
+  Input:  security specification only
+  Reads:  spider-weave/SKILL.md + references (MANDATORY)
+  Output: auth implementation + file list
 ```
 
-**Dependencies:**
+Dispatch an **opus subagent** to implement authentication. The Spider receives ONLY the security specification — no pre-analysis, no opinions. It reads its own skill file and executes its full workflow.
 
-- Spider must complete before Raccoon (needs auth to audit)
-- Raccoon should complete before Turtle (clean first, then harden)
-- May iterate: Turtle findings → Spider/Raccoon fixes → Turtle re-verify
+**What the Spider builds:**
 
-**Iteration Cycle (When Vulnerabilities Found):**
+- OAuth/PKCE flow implementation
+- Session management
+- Route protection middleware
+- CSRF protection
+- Token handling
+
+**Handoff to conductor:** Auth file list (every file created/modified), auth summary (what was implemented, key decisions), integration points.
+
+**Gate check:** Run `gw dev ci --affected --fail-fast` — must compile. If build fails, resume the Spider agent with error output.
+
+---
+
+### Phase 3: AUDIT (Raccoon)
+
+_The Raccoon emerges from the undergrowth, nose twitching..._
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│                   SECURITY ITERATION                              │
-├──────────────────────────────────────────────────────────────────┤
-│                                                                   │
-│  🕷️ Spider ──► 🦝 Raccoon ──► 🐢 Turtle                       │
-│  weaves auth    audits          hardens & tests                   │
-│       ▲                              │                            │
-│       │                              ▼                            │
-│       │                     Deep vulnerabilities?                 │
-│       │                        /          \                       │
-│       │                     Yes            No                     │
-│       │                      │              │                     │
-│       │         ┌────────────┘              ▼                     │
-│       │         ▼                     ✅ Hardened                 │
-│       │    Auth issue?                                            │
-│       │    /         \                                            │
-│       │  Yes          No                                          │
-│       │   │           │                                           │
-│       └───┘    Raccoon/Turtle                                   │
-│                fixes directly                                     │
-└──────────────────────────────────────────────────────────────────┘
+Agent(raccoon, model: sonnet)
+  Input:  file list from Spider + security scope summary
+  Reads:  raccoon-audit/SKILL.md (MANDATORY)
+  Output: audit report + applied fixes
+```
+
+Dispatch a **sonnet subagent** to audit the codebase. The Raccoon receives the file list and a brief scope summary — NOT the Spider's reasoning or implementation details. Fresh eyes for the audit.
+
+**What the Raccoon audits:**
+
+- Secrets in code (hardcoded keys, tokens)
+- Dependency vulnerabilities
+- Dead code and unused imports
+- Unsafe patterns (eval, innerHTML, string SQL)
+- Sensitive data in logs
+
+**Handoff to conductor:** Audit report (findings, fixes applied, remaining concerns), updated file list.
+
+**Gate check:** Run `gw dev ci --affected --fail-fast` — must still compile after audit fixes. If broken, resume Raccoon agent.
+
+---
+
+### Phase 4: HARDEN (Turtle)
+
+_The Turtle approaches. It sees only what was built — not why..._
+
+```
+Agent(turtle, model: opus)
+  Input:  combined file list ONLY (not Spider's or Raccoon's reasoning)
+  Reads:  turtle-harden/SKILL.md + references (MANDATORY)
+  Output: hardening report + applied fixes
+```
+
+Dispatch an **opus subagent** for adversarial security hardening. The Turtle receives ONLY the file list — NOT the Spider's auth decisions or Raccoon's audit reasoning. This is intentional: the Turtle should examine the code with adversarial fresh eyes, not sympathize with prior animals' reasoning.
+
+**What the Turtle hardens:**
+
+- Input validation (Zod schemas on all entry points)
+- Output encoding (context-aware, DOMPurify for rich text)
+- Parameterized queries (no string concatenation in SQL)
+- Security headers (CSP with nonces, HSTS, X-Frame)
+- Signpost error codes (verify Spider used them correctly)
+- Rootwork boundary safety (verify no `as` casts at trust boundaries)
+- Rate limiting on sensitive endpoints
+- CSRF, CORS, session security
+- Exotic attack vectors (prototype pollution, timing attacks, SSRF, race conditions)
+
+**Handoff to conductor:** Hardening report (vulnerabilities found, fixes applied, defense layers, remaining risks), updated file list.
+
+**Gate check:** Run `gw dev ci --affected --fail-fast` — must still compile after hardening.
+
+---
+
+### Phase 5: ITERATION (When Turtle Finds Deep Issues)
+
+_The cycle turns. Some vulnerabilities run deeper than one animal can fix..._
+
+```
+┌──────────────────────────────────────────────────┐
+│              SECURITY ITERATION                   │
+├──────────────────────────────────────────────────┤
+│                                                   │
+│  Turtle hardening report                          │
+│       │                                           │
+│       ▼                                           │
+│  Auth vulnerability found?                        │
+│     /          \                                  │
+│   Yes           No                                │
+│    │             │                                │
+│    ▼             ▼                                │
+│  RESUME Spider  Raccoon/Turtle                    │
+│  (same agent)   fixes directly                    │
+│    │                                              │
+│    ▼                                              │
+│  Gate check                                       │
+│    │                                              │
+│    ▼                                              │
+│  RESUME Turtle                                    │
+│  (re-verify only changed files)                   │
+│    │                                              │
+│    ▼                                              │
+│  Clean? ──→ ✅ Proceed to FORTIFY                │
+│    │                                              │
+│    No ──→ Max 3 iterations, then escalate         │
+└──────────────────────────────────────────────────┘
 ```
 
 **Iteration Rules:**
 
-- Turtle finds auth vulnerability → Spider patches → Turtle re-verifies
-- Turtle finds non-auth vulnerability → Fix directly → Turtle re-verifies
-- Raccoon finds secrets → Raccoon cleans → Turtle verifies no residual exposure
-- Maximum 3 iterations per issue (if more needed, architectural review required)
+- Turtle finds auth vulnerability → **resume** Spider agent with specific finding → Spider patches → **resume** Turtle to re-verify
+- Turtle finds non-auth vulnerability → Turtle fixes directly or conductor applies fix
+- Raccoon finds secrets → Raccoon cleans → **resume** Turtle to verify no residual exposure
+- Maximum 3 iterations per issue (if more needed, escalate to human)
 - Each iteration focuses only on newly found/fixed items
-- Document all iterations in final report
+- Always **resume** agents (preserves context), don't spawn new ones
 
 ---
 
-### Phase 3: EXECUTE
-
-_The web is woven. The audit begins. The shell hardens..._
-
-Execute each animal's phase by loading and running their dedicated skill:
-
----
-
-**🕷️ SPIDER — WEAVE**
-
-Load skill: `spider-weave`
-
-Execute the full Spider workflow for [the auth system being implemented].
-Handoff: working authentication system (OAuth flow, session management, protected routes, CSRF protection) → Raccoon for audit
-
----
-
-**🦝 RACCOON — AUDIT**
-
-Load skill: `raccoon-audit`
-
-Execute the full Raccoon workflow on the entire codebase, with particular attention to the Spider's auth implementation.
-If secrets found or auth issues discovered → Spider patches → Raccoon re-verifies.
-Handoff: clean audit report (no secrets, vulnerabilities patched, dead code removed, pre-commit hooks installed) → Turtle for hardening
-
----
-
-**🐢 TURTLE — HARDEN**
-
-Load skill: `turtle-harden`
-
-Execute the full Turtle workflow on the codebase, including auth routes, API endpoints, and data flows.
-If deep vulnerabilities found in auth → Spider patches → Turtle re-verifies. Maximum 3 iterations per issue.
-Handoff: hardening report (defense-in-depth verified, exotic vectors tested, all layers applied) → VALIDATE phase
-
----
-
-### Phase 4: VALIDATE
+### Phase 6: FORTIFY
 
 _The web holds. The audit confirms. The shell endures..._
 
+The conductor runs final verification:
+
+```bash
+pnpm install
+gw dev ci --affected --fail-fast --diagnose
+```
+
 **Validation Checklist:**
-
-- [ ] Spider: Auth flow works end-to-end
-- [ ] Spider: Routes properly protected
-- [ ] Spider: Sessions expire correctly
-- [ ] Spider: CSRF protection active
-- [ ] Raccoon: No secrets in codebase
-- [ ] Raccoon: Dependencies up to date
-- [ ] Raccoon: No sensitive data in logs
-- [ ] Raccoon: Pre-commit hooks installed
-- [ ] Turtle: Input validation on all entry points
-- [ ] Turtle: Output encoding on all exit points
-- [ ] Turtle: Security headers complete
-- [ ] Turtle: CSP enforced (nonce-based)
-- [ ] Turtle: CORS restricted to exact origins
-- [ ] Turtle: Defense-in-depth verified (2+ layers per critical function)
-- [ ] Turtle: Exotic attack vectors tested and clear
-- [ ] Turtle: Multi-tenant isolation verified (if applicable)
-
-**Rootwork Boundary Validation:**
-
-- [ ] Form data parsed with `parseFormData()`, not raw `formData.get()`
-- [ ] JSON reads validated with `safeJsonParse()`, not unsafe `as` casts
-- [ ] Caught exceptions use `isRedirect()`/`isHttpError()` type guards
-- [ ] No `as any` or `as SomeType` casts at trust boundaries
-- [ ] Schemas defined at module scope, not inside handlers
-
-**Security Test Cases:**
 
 ```
 Authentication:
-[ ] Login redirects to provider
-[ ] Callback exchanges code for tokens
-[ ] Sessions created correctly
-[ ] Logout clears sessions server-side
-[ ] Expired tokens rejected
-[ ] Session fixation prevented
+  [ ] Login redirects to provider
+  [ ] Callback exchanges code for tokens
+  [ ] Sessions created correctly
+  [ ] Logout clears sessions server-side
+  [ ] Expired tokens rejected
 
 Authorization:
-[ ] Protected routes require auth
-[ ] Admin routes check roles
-[ ] API endpoints verify tokens
-[ ] Users can't access others' data (IDOR tested)
-[ ] Horizontal escalation prevented
-[ ] Vertical escalation prevented
+  [ ] Protected routes require auth
+  [ ] API endpoints verify tokens
+  [ ] Users can't access others' data (IDOR)
 
 Hardening:
-[ ] SQL injection prevented (parameterized queries)
-[ ] XSS prevented (output encoding + CSP)
-[ ] CSRF prevented (tokens + SameSite cookies)
-[ ] File uploads sanitized (type + size + rename)
-[ ] Rate limiting active on all sensitive endpoints
-[ ] Prototype pollution vectors blocked
-[ ] Timing attacks mitigated (constant-time comparison)
-[ ] Race conditions prevented (atomic operations)
-[ ] SSRF prevented (URL allowlist, no redirect following)
+  [ ] SQL injection prevented (parameterized queries)
+  [ ] XSS prevented (output encoding + CSP)
+  [ ] CSRF prevented (tokens + SameSite cookies)
+  [ ] Rate limiting active on sensitive endpoints
+  [ ] Signpost error codes on every error path
+  [ ] Rootwork boundary safety at all trust boundaries
 ```
-
----
-
-### Phase 5: COMPLETE
-
-_The gathering ends. The forest is fortified..._
 
 **Completion Report:**
 
-```markdown
-## GATHERING SECURITY COMPLETE
+```
+🌲 GATHERING SECURITY COMPLETE
 
-### Security Work: [Description]
+Security Work: [Description]
 
-### Animals Mobilized
+DISPATCH LOG
+  🕷️ Spider (opus)    — [auth implemented, X files created/modified]
+  🦝 Raccoon (sonnet)  — [audit complete, Y findings fixed]
+  🐢 Turtle (opus)     — [Z hardening fixes, N defense layers applied]
 
-🕷️ Spider → 🦝 Raccoon → 🐢 Turtle
+GATE LOG
+  After Spider:   ✅ compiles clean, auth functional
+  After Raccoon:  ✅ compiles clean, audit findings resolved
+  After Turtle:   ✅ compiles clean, hardening applied
+  Iterations:     [N iterations, all resolved / none needed]
+  Final CI:       ✅ gw dev ci --affected passes
 
-### Authentication Implemented
+HARDENING SUMMARY
+  | Defense Layer    | Status | Details                    |
+  | Input Validation | ✅     | Zod schemas on all entry   |
+  | Output Encoding  | ✅     | Context-aware + DOMPurify  |
+  | SQL Injection    | ✅     | All queries parameterized  |
+  | Security Headers | ✅     | CSP, HSTS, X-Frame         |
+  | CORS             | ✅     | Exact origin allowlist     |
+  | Session Security | ✅     | HttpOnly, Secure, SameSite |
+  | Rate Limiting    | ✅     | Per-endpoint limits        |
 
-- **Provider:** [OAuth 2.0 / GitHub / Google / etc.]
-- **Flow:** [PKCE / Authorization Code]
-- **Session Type:** [Token / Session Cookie]
-- **Routes Protected:** [count]
-
-### Security Audit Results
-
-- Secrets found: [count] (all rotated/removed)
-- Dependencies patched: [count]
-- Dead code removed: [lines]
-- Pre-commit hooks: Installed
-
-### Hardening Applied
-
-| Defense Layer    | Status          | Details                                |
-| ---------------- | --------------- | -------------------------------------- |
-| Input Validation | [PASS/FAIL]     | Zod schemas on all endpoints           |
-| Output Encoding  | [PASS/FAIL]     | Context-aware, DOMPurify for rich text |
-| SQL Injection    | [PASS/FAIL]     | All queries parameterized              |
-| Security Headers | [PASS/FAIL]     | CSP, HSTS, X-Frame, etc.               |
-| CORS             | [PASS/FAIL]     | Exact origin allowlist                 |
-| Session Security | [PASS/FAIL]     | HttpOnly, Secure, SameSite             |
-| CSRF Protection  | [PASS/FAIL]     | Tokens + SameSite                      |
-| Rate Limiting    | [PASS/FAIL]     | Per-endpoint limits configured         |
-| Multi-Tenant     | [PASS/FAIL/N/A] | Tenant scoping verified                |
-| File Uploads     | [PASS/FAIL/N/A] | Type/size/rename enforced              |
-
-### Exotic Attack Vectors Tested
-
-| Vector              | Status        |
-| ------------------- | ------------- |
-| Prototype Pollution | [CLEAR/FOUND] |
-| Timing Attacks      | [CLEAR/FOUND] |
-| Race Conditions     | [CLEAR/FOUND] |
-| ReDoS               | [CLEAR/FOUND] |
-| SSRF                | [CLEAR/FOUND] |
-| Unicode Attacks     | [CLEAR/FOUND] |
-| Cache Poisoning     | [CLEAR/FOUND] |
-| SVG XSS             | [CLEAR/FOUND] |
-
-### Defense-in-Depth Compliance
-
-- **Layers verified:** [X/5] (Network, Application, Data, Infrastructure, Process)
-- **Critical functions with 2+ layers:** [X/Y]
-
-### Vulnerabilities Found & Fixed
-
-| Severity | Count | Status           |
-| -------- | ----- | ---------------- |
-| CRITICAL | [n]   | All fixed        |
-| HIGH     | [n]   | All fixed        |
-| MEDIUM   | [n]   | [fixed/accepted] |
-| LOW      | [n]   | [fixed/deferred] |
-
-### Files Created/Modified
-
-- Auth routes: [files]
-- Middleware: [files]
-- Configuration: [files]
-- Security tests: [files]
-
-_Woven tight, audited clean, hardened deep — the forest endures._ 🌲
+Woven tight, audited clean, hardened deep — the forest endures.
 ```
 
 ---
 
-## Example Gathering
+## Conductor Rules
 
-**User:** "/gathering-security Add GitHub OAuth, audit everything, and harden for production"
+### Never Do Animal Work
 
-**Gathering execution:**
+The conductor dispatches. It does not implement auth, audit secrets, or harden code. If you catch yourself writing security code, stop — dispatch a subagent.
 
-1. 🌲 **SUMMON** — "Mobilizing full security gathering: GitHub OAuth + audit + hardening. All three animals needed."
+### Fresh Eyes Are a Feature
 
-2. 🌲 **ORGANIZE** — "Spider implements auth → Raccoon audits for secrets/vulns → Turtle hardens everything"
+Turtle intentionally receives LESS context than the full history. It doesn't see Spider's reasoning or Raccoon's audit logic. Adversarial fresh eyes produce better security review.
 
-3. 🌲 **EXECUTE** —
-   - 🕷️ Spider: "OAuth client registered, PKCE flow implemented, sessions working, routes protected"
-   - 🦝 Raccoon: "No secrets found, 2 dependency vulns patched, dead debug endpoint removed"
-   - 🐢 Turtle: "CSP configured with nonces, CORS locked to exact origins, all inputs validated with Zod, constant-time token comparison added, prototype pollution vector in config merge fixed, defense-in-depth verified at 3 layers per critical function"
+### Gate Every Transition
 
-4. 🌲 **VALIDATE** — "Auth works, audit clean, hardening verified, all exotic vectors tested clear"
+Run CI between every animal. Don't let bad state cascade.
 
-5. 🌲 **COMPLETE** — "GitHub OAuth live, secrets clean, shell hardened. The forest endures."
+### Resume, Don't Restart
+
+If a gate check fails or iteration is needed, **resume** the failing agent with the error context. Don't spawn a new one — the resumed agent has its prior work in context.
+
+### Selective Mobilization
+
+Not every security gathering needs all three animals. Auth-only work skips Turtle. Hardening-only work skips Spider. The conductor decides based on the request.
+
+---
+
+## Anti-Patterns
+
+**The conductor does NOT:**
+
+- Write security code itself (dispatch subagents)
+- Pass full conversation history to every agent (structured handoffs only)
+- Skip gate checks between animals
+- Let agents skip reading their skill file (MANDATORY in every prompt)
+- Let Turtle see Spider's reasoning (adversarial isolation is the point)
+- Continue after a gate failure without fixing it
+- Iterate more than 3 times without escalating to human
 
 ---
 
 ## Quick Decision Guide
 
-| Situation                        | Animals to Mobilize                 |
-| -------------------------------- | ----------------------------------- |
-| New auth + full security         | Spider → Raccoon → Turtle           |
-| Auth exists, need deep hardening | Raccoon → Turtle                    |
-| New feature, secure by design    | Turtle (optionally + Raccoon)       |
-| Incident response                | Raccoon → Spider → Turtle           |
-| Pre-production deploy            | Raccoon → Turtle                    |
-| Auth-only work                   | Spider → Raccoon (no Turtle needed) |
+| Situation                        | Animals to Dispatch           | Models             |
+| -------------------------------- | ----------------------------- | ------------------ |
+| New auth + full security         | Spider → Raccoon → Turtle     | opus, sonnet, opus |
+| Auth exists, need deep hardening | Raccoon → Turtle              | sonnet, opus       |
+| New feature, secure by design    | Turtle (optionally + Raccoon) | opus (+ sonnet)    |
+| Incident response                | Raccoon → Spider → Turtle     | sonnet, opus, opus |
+| Pre-production deploy            | Raccoon → Turtle              | sonnet, opus       |
+| Auth-only work                   | Spider → Raccoon              | opus, sonnet       |
 
 ---
 

--- a/.claude/skills/gathering-security/references/conductor-dispatch.md
+++ b/.claude/skills/gathering-security/references/conductor-dispatch.md
@@ -1,0 +1,297 @@
+# Gathering Security — Conductor Dispatch Reference
+
+Each animal is dispatched as a subagent with a specific prompt, model, and input. The conductor fills the templates below, verifies gate checks, and manages handoffs.
+
+---
+
+## Dispatch Template (Common Structure)
+
+Every subagent prompt follows this structure:
+
+```
+You are the {ANIMAL} in a security gathering.
+
+BEFORE DOING ANYTHING: Read your skill file at `.claude/skills/{skill-name}/SKILL.md`.
+If it has references/, read those too. Follow your skill's workflow exactly.
+
+## Your Mission
+{mission}
+
+## Your Input
+{structured_input}
+
+## Constraints
+- You MUST read your skill file first — it defines your workflow
+- {animal_specific_constraints}
+- Use `gw` for all git operations, `gf` for codebase search
+- Use Signpost error codes for all error paths
+- Auth errors NEVER reveal user existence ("Invalid credentials" — not "user not found")
+
+## Output Format
+When complete, provide a structured summary:
+- Files created/modified: [list with paths]
+- Key decisions: [brief list]
+- Open questions: [anything the next animal should know]
+- {animal_specific_output}
+```
+
+---
+
+## 1. Spider Dispatch
+
+**Model:** `opus`
+**Subagent type:** `general-purpose`
+
+```
+You are the SPIDER in a security gathering. Your job: weave authentication.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/spider-weave/SKILL.md` and its references/.
+Follow the full SPIN → THREAD → CONNECT → ANCHOR → TEST workflow.
+
+## Your Mission
+Implement authentication for this security scope:
+
+{security_spec}
+
+## Cross-Cutting Standards (NON-NEGOTIABLE)
+- ALL error paths use Signpost codes: buildErrorJson (API), throwGroveError (pages), buildErrorUrl (auth redirects)
+- ALL form inputs validated with parseFormData() + Zod schema
+- ALL JSON/KV reads use safeJsonParse() with Zod schema
+- ALL catch blocks use isRedirect()/isHttpError() type guards
+- NO `as any` or unsafe casts at trust boundaries
+- Auth errors NEVER reveal user existence
+- Sessions: HttpOnly, Secure, SameSite=Lax minimum
+- CSRF: tokens + SameSite cookies
+- Reference: AgentUsage/error_handling.md, AgentUsage/rootwork_type_safety.md
+
+## Constraints
+- You MUST read your skill file first
+- Build ONLY what the security spec demands — no drive-by improvements
+- Follow existing patterns in the codebase (use `gf` to find them)
+- Use `gw` for all git operations, `gf` for codebase search
+
+## Output Format
+AUTH MANIFEST:
+- Files created: [list with paths]
+- Files modified: [list with paths + summary of changes]
+- Auth flow: [provider, flow type, session type]
+- Routes protected: [list]
+- Key decisions: [architectural choices made]
+- Integration points: [where auth connects to existing code]
+- Open questions: [anything unresolved]
+```
+
+**Gate check after return:**
+
+```bash
+gw dev ci --affected --fail-fast
+```
+
+Must compile. If it fails, resume the Spider agent with the error.
+
+---
+
+## 2. Raccoon Dispatch
+
+**Model:** `sonnet`
+**Subagent type:** `general-purpose`
+
+```
+You are the RACCOON in a security gathering. Your job: audit for security risks and cleanup.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/raccoon-audit/SKILL.md`.
+Follow the full SNIFF → RUMMAGE → WASH → INSPECT → SCURRY workflow.
+
+## Your Mission
+Audit these files for security risks, secrets, and dead code:
+
+{file_list}
+
+Security scope: {security_scope_summary}
+
+## What to Audit
+- Secrets in code (hardcoded API keys, tokens, passwords)
+- Dependency vulnerabilities (outdated packages with known CVEs)
+- Dead code and unused imports
+- Unsafe patterns (eval, innerHTML, string concatenation in SQL)
+- Sensitive data in logs (tokens, passwords, PII)
+- Missing error handling (bare throw, console.error without logGroveError)
+
+## Constraints
+- You MUST read your skill file first
+- Focus on FINDING and FIXING — not on understanding why things were built this way
+- Fix what you find directly in the code
+- Flag anything that needs the Turtle's deeper attention
+- Use `gw` for all git operations, `gf` for codebase search
+
+## Output Format
+AUDIT REPORT:
+- Secrets found: [count, locations — all removed/rotated]
+- Unsafe patterns: [count, what was fixed]
+- Dead code removed: [count, locations]
+- Dependency issues: [any]
+- Flagged for Turtle: [issues needing deeper hardening]
+- Files modified: [list with paths]
+```
+
+**IMPORTANT:** The Raccoon receives the **file list and scope summary** — NOT the Spider's implementation reasoning. Fresh auditing eyes.
+
+**Gate check after return:**
+
+```bash
+gw dev ci --affected --fail-fast
+```
+
+Must still compile after audit fixes.
+
+---
+
+## 3. Turtle Dispatch
+
+**Model:** `opus`
+**Subagent type:** `general-purpose`
+
+```
+You are the TURTLE in a security gathering. Your job: harden the code with adversarial eyes.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/turtle-harden/SKILL.md` and its references/.
+Follow the full WITHDRAW → INSPECT → LAYER → TEST → EMERGE workflow.
+
+## Your Mission
+Harden the security of these files. You have NOT seen how they were built or audited — examine them with fresh, adversarial eyes.
+
+## Files to Harden
+{combined_file_list}
+
+## What to Look For
+- Missing input validation (all entry points need Zod schemas)
+- Missing output encoding (context-aware, DOMPurify for rich text)
+- SQL injection (string concatenation instead of parameterized queries)
+- Missing security headers (CSP nonces, HSTS, X-Frame-Options)
+- Bare throw/console.error (should use Signpost codes + logGroveError)
+- Unsafe type casts at trust boundaries (should use Rootwork utilities)
+- Missing rate limiting on sensitive endpoints
+- CSRF, CORS, session security gaps
+- Auth errors revealing user existence
+- Exotic attack vectors:
+  - Prototype pollution
+  - Timing attacks (use constant-time comparison for tokens)
+  - Race conditions (atomic operations for state changes)
+  - SSRF (URL allowlist, no redirect following)
+  - ReDoS (check regex patterns)
+  - Cache poisoning
+  - SVG XSS
+
+## Constraints
+- You are ADVERSARIAL. Think like an attacker examining this code.
+- Do NOT assume prior animals did anything right — verify everything.
+- Fix what you find directly in the code.
+- If you find architectural security issues, flag them but don't restructure.
+- Use `gw` for all git operations, `gf` for codebase search
+
+## Output Format
+HARDENING REPORT:
+- Vulnerabilities found: [severity, location, description]
+- Fixes applied: [what you changed and where]
+- Defense layers added: [input validation, output encoding, headers, etc.]
+- Auth issues found: [any — these may require Spider iteration]
+- Exotic vectors tested: [vector, status (CLEAR/FOUND)]
+- Remaining risks: [anything you couldn't fix, needs architectural change]
+- Files modified: [list with paths]
+```
+
+**IMPORTANT:** The Turtle receives the **combined file list only** — NOT Spider's auth decisions or Raccoon's audit reasoning. This is intentional. Fresh adversarial eyes produce better security review.
+
+**Gate check after return:**
+
+```bash
+gw dev ci --affected --fail-fast
+```
+
+Must still compile after hardening.
+
+---
+
+## Iteration Dispatch (When Turtle Finds Auth Issues)
+
+When the Turtle's hardening report flags auth vulnerabilities:
+
+### Resume Spider for Auth Fix
+
+```
+The Turtle found an auth vulnerability in your implementation:
+
+VULNERABILITY:
+{turtle_finding}
+
+Please fix this specific issue. Do NOT restructure — just patch the vulnerability.
+
+After fixing, provide:
+- Files modified: [list]
+- Fix description: [what you changed]
+```
+
+**Resume the original Spider agent** — don't spawn a new one. It has the auth context.
+
+### Resume Turtle for Re-Verification
+
+```
+The Spider has patched the auth vulnerability you found.
+
+PATCH DETAILS:
+{spider_fix_summary}
+
+FILES CHANGED:
+{changed_files}
+
+Please re-verify ONLY the changed files. Confirm the fix is sound and no new issues were introduced.
+```
+
+**Resume the original Turtle agent** — don't spawn a new one.
+
+---
+
+## Handoff Data Formats
+
+### Auth Manifest (Spider → conductor → Raccoon/Turtle)
+
+```
+FILES_CREATED: [paths]
+FILES_MODIFIED: [paths]
+AUTH_FLOW: [provider, flow type]
+ROUTES_PROTECTED: [list]
+```
+
+Note: Raccoon receives file list + brief scope. Turtle receives file list ONLY.
+
+### Audit Report (Raccoon → conductor)
+
+```
+FINDINGS: [count by severity]
+FIXES_APPLIED: [summary]
+FLAGGED_FOR_TURTLE: [specific concerns]
+FILES_MODIFIED: [paths]
+```
+
+### Hardening Report (Turtle → conductor)
+
+```
+VULNERABILITIES: [by severity]
+DEFENSE_LAYERS: [what was added]
+AUTH_ISSUES: [any requiring Spider iteration]
+EXOTIC_VECTORS: [tested, results]
+FILES_MODIFIED: [paths]
+```
+
+---
+
+## Error Recovery
+
+| Failure                               | Action                                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Agent doesn't read skill file         | Resume with: "You MUST read your skill file first. It's at .claude/skills/{name}/SKILL.md" |
+| Spider builds insecure auth           | Raccoon + Turtle will catch it — that's the point of isolation                             |
+| Gate check fails (CI broken)          | Resume the failing agent with error output                                                 |
+| Turtle finds auth issue               | Resume Spider with finding → Spider patches → Resume Turtle to re-verify                   |
+| Iteration exceeds 3 cycles            | Escalate to human with full context                                                        |
+| Raccoon and Turtle conflict on a file | Conductor resolves: apply non-conflicting changes, re-run CI                               |

--- a/.claude/skills/gathering-ui/SKILL.md
+++ b/.claude/skills/gathering-ui/SKILL.md
@@ -5,7 +5,7 @@ description: The drum sounds. Chameleon and Deer gather for complete UI work. Us
 
 # Gathering UI 🌲🦎🦌
 
-The drum echoes through the glade. The Chameleon shifts its colors, painting the forest with glass and light. The Deer senses what others cannot see, ensuring every path is clear. Together they create spaces that welcome all wanderers—beautiful to behold, accessible to all.
+The drum echoes through the glade. The conductor stands at the clearing's center, orchestrating two very different kinds of attention. The Chameleon arrives with fresh eyes — no preconceptions about what the page should look like, just the spec and the forest's palette. The Deer arrives later, also with fresh eyes — it hasn't watched the CSS being written, so it tests accessibility without unconscious trust. Beautiful and accessible, built by isolated minds.
 
 ## When to Summon
 
@@ -15,38 +15,27 @@ The drum echoes through the glade. The Chameleon shifts its colors, painting the
 - Creating Grove-themed experiences
 - When beauty and inclusion must coexist
 
----
-
-## Grove Tools for This Gathering
-
-Use `gw` and `gf` throughout. Quick reference for UI work:
-
-```bash
-# Find existing UI patterns and components
-gf --agent search "GlassCard|GlassButton"  # Find glass component usage
-gf --agent glass                    # Find glassmorphism patterns
-gf --agent store                    # Find store usage (season, theme)
-gf --agent routes                   # Understand route structure
-
-# Test UI changes
-gw ci --affected                    # Run CI on affected packages
-```
+**IMPORTANT:** This gathering is a **conductor**. It never writes components or audits accessibility directly. It dispatches subagents — one per animal — each with isolated context and an intentional model. The conductor only manages handoffs and gate checks.
 
 ---
 
 ## The Gathering
 
 ```
-SUMMON → ORGANIZE → EXECUTE → VALIDATE → COMPLETE
-   ↓         ↲          ↲          ↲          ↓
-Receive  Dispatch   Animals    Verify   UI
-Request  Animals    Work       Design   Complete
+SUMMON → DISPATCH → GATE → DISPATCH → GATE → VERIFY
+  ↓         ↓        ↓        ↓        ↓        ↓
+Spec    Chameleon  Check     Deer    Check    Visual
+(self)  (sonnet)    ✓      (sonnet)   ✓     Proof
 ```
 
-### Animals Mobilized
+### Animals Dispatched
 
-1. **🦎 Chameleon** — Design the UI with glassmorphism and seasonal themes
-2. **🦌 Deer** — Audit accessibility and ensure inclusive design
+| Order | Animal       | Model  | Role                              | Fresh Eyes?                                     |
+| ----- | ------------ | ------ | --------------------------------- | ----------------------------------------------- |
+| 1     | 🦎 Chameleon | sonnet | Design UI with Grove aesthetics   | Yes — sees only the UI spec                     |
+| 2     | 🦌 Deer      | sonnet | Audit accessibility independently | Yes — sees file list only, not design reasoning |
+
+**Reference:** Load `references/conductor-dispatch.md` for exact subagent prompts and handoff formats
 
 ---
 
@@ -54,7 +43,7 @@ Request  Animals    Work       Design   Complete
 
 _The drum sounds. The glade awaits..._
 
-Receive and parse the request:
+The conductor receives the UI request and prepares the dispatch plan:
 
 **Clarify the UI Work:**
 
@@ -63,103 +52,103 @@ Receive and parse the request:
 - Which season should it reflect?
 - What's the content structure?
 
-**Scope Check:**
+**Confirm with the human, then proceed.**
 
-> "I'll mobilize a UI gathering for: **[UI description]**
->
-> This will involve:
->
-> - 🦎 Chameleon designing with Grove aesthetics
->   - Glassmorphism containers
->   - Seasonal colors and themes
->   - Randomized forests if appropriate
->   - Lucide icons (no emojis)
-> - 🦌 Deer auditing for accessibility
->   - Keyboard navigation
->   - Screen reader compatibility
->   - Color contrast
->   - Reduced motion support
->
-> Proceed with the gathering?"
+**Output:** UI specification, dispatch plan confirmed.
 
 ---
 
-### Phase 2: ORGANIZE
+### Phase 2: ADAPT (Chameleon)
 
-_The animals take their positions..._
-
-Dispatch in sequence:
-
-**Dispatch Order:**
+_The conductor signals. The Chameleon shifts its colors..._
 
 ```
-Chameleon ──→ Deer
-     │            │
-     │            │
-Design         Audit
-UI             Accessibility
+Agent(chameleon, model: sonnet)
+  Input:  UI specification only
+  Reads:  chameleon-adapt/SKILL.md + references (MANDATORY)
+  Output: built components + file list
 ```
 
-**Dependencies:**
+Dispatch a **sonnet subagent** to design and build the UI. The Chameleon receives ONLY the UI specification. It reads its own skill file and executes its full workflow.
 
-- Chameleon must complete before Deer (needs UI to audit)
-- May iterate: Deer findings → Chameleon fixes → Deer re-audit
+**What the Chameleon builds:**
 
----
+- Svelte components with glassmorphism
+- Seasonal color palette integration
+- Nature decorations (trees, creatures, weather)
+- Mobile-responsive layouts
+- Reduced motion support
+- GroveTerm components for user-facing terminology
 
-### Phase 3: EXECUTE
+**Handoff to conductor:** File list (every file created/modified), component summary (what was built, glass variants used, seasonal elements).
 
-_The glade transforms..._
-
-Execute each phase by loading and running each animal's dedicated skill:
-
----
-
-**🦎 CHAMELEON — ADAPT**
-
-Load skill: `chameleon-adapt`
-
-Execute the full Chameleon workflow for [the page/component being designed], applying Grove's glassmorphism, seasonal palette, and nature decorations.
-Handoff: complete Svelte components (glass variants, seasonal decorations, GroveTerm usage, mobile-responsive, reduced motion support) → Deer for accessibility audit
+**Gate check:** Run `gw dev ci --affected --fail-fast` — must compile. If build fails, resume Chameleon.
 
 ---
 
-**🦌 DEER — SENSE**
+### Phase 3: SENSE (Deer)
 
-Load skill: `deer-sense`
+_The Deer steps into the glade. It hasn't watched the colors change..._
 
-Execute the full Deer workflow on everything the Chameleon produced.
-If issues are found: return to Chameleon for fixes, then Deer re-audits. Repeat until clean.
-Handoff: accessibility-verified components → VALIDATE phase
+```
+Agent(deer, model: sonnet)
+  Input:  UI file list ONLY (not Chameleon's design reasoning)
+  Reads:  deer-sense/SKILL.md + references (MANDATORY)
+  Output: accessibility report + applied fixes
+```
+
+Dispatch a **sonnet subagent** to audit accessibility. The Deer receives ONLY the file list — NOT the Chameleon's design decisions or reasoning. This isolation is intentional: the Deer should test what's rendered, not trust what was intended.
+
+**What the Deer audits:**
+
+- Keyboard navigation (tab order, focus management, escape handling)
+- Screen reader compatibility (ARIA labels, semantic HTML, live regions)
+- Color contrast (4.5:1 minimum, WCAG AA)
+- Touch targets (44px minimum)
+- Reduced motion (prefers-reduced-motion respected)
+- Focus indicators visible
+
+**Handoff to conductor:** Accessibility report (violations found, fixes applied, WCAG level achieved), updated file list.
+
+**Gate check:** Run `gw dev ci --affected --fail-fast` — must still compile after a11y fixes.
 
 ---
 
-### Phase 4: VALIDATE
+### Phase 4: ITERATION (When Deer Finds Issues)
 
-_The design stands. Both animals verify — with their own eyes..._
+If the Deer's report includes issues it couldn't fix directly (e.g., structural changes needed for keyboard navigation, color scheme changes for contrast):
 
-**Visual Verification (mandatory):**
+1. **Resume Chameleon** with Deer's specific findings
+2. Chameleon applies fixes
+3. Gate check: CI passes
+4. **Resume Deer** to re-verify only the changed files
+5. Max 2 iterations — then escalate to human
 
-Before checking boxes, actually _look_ at what was built. Use Glimpse to capture and review the rendered result:
+---
+
+### Phase 5: VERIFY
+
+_The glade is complete. But the conductor looks with its own eyes..._
+
+**Visual Verification (MANDATORY for UI gatherings):**
 
 ```bash
-# Prerequisite: seed the database if not already done
+# Seed database if not already done
 uv run --project tools/glimpse glimpse seed --yes
 
-# Capture the page across all seasons and themes
-# Local routing uses ?subdomain= for tenant isolation; --auto starts the dev server
+# Capture across all seasons and themes
 uv run --project tools/glimpse glimpse matrix \
   "http://localhost:5173/[page]?subdomain=midnight-bloom" \
   --seasons spring,summer,autumn,winter --themes light,dark --logs --auto
 
-# Browse interactively — verify flows, click targets, scrolling
+# Interactive verification — click around, verify flows
 uv run --project tools/glimpse glimpse browse \
   "http://localhost:5173/[page]?subdomain=midnight-bloom" \
-  --do "click navigation, scroll to content, click interactive elements" \
+  --do "click navigation, scroll content, interact with elements" \
   --screenshot-each --logs --auto
 ```
 
-Review every screenshot. If something looks wrong — fix it and capture again. The gathering does not declare UI complete without visual proof.
+Review every screenshot. If something looks wrong — fix it and capture again.
 
 **Validation Checklist (after visual verification):**
 
@@ -167,7 +156,6 @@ Review every screenshot. If something looks wrong — fix it and capture again. 
 - [ ] Glimpse: Light and dark mode both visually verified
 - [ ] Glimpse: No console errors in `--logs` output
 - [ ] Chameleon: UI matches Grove aesthetic (verified by screenshot)
-- [ ] Chameleon: Seasonal theme appropriate (verified by matrix)
 - [ ] Chameleon: Glassmorphism readable (verified by screenshot)
 - [ ] Chameleon: Mobile responsive
 - [ ] Deer: Keyboard navigation works
@@ -175,103 +163,73 @@ Review every screenshot. If something looks wrong — fix it and capture again. 
 - [ ] Deer: Color contrast passes (4.5:1)
 - [ ] Deer: Reduced motion respected
 - [ ] Deer: Touch targets adequate (44px)
-- [ ] Both: Grove terminology uses GroveTerm components (not hardcoded)
-- [ ] Both: `[[term]]` syntax used in data-driven content strings
-
-**Quality Gates:**
-
-```
-Chameleon completes → Glimpse capture → Review screenshots
-                                              ↓
-                                    Looks correct?
-                                       /        \
-                                    No            Yes
-                                     |             |
-                              Chameleon fixes      ↓
-                                     |          Deer audits
-                              Glimpse re-capture    ↓
-                                     |         Issues found?
-                                  Repeat        /        \
-                                             Yes          No
-                                              |            |
-                                       Chameleon fixes     ↓
-                                              |         Proceed
-                                       Deer re-audit
-                                              |
-                                          Complete
-```
-
----
-
-### Phase 5: COMPLETE
-
-_The gathering ends. A welcoming space awaits..._
+- [ ] Both: Grove terminology uses GroveTerm components
 
 **Completion Report:**
 
-```markdown
-## 🌲 GATHERING UI COMPLETE
+```
+🌲 GATHERING UI COMPLETE
 
-### UI: [Name]
+UI: [Name]
 
-### Animals Mobilized
+DISPATCH LOG
+  🦎 Chameleon (sonnet) — [X components built, Y files created/modified]
+  🦌 Deer (sonnet)       — [Z a11y issues found, W fixed]
 
-🦎 Chameleon → 🦌 Deer
+GATE LOG
+  After Chameleon: ✅ compiles clean
+  After Deer:      ✅ compiles clean, a11y verified
+  Iterations:      [N iterations / none needed]
+  Visual:          ✅ Glimpse matrix captured and reviewed
+  Final CI:        ✅ gw dev ci --affected passes
 
-### Design Decisions
+ACCESSIBILITY
+  Keyboard nav: ✅
+  Screen reader: ✅
+  Contrast: ✅ [ratios]
+  Touch targets: ✅ 44px+
+  Reduced motion: ✅
+  WCAG level: [AA/AAA]
 
-- **Season:** [spring/summer/autumn/winter/midnight]
-- **Decoration Level:** [minimal/moderate/full]
-- **Glass Variants Used:** [surface/tint/card/accent]
-
-### Visual Elements
-
-- Randomized forests: [count] trees
-- Weather effects: [snow/petals/leaves/none]
-- Seasonal birds: [species]
-- Icons: Lucide ([list])
-
-### Accessibility Features
-
-- Keyboard navigation: ✅
-- Screen reader tested: [VoiceOver/NVDA]
-- Color contrast: ✅ [ratios]
-- Reduced motion: ✅
-- Touch targets: ✅ [44px minimum]
-
-### Files Created
-
-- [Component files]
-- [Style files]
-- [Accessibility documentation]
-
-### Time Elapsed
-
-[Duration]
-
-_The glade welcomes all wanderers._ 🌲
+The glade welcomes all wanderers.
 ```
 
 ---
 
-## Example Gathering
+## Conductor Rules
 
-**User:** "/gathering-ui Create the user profile page"
+### Never Do Animal Work
 
-**Gathering execution:**
+The conductor dispatches. It does not write CSS, build components, or audit accessibility.
 
-1. 🌲 **SUMMON** — "Mobilizing for: User profile page. Personal settings, avatar, bio. Emotional: reflection."
+### Fresh Eyes Are a Feature
 
-2. 🌲 **ORGANIZE** — "Chameleon designs → Deer audits"
+The Deer hasn't watched the Chameleon work. It sees only the rendered result, not the design intent. This isolation catches contrast issues, missing labels, and navigation gaps that a sympathetic observer would miss.
 
-3. 🌲 **EXECUTE** —
-   - 🦎 Chameleon: "Autumn theme, glass cards for settings, randomized birch trees, cardinals perched, Lucide icons"
-   - 🦌 Deer: "Tab order logical, form labels associated, contrast passes, screen reader announces changes"
+### Gate Every Transition
 
-4. 🌲 **VALIDATE** — "Visual design matches Grove, all accessibility checks pass"
+CI between Chameleon and Deer. CI after Deer's fixes. Glimpse after everything.
 
-5. 🌲 **COMPLETE** — "Profile page complete, beautiful and accessible"
+### Visual Proof Required
+
+The conductor MUST capture and review Glimpse screenshots before declaring complete. CI passing is not the same as looking correct.
+
+### Resume, Don't Restart
+
+If iteration is needed, resume existing agents. They have context from their prior work.
 
 ---
 
-_Beautiful and accessible—the forest welcomes all._ 🌲
+## Anti-Patterns
+
+**The conductor does NOT:**
+
+- Write components itself
+- Let Deer see Chameleon's design reasoning (isolation is the point)
+- Skip Glimpse verification ("CI passed so it looks fine")
+- Skip the Deer phase ("it's just a small component")
+- Declare complete without visual proof
+
+---
+
+_Beautiful and accessible — the forest welcomes all._ 🌲

--- a/.claude/skills/gathering-ui/references/conductor-dispatch.md
+++ b/.claude/skills/gathering-ui/references/conductor-dispatch.md
@@ -1,0 +1,191 @@
+# Gathering UI — Conductor Dispatch Reference
+
+Each animal is dispatched as a subagent with a specific prompt, model, and input. The conductor fills the templates below, verifies gate checks, and manages handoffs.
+
+---
+
+## 1. Chameleon Dispatch
+
+**Model:** `sonnet`
+**Subagent type:** `general-purpose`
+
+```
+You are the CHAMELEON in a UI gathering. Your job: design and build the interface with Grove aesthetics.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/chameleon-adapt/SKILL.md` and its references/.
+Follow the full READ → BLEND → SHIFT → SETTLE → DISPLAY workflow.
+
+## Your Mission
+Design and build the UI for:
+
+{ui_spec}
+
+## Grove Design Standards (NON-NEGOTIABLE)
+- Use glassmorphism containers (GlassCard, GlassButton from @autumnsgrove/lattice/ui)
+- Apply seasonal colors from the Grove palette (grove-*, cream-*, bark-*)
+- DO NOT use standard Tailwind colors (gray-*, slate-*, red-*, blue-*, etc.)
+- Use Lucide icons, never emojis in UI
+- Use GroveTerm components for user-facing terminology (Wanderer, Rooted, etc.)
+- Use `[[term]]` syntax in data-driven content strings
+- Support reduced motion (prefers-reduced-motion)
+- Mobile-responsive (test at 375px minimum)
+- Import components from @autumnsgrove/lattice — engine-first pattern
+- Reference: AGENT.md design standards section, AgentUsage/design_context.md
+
+## Constraints
+- You MUST read your skill file first
+- Build ONLY what the UI spec demands — no drive-by improvements
+- Follow existing component patterns (use `gf` to find them)
+- Use `gw` for all git operations, `gf` for codebase search
+
+## Output Format
+UI MANIFEST:
+- Files created: [list with paths]
+- Files modified: [list with paths + summary]
+- Components built: [list with glass variants used]
+- Seasonal elements: [trees, creatures, weather effects]
+- Icons used: [Lucide icon names]
+- GroveTerm usage: [where terminology components were used]
+- Responsive breakpoints: [what was tested]
+- Open questions: [anything unresolved]
+```
+
+**Gate check after return:**
+
+```bash
+gw dev ci --affected --fail-fast
+```
+
+Must compile. If it fails, resume the Chameleon with the error.
+
+---
+
+## 2. Deer Dispatch
+
+**Model:** `sonnet`
+**Subagent type:** `general-purpose`
+
+```
+You are the DEER in a UI gathering. Your job: audit accessibility with fresh, independent eyes.
+
+BEFORE DOING ANYTHING: Read `.claude/skills/deer-sense/SKILL.md` and its references/.
+Follow the full LISTEN → SCAN → TEST → GUIDE → PROTECT workflow.
+
+## Your Mission
+Audit these UI files for accessibility. You have NOT seen how they were designed — examine them with independent eyes.
+
+## Files to Audit
+{ui_file_list}
+
+## Accessibility Standards (NON-NEGOTIABLE)
+- Keyboard navigation: logical tab order, visible focus indicators, escape closes modals
+- Screen readers: semantic HTML, ARIA labels on interactive elements, live regions for dynamic content
+- Color contrast: 4.5:1 minimum (WCAG AA) for normal text, 3:1 for large text
+- Touch targets: 44px minimum on interactive elements
+- Reduced motion: prefers-reduced-motion respected, no essential info in animation
+- Focus management: focus trapped in modals, restored on close
+- Form accessibility: labels associated with inputs, error messages linked with aria-describedby
+
+## Constraints
+- You are INDEPENDENT. Test what's rendered, not what was intended.
+- Fix what you find directly in the Svelte components.
+- If a fix requires structural changes you can't make, flag it for the Chameleon.
+- Use `gw` for all git operations, `gf` for codebase search
+
+## Output Format
+A11Y REPORT:
+- Violations found: [count, severity, location, WCAG criterion]
+- Fixes applied: [what was changed and where]
+- Flagged for Chameleon: [issues requiring design changes]
+- WCAG level achieved: [A / AA / AAA]
+- Keyboard test results: [tab order, focus management, escape handling]
+- Screen reader test results: [semantic structure, ARIA, live regions]
+- Contrast check: [pass/fail with specific ratios]
+- Touch target check: [pass/fail with measurements]
+- Files modified: [list with paths]
+```
+
+**IMPORTANT:** The Deer receives the **file list only** — NOT the Chameleon's design reasoning or aesthetic decisions. The Deer tests what exists, not what was intended.
+
+**Gate check after return:**
+
+```bash
+gw dev ci --affected --fail-fast
+```
+
+Must still compile after a11y fixes.
+
+---
+
+## Iteration Dispatches
+
+### Resume Chameleon for Design Fixes
+
+When Deer flags issues requiring design changes:
+
+```
+The Deer found accessibility issues that require design changes:
+
+A11Y ISSUES:
+{deer_flagged_issues}
+
+Please fix these specific issues. Maintain the Grove aesthetic while meeting accessibility standards.
+- Contrast: if colors fail 4.5:1, adjust within the Grove palette (don't use standard Tailwind colors)
+- Touch targets: increase interactive element sizes to 44px minimum
+- Structure: add semantic HTML where needed for screen readers
+
+Provide:
+- Files modified: [list]
+- Fixes applied: [what you changed]
+```
+
+### Resume Deer for Re-Verification
+
+```
+The Chameleon has fixed the accessibility issues you flagged.
+
+FIXES APPLIED:
+{chameleon_fixes}
+
+FILES CHANGED:
+{changed_files}
+
+Re-verify ONLY the changed files. Confirm the fixes meet accessibility standards and no new issues were introduced.
+```
+
+Maximum 2 iterations. If unresolved, escalate to human.
+
+---
+
+## Handoff Data Formats
+
+### UI Manifest (Chameleon → conductor → Deer)
+
+```
+FILES_CREATED: [paths]
+FILES_MODIFIED: [paths]
+COMPONENTS: [list]
+```
+
+Note: Deer receives file list ONLY. Not design reasoning.
+
+### A11Y Report (Deer → conductor)
+
+```
+VIOLATIONS: [count by severity]
+FIXES_APPLIED: [summary]
+FLAGGED_FOR_CHAMELEON: [issues needing design changes]
+WCAG_LEVEL: [achieved]
+```
+
+---
+
+## Error Recovery
+
+| Failure                            | Action                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| Chameleon uses non-Grove colors    | Resume with: "Only use Grove palette colors (grove-_, cream-_, bark-\*)" |
+| Deer can't fix structural issue    | Flag for Chameleon → resume Chameleon → resume Deer                      |
+| Gate check fails (CI broken)       | Resume the failing agent with error output                               |
+| Contrast fails after Chameleon fix | Resume Chameleon with specific failing ratios                            |
+| Iteration exceeds 2 cycles         | Escalate to human                                                        |


### PR DESCRIPTION
## Summary

Converts four gathering skills from inline skill invocation to the **conductor pattern** — isolated subagents with intentional model selection, structured handoffs, and gate checks between every phase transition.

- **gathering-security** (High): Spider (opus) → Raccoon (sonnet) → Turtle (opus) with iteration cycle for auth vulnerabilities
- **gathering-architecture** (Medium): Eagle (opus) → Crow (sonnet) → Swan (opus) → Elephant (opus) with Eagle-Crow challenge iteration
- **gathering-ui** (Low): Chameleon (sonnet) → Deer (sonnet) with Glimpse visual verification
- **gathering-migration** (Low): Bloodhound (haiku) → Bear (opus) with count validation

**Intentionally skipped:** `gathering-planning` — only 2 lightweight animals (Bee + Badger) that don't benefit from conductor overhead.

Each gathering now has `references/conductor-dispatch.md` with exact subagent prompts, handoff formats, gate checks, iteration protocols, and error recovery tables.

### Key design decisions
- **Adversarial isolation preserved**: Turtle never sees Spider's reasoning, Crow never sees Eagle's reasoning, Deer never sees Chameleon's design intent
- **Model selection is intentional**: opus for complex work (auth, hardening, architecture, specs), sonnet for systematic work (audits, challenges, UI), haiku for scouting
- **Resume over restart**: failed agents are resumed with error context, not respawned — preserves prior work

Fixes #1453

## Test plan

- [ ] Verify each SKILL.md has the conductor pattern (dispatches subagents, not inline skills)
- [ ] Verify each has `references/conductor-dispatch.md` with exact prompts
- [ ] Verify model selection table in each SKILL.md
- [ ] Verify gate checks defined between every phase
- [ ] Verify `gathering-planning` was intentionally left unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)