### PR TITLE
chore(ci): update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/actions/grove-setup/action.yml
+++ b/.github/actions/grove-setup/action.yml
@@ -31,20 +31,20 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       if: inputs.checkout-ref == ''
 
     - name: Checkout (specific ref)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       if: inputs.checkout-ref != ''
       with:
         ref: ${{ inputs.checkout-ref }}
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"

--- a/.github/workflows/_deploy-pages.yml
+++ b/.github/workflows/_deploy-pages.yml
@@ -82,19 +82,19 @@ jobs:
       # ── Inline grove-setup (can't use composite action in reusable workflow) ──
       - name: Checkout
         if: inputs.checkout-ref == ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout (specific ref)
         if: inputs.checkout-ref != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.checkout-ref }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/_deploy-worker.yml
+++ b/.github/workflows/_deploy-worker.yml
@@ -92,19 +92,19 @@ jobs:
       # ── Inline grove-setup (can't use composite action in reusable workflow) ──
       - name: Checkout
         if: inputs.checkout-ref == ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout (specific ref)
         if: inputs.checkout-ref != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.checkout-ref }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Label by Grove component
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Full history for accurate commit count
 
@@ -108,11 +108,11 @@ jobs:
 
       - name: Setup pnpm
         if: steps.snapshot.outcome == 'success'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         if: steps.snapshot.outcome == 'success'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -365,7 +365,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup workspace
         uses: ./.github/actions/grove-setup
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup workspace
         uses: ./.github/actions/grove-setup
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Verify engine barrel exports
         run: ./tools/verify-engine-exports.sh
@@ -148,7 +148,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup workspace
         uses: ./.github/actions/grove-setup
@@ -161,7 +161,7 @@ jobs:
 
       - name: Comment on PR with lint errors
         if: steps.lint.outcome == 'failure' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -252,7 +252,7 @@ jobs:
 
       - name: Comment on PR with failure summary
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const failed = '${{ steps.check.outputs.failed_jobs }}'.trim().split(/\s+/);

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-compliance-review.yml
+++ b/.github/workflows/claude-compliance-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-design-review.yml
+++ b/.github/workflows/claude-design-review.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -53,14 +53,14 @@ jobs:
               - '**/*.md'
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
           output: codeql-results
           upload: always
 
       - name: Upload CodeQL results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: codeql-results
           path: codeql-results

--- a/.github/workflows/component-inventory.yml
+++ b/.github/workflows/component-inventory.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Full history needed for git diff against base branch
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: Comment on PR (if components changed)
         if: github.event_name == 'pull_request' && steps.count-components.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EXPECTED: ${{ steps.count-components.outputs.expected }}
           ACTUAL: ${{ steps.count-components.outputs.actual }}
@@ -207,7 +207,7 @@ jobs:
 
       - name: Create issue for inventory drift (scheduled run only)
         if: github.event_name == 'schedule' && steps.count-components.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EXPECTED: ${{ steps.count-components.outputs.expected }}
           ACTUAL: ${{ steps.count-components.outputs.actual }}

--- a/.github/workflows/deploy-engine.yml
+++ b/.github/workflows/deploy-engine.yml
@@ -25,7 +25,7 @@ jobs:
       # Aspen (apps/aspen) handles the tenant app deploy via deploy-aspen.yml.
       # This workflow builds, tests, type-checks, and runs D1 migrations.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup workspace
         uses: ./.github/actions/grove-setup

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -236,7 +236,7 @@ jobs:
 
       - name: Comment on PR (if issues found)
         if: github.event_name == 'pull_request' && (steps.check-docs.outputs.has_issues == 'true' || steps.check-greenhouse.outputs.greenhouse_status == 'drift')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ACTUAL_TOTAL: ${{ steps.check-docs.outputs.actual_total }}
           EXPECTED_TOTAL: ${{ steps.check-docs.outputs.expected_total }}
@@ -334,7 +334,7 @@ jobs:
 
       - name: Create issue for knowledge base health (scheduled run only)
         if: github.event_name == 'schedule' && steps.check-docs.outputs.has_issues == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ACTUAL_TOTAL: ${{ steps.check-docs.outputs.actual_total }}
           EXPECTED_TOTAL: ${{ steps.check-docs.outputs.expected_total }}

--- a/.github/workflows/graft-inventory.yml
+++ b/.github/workflows/graft-inventory.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -184,7 +184,7 @@ jobs:
 
       - name: Comment on PR (if grafts changed)
         if: github.event_name == 'pull_request' && (steps.count-grafts.outputs.has_changes == 'true' || steps.check-maturity.outputs.has_maturity_issues == 'true' || steps.check-article.outputs.article_status != 'fresh')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EXPECTED: ${{ steps.count-grafts.outputs.expected }}
           ACTUAL: ${{ steps.count-grafts.outputs.actual }}
@@ -277,7 +277,7 @@ jobs:
 
       - name: Create issue for inventory drift (scheduled run only)
         if: github.event_name == 'schedule' && steps.count-grafts.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EXPECTED: ${{ steps.count-grafts.outputs.expected }}
           ACTUAL: ${{ steps.count-grafts.outputs.actual }}

--- a/.github/workflows/grove-census.yml
+++ b/.github/workflows/grove-census.yml
@@ -15,7 +15,7 @@ jobs:
   census:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Full history needed for accurate commit hash
 

--- a/.github/workflows/guide-freshness.yml
+++ b/.github/workflows/guide-freshness.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -215,7 +215,7 @@ jobs:
 
       - name: Comment on PR (if issues found)
         if: github.event_name == 'pull_request' && steps.check-guides.outputs.has_issues == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ACTUAL_TOTAL: ${{ steps.check-guides.outputs.actual_total }}
           EXPECTED_TOTAL: ${{ steps.check-guides.outputs.expected_total }}
