### PR TITLE
fix: add markdown link parsing to GroveText component

### DIFF
--- a/libs/engine/src/lib/components/terminology/GroveText.svelte
+++ b/libs/engine/src/lib/components/terminology/GroveText.svelte
@@ -2,12 +2,14 @@
 	import GroveTerm from './GroveTerm.svelte';
 
 	// GroveText - String parser that renders [[term]] markers as GroveTerm
+	// and [text](url) markdown links as <a> tags.
 	//
 	// Defaults to non-interactive (silent swap). Use ! suffix for interactive:
 	//   [[bloom]]         → <GroveTerm term="bloom" />              (silent swap)
 	//   [[bloom!]]        → <GroveTerm term="bloom" interactive />  (popup + underline)
 	//   [[bloom|blooms]]  → <GroveTerm term="bloom">blooms</GroveTerm>
 	//   [[bloom!|blooms]] → <GroveTerm term="bloom" interactive>blooms</GroveTerm>
+	//   [click here](/page) → <a href="/page">click here</a>
 
 	interface Props {
 		/** String containing [[term]] or [[term|display]] markers */
@@ -19,21 +21,39 @@
 	const PATTERN = /\[\[([a-zA-Z][a-zA-Z0-9-]*)(!)?\s*(?:\|([^\]]*))?\]\]/g;
 
 	interface Segment {
-		type: 'text' | 'term';
+		type: 'text' | 'term' | 'link';
 		value: string;
 		display?: string;
 		interactive?: boolean;
+		href?: string;
+	}
+
+	const LINK_PATTERN = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+	function parseLinks(text: string): Segment[] {
+		const result: Segment[] = [];
+		let lastIndex = 0;
+		const re = new RegExp(LINK_PATTERN.source, 'g');
+		let match: RegExpExecArray | null;
+		while ((match = re.exec(text)) !== null) {
+			if (match.index > lastIndex)
+				result.push({ type: 'text', value: text.slice(lastIndex, match.index) });
+			result.push({ type: 'link', value: match[1], href: match[2] });
+			lastIndex = re.lastIndex;
+		}
+		if (lastIndex < text.length) result.push({ type: 'text', value: text.slice(lastIndex) });
+		return result;
 	}
 
 	const segments = $derived.by(() => {
-		const result: Segment[] = [];
+		const termParsed: Segment[] = [];
 		let lastIndex = 0;
 		const re = new RegExp(PATTERN.source, 'g');
 		let match: RegExpExecArray | null;
 		while ((match = re.exec(content)) !== null) {
 			if (match.index > lastIndex)
-				result.push({ type: 'text', value: content.slice(lastIndex, match.index) });
-			result.push({
+				termParsed.push({ type: 'text', value: content.slice(lastIndex, match.index) });
+			termParsed.push({
 				type: 'term',
 				value: match[1],
 				interactive: match[2] === '!',
@@ -42,9 +62,19 @@
 			lastIndex = re.lastIndex;
 		}
 		if (lastIndex < content.length)
-			result.push({ type: 'text', value: content.slice(lastIndex) });
+			termParsed.push({ type: 'text', value: content.slice(lastIndex) });
+
+		// Second pass: parse markdown links in text segments
+		const result: Segment[] = [];
+		for (const seg of termParsed) {
+			if (seg.type === 'text' && LINK_PATTERN.test(seg.value)) {
+				result.push(...parseLinks(seg.value));
+			} else {
+				result.push(seg);
+			}
+		}
 		return result;
 	});
 </script>
 
-{#each segments as seg}{#if seg.type === 'text'}{seg.value}{:else}<GroveTerm term={seg.value} interactive={seg.interactive}>{#if seg.display}{seg.display}{:else}{seg.value}{/if}</GroveTerm>{/if}{/each}
+{#each segments as seg}{#if seg.type === 'text'}{seg.value}{:else if seg.type === 'link'}<a href={seg.href} class="text-accent-muted hover:text-accent underline underline-offset-2 transition-colors">{seg.value}</a>{:else}<GroveTerm term={seg.value} interactive={seg.interactive}>{#if seg.display}{seg.display}{:else}{seg.value}{/if}</GroveTerm>{/if}{/each}


### PR DESCRIPTION
The FAQ "How is Grove different" answer contained a markdown-style link
[See how Grove compares →](/compare) that was rendering as raw text
because GroveText only parsed [[term]] markers. Added a second parsing
pass for [text](url) markdown links, rendering them as proper <a> tags.

https://claude.ai/code/session_01SPsaBtBuUwkRt4AMwrwjRi