### PR TITLE
fix(aspen): add feature-flag mocks to chat API tests

### DIFF
--- a/apps/aspen/src/routes/api/chat/chat.test.ts
+++ b/apps/aspen/src/routes/api/chat/chat.test.ts
@@ -63,6 +63,11 @@ vi.mock("@autumnsgrove/lattice/loom/sveltekit", () => ({
 	})),
 }));
 
+vi.mock("@autumnsgrove/lattice/feature-flags", () => ({
+	isInGreenhouse: vi.fn().mockResolvedValue(true),
+	isFeatureEnabled: vi.fn().mockResolvedValue(true),
+}));
+
 import { getUserHomeGrove } from "@autumnsgrove/lattice/server/services/users";
 import {
 	listConversations,
@@ -132,7 +137,7 @@ function makeGETEvent(
 		url.searchParams.set(k, v);
 	}
 	return {
-		platform: { env: { DB: db }, context: { waitUntil: vi.fn() } },
+		platform: { env: { DB: db, CACHE_KV: {} }, context: { waitUntil: vi.fn() } },
 		locals: { user: opts.user !== undefined ? opts.user : TEST_USER },
 		url,
 		params: opts.params ?? {},
@@ -150,7 +155,7 @@ function makePOSTEvent(
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body),
 		}),
-		platform: { env: { DB: db, CHAT: {} }, context: { waitUntil: vi.fn() } },
+		platform: { env: { DB: db, CHAT: {}, CACHE_KV: {} }, context: { waitUntil: vi.fn() } },
 		locals: { user: opts.user !== undefined ? opts.user : TEST_USER },
 		params: opts.params ?? {},
 	};


### PR DESCRIPTION
The conversations route added a chirp_enabled graft gate via
isInGreenhouse/isFeatureEnabled, but the chat tests didn't mock
the @autumnsgrove/lattice/feature-flags module. This caused the
gate to return false, throwing 403 on 5 conversation tests.

Also adds CACHE_KV to test event factories since the feature flag
check requires the KV binding to be present.

https://claude.ai/code/session_01947BErFFwZZZs2aW1eL9Wf