### PR TITLE
Refactor garden page styling to use design system variables

### DIFF
--- a/apps/aspen/src/routes/garden/+page.svelte
+++ b/apps/aspen/src/routes/garden/+page.svelte
@@ -179,10 +179,14 @@
 <style>
 	.blog-header-title {
 		font-size: 2.5rem;
-		color: var(--blog-header-title);
+		color: var(--grove-accent-dark);
 		margin-bottom: 0.75rem;
 		letter-spacing: -0.02em;
 		transition: color 0.3s ease;
+	}
+
+	:global(.dark) .blog-header-title {
+		color: var(--grove-accent);
 	}
 
 	@media (max-width: 768px) {
@@ -192,7 +196,7 @@
 	}
 
 	.blog-header-text {
-		color: var(--blog-header-text);
+		color: var(--color-text-muted);
 		font-size: 1.1rem;
 		transition: color 0.3s ease;
 	}
@@ -216,7 +220,7 @@
 	}
 
 	.description {
-		color: var(--blog-header-text);
+		color: var(--color-text-muted);
 		line-height: 1.6;
 		margin: 0;
 		transition: color 0.3s ease;


### PR DESCRIPTION
## Summary

Updates the garden page (`+page.svelte`) to use consistent design system color variables instead of custom blog-specific variables. This improves maintainability and ensures the page respects the application's color scheme, including proper dark mode support.

## Changes

- Replaced `--blog-header-title` with `--grove-accent-dark` for the main title color
- Added dark mode support for the title using `--grove-accent` 
- Replaced `--blog-header-text` with `--color-text-muted` for secondary text elements (header text and description)
- These changes apply to the blog header title, header text, and description sections

## Type of Change

- [x] Refactoring

## Testing

Visual verification that the garden page displays correctly with the new color variables in both light and dark modes. Existing styles and layout remain unchanged; only color variable references are updated.

https://claude.ai/code/session_01CUtNNtazt7FdRDTZBKzRqU