### PR TITLE
fix: align turnstile cookie Max-Age with 30-day constant

### DIFF
--- a/apps/aspen/src/routes/api/verify/turnstile/+server.ts
+++ b/apps/aspen/src/routes/api/verify/turnstile/+server.ts
@@ -4,7 +4,7 @@
  * POST /api/verify/turnstile
  *
  * Validates a Turnstile token and sets a verification cookie.
- * Cookie lasts 7 days, shared across all *.grove.place subdomains.
+ * Cookie lasts 30 days, shared across all *.grove.place subdomains.
  */
 
 import { error } from "@sveltejs/kit";
@@ -13,6 +13,7 @@ import {
 	verifyTurnstileToken,
 	createVerificationCookie,
 	TURNSTILE_COOKIE_NAME,
+	TURNSTILE_COOKIE_MAX_AGE,
 } from "@autumnsgrove/lattice/server/services/turnstile";
 import { createThreshold } from "@autumnsgrove/lattice/threshold/factory";
 import { thresholdCheck } from "@autumnsgrove/lattice/threshold/adapters/sveltekit";
@@ -76,11 +77,11 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 	const cookieValue = await createVerificationCookie(secretKey);
 
 	// Build Set-Cookie header manually to ensure it's correct
-	// Format: name=value; Path=/; Max-Age=604800; HttpOnly; Secure; SameSite=Lax; Domain=.grove.place
+	// Format: name=value; Path=/; Max-Age=<30 days>; HttpOnly; Secure; SameSite=Lax; Domain=.grove.place
 	const cookieHeader = [
 		`${TURNSTILE_COOKIE_NAME}=${cookieValue}`,
 		"Path=/",
-		"Max-Age=604800", // 7 days
+		`Max-Age=${TURNSTILE_COOKIE_MAX_AGE}`, // 30 days
 		"HttpOnly",
 		"Secure",
 		"SameSite=Lax",

--- a/docs/guides/shade-developer-guide.md
+++ b/docs/guides/shade-developer-guide.md
@@ -51,7 +51,7 @@ This is the layer developers interact with most. Every first-time visitor to a p
 4. On success, the widget returns a token. The page POSTs it to `/api/verify/turnstile`.
 5. The endpoint validates the token with Cloudflare's `siteverify` API, creates an HMAC-signed cookie, and returns it via `Set-Cookie`.
 6. The verify page does a hard redirect (`window.location.href`) back to the original URL. A hard redirect is required because SvelteKit's client-side navigation won't pick up the new cookie.
-7. On the next request, the hook finds a valid cookie and lets the request through. The cookie lasts 7 days.
+7. On the next request, the hook finds a valid cookie and lets the request through. The cookie lasts 30 days.
 
 ### Key files
 
@@ -103,14 +103,14 @@ The timestamp is `Date.now()` at creation time. The signature is an HMAC-SHA256 
 |-----------|-------|-----|
 | Domain | `grove.place` | Shared across all tenant subdomains |
 | Path | `/` | Applies everywhere |
-| Max-Age | `604800` (7 days) | Balance between UX and security |
+| Max-Age | `2592000` (30 days) | Balance between UX and security |
 | HttpOnly | `true` | Not accessible to client-side JS |
 | Secure | `true` | HTTPS only |
 | SameSite | `Lax` | Sent on top-level navigations, not cross-origin requests |
 
 ### Validation
 
-`validateVerificationCookie()` in `turnstile.ts` checks two things: that the HMAC signature matches (proving the cookie wasn't forged) and that the timestamp hasn't expired (proving it's still within the 7-day window). Both checks must pass.
+`validateVerificationCookie()` in `turnstile.ts` checks two things: that the HMAC signature matches (proving the cookie wasn't forged) and that the timestamp hasn't expired (proving it's still within the 30-day window). Both checks must pass.
 
 ```typescript
 import {

--- a/docs/specs/shade-spec.md
+++ b/docs/specs/shade-spec.md
@@ -175,7 +175,7 @@ Shade implements defense in depth through nine complementary layers:
 │              LAYER 7: TURNSTILE HUMAN VERIFICATION              │
 │  • Cloudflare Turnstile widget (managed mode)                   │
 │  • Server-side token validation                                 │
-│  • Cookie-based verification (7-day expiry)                     │
+│  • Cookie-based verification (30-day expiry)                    │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -381,7 +381,7 @@ Turnstile is Cloudflare's human verification system that doesn't require solving
 2. **Redirect:** hooks.server.ts redirects to `/verify?return=<original_url>`
 3. **Challenge:** Turnstile widget runs (invisible for most users)
 4. **Verification:** Token sent to `/api/verify/turnstile`, validated with Cloudflare
-5. **Cookie Set:** `grove_verified` cookie set with HMAC signature (7-day expiry)
+5. **Cookie Set:** `grove_verified` cookie set with HMAC signature (30-day expiry)
 6. **Redirect Back:** User returned to their original destination
 7. **Subsequent Visits:** Cookie validated server-side, no challenge needed
 
@@ -389,7 +389,7 @@ Turnstile is Cloudflare's human verification system that doesn't require solving
 ```
 Cookie: grove_verified=<timestamp>.<hmac_signature>
 Domain: .grove.place (shared across subdomains)
-Max-Age: 604800 (7 days)
+Max-Age: 2592000 (30 days)
 SameSite: Lax
 Secure: true (production only)
 HttpOnly: false (read by client for UX)
@@ -1045,7 +1045,7 @@ Key metrics to track in Dashboard → Security → Events:
 - [x] Create /api/verify/turnstile endpoint
 - [x] Update CSP to allow challenges.cloudflare.com
 - [x] Add verification page (/verify) for first-time visitors
-- [x] Set grove_verified cookie (7-day expiry)
+- [x] Set grove_verified cookie (30-day expiry)
 - [x] Write help center article (how-grove-protects-your-content.md)
 - [x] Integrate with hooks.server.ts for site-wide verification
 


### PR DESCRIPTION
The API endpoint was hard-coding Max-Age=604800 (7 days) in the
Set-Cookie header while the engine constant TURNSTILE_COOKIE_MAX_AGE
was already set to 30 days. This mismatch caused browsers to expire
the verification cookie after just 7 days, forcing unnecessary
re-verification. Now uses the shared constant for consistency.

https://claude.ai/code/session_019hUPW715VD1RfdDD2iAk1J