@@ -297,7 +297,7 @@ jobs:
 
       - name: Create issue (scheduled run only)
         if: github.event_name == 'schedule' && steps.check-guides.outputs.has_issues == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ACTUAL_TOTAL: ${{ steps.check-guides.outputs.actual_total }}
           EXPECTED_TOTAL: ${{ steps.check-guides.outputs.expected_total }}

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -87,7 +87,7 @@ jobs:
       - name: Format Lighthouse Results
         id: results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           LH_MANIFEST: ${{ steps.lighthouse.outputs.manifest }}
           LH_LINKS: ${{ steps.lighthouse.outputs.links }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.results.outputs.comment != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMENT_BODY: ${{ steps.results.outputs.comment }}
         with:

--- a/.github/workflows/link-pr-to-issue.yml
+++ b/.github/workflows/link-pr-to-issue.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
       - name: Extract issue number and update status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/pr-size-labels.yml
+++ b/.github/workflows/pr-size-labels.yml
@@ -15,8 +15,8 @@ jobs:
 
     steps:
       - name: Assign size label
-        # Pinned to v0.5.5 commit SHA — tags are mutable, SHAs are not
-        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
+        # Pinned to v0.5.7 commit SHA — tags are mutable, SHAs are not
+        uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff # v0.5.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Grove-themed size labels:
@@ -39,7 +39,7 @@ jobs:
 
       - name: Warn on very large PRs
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({

--- a/.github/workflows/rebuild-gf-binaries.yml
+++ b/.github/workflows/rebuild-gf-binaries.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 

--- a/.github/workflows/rebuild-gw-binaries.yml
+++ b/.github/workflows/rebuild-gw-binaries.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 

--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -84,10 +84,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 
@@ -127,10 +127,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 
@@ -153,7 +153,7 @@ jobs:
           ls -lh "$BINARY"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ needs.prepare.outputs.tool }}-${{ matrix.platform }}
           path: ${{ needs.prepare.outputs.directory }}/${{ needs.prepare.outputs.tool }}-${{ matrix.platform }}${{ matrix.ext }}
@@ -169,12 +169,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts/
 

--- a/.github/workflows/reverie-inventory.yml
+++ b/.github/workflows/reverie-inventory.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -133,7 +133,7 @@ jobs:
 
       - name: Comment on PR (if schemas changed)
         if: github.event_name == 'pull_request' && steps.count-schemas.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EXPECTED_SCHEMAS: ${{ steps.count-schemas.outputs.expected_schemas }}
           ACTUAL_SCHEMAS: ${{ steps.count-schemas.outputs.actual_schemas }}
@@ -196,7 +196,7 @@ jobs:
 
       - name: Create issue for inventory drift (scheduled run only)
         if: github.event_name == 'schedule' && steps.count-schemas.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EXPECTED_SCHEMAS: ${{ steps.count-schemas.outputs.expected_schemas }}
           ACTUAL_SCHEMAS: ${{ steps.count-schemas.outputs.actual_schemas }}

--- a/.github/workflows/security-txt-review.yml
+++ b/.github/workflows/security-txt-review.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check for existing open issue
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issues = await github.rest.issues.listForRepo({
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create annual review issue
         if: steps.check.outputs.exists == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const year = new Date().getFullYear();

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run Semgrep (SARIF output)
         # Exit code 7 = findings detected (success with results, not an error)
@@ -74,13 +74,13 @@ jobs:
             --json --output=semgrep-results.json || true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep-results.sarif
         if: always()
 
       - name: Upload JSON results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: semgrep-results
           path: |

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           

--- a/.github/workflows/test-failure-analysis.yml
+++ b/.github/workflows/test-failure-analysis.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Analyze test failure
         id: analyze

--- a/.github/workflows/validate-deployments.yml
+++ b/.github/workflows/validate-deployments.yml
@@ -101,13 +101,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -181,13 +181,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/waystone-inventory.yml
+++ b/.github/workflows/waystone-inventory.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -147,7 +147,7 @@ jobs:
 
       - name: Comment on PR (if waystones changed)
         if: github.event_name == 'pull_request' && steps.count-waystones.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EXPECTED: ${{ steps.count-waystones.outputs.expected }}
           ACTUAL: ${{ steps.count-waystones.outputs.actual }}
@@ -226,7 +226,7 @@ jobs:
 
       - name: Create issue for inventory drift (scheduled run only)
         if: github.event_name == 'schedule' && steps.count-waystones.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EXPECTED: ${{ steps.count-waystones.outputs.expected }}
           ACTUAL: ${{ steps.count-waystones.outputs.actual }}


### PR DESCRIPTION
Node 20 reaches EOL April 30, 2026, and GitHub runners switch to
Node 24 by default June 2, 2026. Bump all first-party actions to
their Node 24 releases:

- actions/checkout v4 → v5
- actions/setup-node v4 → v6
- actions/setup-go v5 → v6
- actions/upload-artifact v4 → v5
- actions/download-artifact v4 → v5
- actions/github-script v7 → v8
- actions/stale v9 → v10
- pnpm/action-setup v4 → v5
- github/codeql-action v3 → v4
- pascalgn/size-label-action v0.5.5 → v0.5.7 (SHA-pinned)

Third-party actions without Node 24 releases yet (keep as-is):
- cloudflare/wrangler-action@v3
- anthropics/claude-code-action@v1
- treosh/lighthouse-ci-action@v12

https://claude.ai/code/session_01RYQ4iaTuYsCP2nEFEpsGjb