### PR TITLE
fix(meadow-poller): fix SSRF subdomain pattern and add vitest config

### DIFF
--- a/workers/meadow-poller/src/config.ts
+++ b/workers/meadow-poller/src/config.ts
@@ -4,45 +4,45 @@
 
 /** Cloudflare Worker environment bindings */
 export interface Env {
-  DB: D1Database;
-  POLL_STATE: KVNamespace;
+	DB: D1Database;
+	POLL_STATE: KVNamespace;
 }
 
 /** Tenant row from D1 for feed discovery */
 export interface TenantInfo {
-  id: string;
-  subdomain: string;
-  display_name: string | null;
+	id: string;
+	subdomain: string;
+	display_name: string | null;
 }
 
 /** Per-tenant poll state stored in KV */
 export interface PollState {
-  lastEtag: string | null;
-  lastPollAt: number;
-  consecutiveErrors: number;
-  lastErrorMessage: string | null;
+	lastEtag: string | null;
+	lastPollAt: number;
+	consecutiveErrors: number;
+	lastErrorMessage: string | null;
 }
 
 /** Parsed RSS feed structure */
 export interface ParsedFeed {
-  title: string;
-  link: string;
-  description: string;
-  items: ParsedFeedItem[];
+	title: string;
+	link: string;
+	description: string;
+	items: ParsedFeedItem[];
 }
 
 /** Individual parsed feed item */
 export interface ParsedFeedItem {
-  title: string;
-  link: string;
-  guid: string;
-  pubDate: string | null;
-  description: string;
-  contentEncoded: string | null;
-  categories: string[];
-  enclosureUrl: string | null;
-  /** Custom blaze slug from grove:blaze RSS extension */
-  blaze: string | null;
+	title: string;
+	link: string;
+	guid: string;
+	pubDate: string | null;
+	description: string;
+	contentEncoded: string | null;
+	categories: string[];
+	enclosureUrl: string | null;
+	/** Custom blaze slug from grove:blaze RSS extension */
+	blaze: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -67,5 +67,7 @@ export const ERROR_BACKOFF_THRESHOLD = 3;
 /** Backoff interval when error threshold is exceeded (1 hour in seconds) */
 export const BACKOFF_INTERVAL_S = 60 * 60;
 
-/** Subdomain validation pattern — only alphanumeric and hyphens */
-export const SUBDOMAIN_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+/** Subdomain validation pattern — only alphanumeric and hyphens.
+ * Accepts single-char subdomains (e.g. "a") and multi-char with optional
+ * hyphens in the middle. First and last char must be alphanumeric. */
+export const SUBDOMAIN_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;

--- a/workers/meadow-poller/src/index.test.ts
+++ b/workers/meadow-poller/src/index.test.ts
@@ -220,6 +220,24 @@ describe("meadow-poller", () => {
 			expect(mockFetch).not.toHaveBeenCalled();
 		});
 
+		it("polls tenants with single-character subdomains", async () => {
+			const tenants = [{ id: "t1", subdomain: "a", display_name: "A" }];
+			const { env, mockD1 } = createTestEnv(tenants);
+
+			mockFetch.mockResolvedValueOnce(
+				new Response(VALID_RSS, {
+					status: 200,
+					headers: { "Content-Type": "application/rss+xml" },
+				}),
+			);
+
+			await worker.default.fetch(new Request("https://example.com/trigger"), env);
+
+			// Single-char subdomain must NOT be rejected by SSRF validation
+			expect(mockFetch).toHaveBeenCalledWith("https://a.grove.place/api/feed", expect.any(Object));
+			expect(mockD1.batch).toHaveBeenCalled();
+		});
+
 		it("rejects feeds exceeding size limit", async () => {
 			const tenants = [{ id: "t1", subdomain: "alice", display_name: "Alice" }];
 			const { env, kvStore } = createTestEnv(tenants);

--- a/workers/meadow-poller/vitest.config.ts
+++ b/workers/meadow-poller/vitest.config.ts
@@ -1,0 +1,24 @@
+/**
+ * Vitest config for meadow-poller.
+ *
+ * Aliases @autumnsgrove/lattice subpath exports to their TypeScript source so
+ * Vitest can resolve them without requiring an engine build. This mirrors the
+ * pattern used in workers/reverie — package.json exports resolve to dist/ but
+ * dist/ doesn't exist in a fresh worktree.
+ */
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+const engineSrc = path.resolve(__dirname, "../../libs/engine/src/lib");
+
+export default defineConfig({
+	resolve: {
+		alias: {
+			"@autumnsgrove/lattice/errors": path.join(engineSrc, "errors/index.ts"),
+		},
+	},
+	test: {
+		globals: true,
+		include: ["src/**/*.test.ts"],
+	},
+});


### PR DESCRIPTION
## Summary

- **SSRF subdomain pattern bug**: `SUBDOMAIN_PATTERN` was `/^[a-z0-9][a-z0-9-]*[a-z0-9]$/` — required at least 2 characters, silently skipping any tenant with a single-character subdomain. Fixed to `/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/` which accepts single-char while still enforcing alphanumeric-only start/end and rejecting hyphens at boundaries.
- **Missing vitest config**: All 8 integration tests in `index.test.ts` were failing because `@autumnsgrove/infra/cloudflare` transitively imports `@autumnsgrove/lattice/errors`, which resolves to `dist/errors/index.js` — a file that doesn't exist in fresh worktrees without an engine build. Added `vitest.config.ts` with `resolve.alias` pointing to the source file directly (same pattern as `workers/reverie`).
- **New regression test**: Added test proving single-char subdomains (`"a"`) are polled correctly, not silently dropped.

## Test plan

- [ ] `cd workers/meadow-poller && pnpm test` → 29 tests pass (was 20 parser + 0 integration, now 20 + 9)
- [ ] `gw ci --affected` → all checks green
- [ ] Manually verify `wrangler tail grove-meadow-poller` shows polling activity for opted-in tenants

Closes #1378

🤖 Generated with [Claude Code](https://claude.com/claude-code)