### PR TITLE
fix: use featureIcons.code instead of actionIcons.code in EditorDemo

### DIFF
--- a/apps/landing/src/lib/components/demos/EditorDemo.svelte
+++ b/apps/landing/src/lib/components/demos/EditorDemo.svelte
@@ -7,10 +7,10 @@
 <script lang="ts">
 	import { browser } from "$app/environment";
 	import MarkdownIt from "markdown-it";
-	import { actionIcons } from "@autumnsgrove/prism/icons";
+	import { actionIcons, featureIcons } from "@autumnsgrove/prism/icons";
 	const Bold = actionIcons.bold;
 	const Italic = actionIcons.italic;
-	const Code = actionIcons.code;
+	const Code = featureIcons.code;
 	const Link = actionIcons.link;
 	const Heading1 = actionIcons.heading1;
 	const Heading2 = actionIcons.heading2;


### PR DESCRIPTION
The `code` icon lives in the feature group, not action. The Prism Proxy
returned undefined for actionIcons.code, causing a "Code2 is not a
function" TypeError during SSR — which 500'd the entire landing page.

https://claude.ai/code/session_018acifk7YiohfZ6boKaPLTN