### PR TITLE
feat(loom): add FeedDO per-user social feed with CF Queue pipeline

### DIFF
--- a/apps/aspen/src/app.d.ts
+++ b/apps/aspen/src/app.d.ts
@@ -164,6 +164,9 @@ declare global {
 
 				/** Dev-only: enables simulated auth for Glimpse visual testing (never set in prod) */
 				DEV_AUTH_ENABLED?: string;
+
+				/** Feed event queue (post.published → subscriber FeedDOs) */
+				FEED_QUEUE?: Queue;
 			};
 			context: {
 				waitUntil(promise: Promise<unknown>): void;

--- a/apps/aspen/src/routes/api/blooms/[slug]/+server.ts
+++ b/apps/aspen/src/routes/api/blooms/[slug]/+server.ts
@@ -64,6 +64,7 @@ export const PUT: RequestHandler = async ({ params, request, platform, locals })
 				AI: platform.env.AI,
 				OPENROUTER_API_KEY: platform.env.OPENROUTER_API_KEY,
 				CACHE_KV: platform.env.CACHE_KV,
+				FEED_QUEUE: platform.env.FEED_QUEUE,
 			},
 			platform.context?.waitUntil.bind(platform.context),
 		);

--- a/apps/aspen/src/routes/api/blooms/[slug]/bloom-service.ts
+++ b/apps/aspen/src/routes/api/blooms/[slug]/bloom-service.ts
@@ -331,6 +331,7 @@ export async function updatePost(
 	}
 
 	// Feed: notify subscribers when a post is first published
+	// publishedAt uses unix seconds to match the bloom's published_at column
 	if (isFirstPublish && platformEnv.FEED_QUEUE && waitUntil) {
 		waitUntil(
 			platformEnv.FEED_QUEUE.send({
@@ -341,7 +342,7 @@ export async function updatePost(
 					title,
 					excerpt: data.description || null,
 					image: data.featured_image || null,
-					publishedAt: Date.now(),
+					publishedAt: published_at ?? unixNow,
 				},
 				timestamp: new Date().toISOString(),
 			}).catch((err) => {

--- a/apps/aspen/src/routes/api/blooms/[slug]/bloom-service.ts
+++ b/apps/aspen/src/routes/api/blooms/[slug]/bloom-service.ts
@@ -149,6 +149,7 @@ export async function updatePost(
 		AI?: Ai;
 		OPENROUTER_API_KEY?: string;
 		CACHE_KV?: KVNamespace;
+		FEED_QUEUE?: Queue;
 	},
 	waitUntil?: (promise: Promise<unknown>) => void,
 ): Promise<{ slug: string }> {
@@ -325,6 +326,26 @@ export async function updatePost(
 				contentType: "blog_post",
 				hookPoint: "on_edit",
 				contentRef: newSlug || slug,
+			}),
+		);
+	}
+
+	// Feed: notify subscribers when a post is first published
+	if (isFirstPublish && platformEnv.FEED_QUEUE && waitUntil) {
+		waitUntil(
+			platformEnv.FEED_QUEUE.send({
+				type: "post.published",
+				payload: {
+					tenantId,
+					slug: newSlug || slug,
+					title,
+					excerpt: data.description || null,
+					image: data.featured_image || null,
+					publishedAt: Date.now(),
+				},
+				timestamp: new Date().toISOString(),
+			}).catch((err) => {
+				console.error("[Blooms] Feed queue send failed:", err);
 			}),
 		);
 	}

--- a/apps/aspen/wrangler.toml
+++ b/apps/aspen/wrangler.toml
@@ -157,6 +157,13 @@ class_name = "ChatDO"
 script_name = "grove-durable-objects"
 
 # =============================================================================
+# Queue - Feed events (post.published → subscriber FeedDOs)
+# =============================================================================
+[[queues.producers]]
+queue = "grove-feed-events"
+binding = "FEED_QUEUE"
+
+# =============================================================================
 # Environment Variables (non-sensitive)
 # =============================================================================
 [vars]

--- a/services/durable-objects/src/FeedDO.test.ts
+++ b/services/durable-objects/src/FeedDO.test.ts
@@ -1,0 +1,296 @@
+/**
+ * FeedDO Tests
+ *
+ * Tests the per-user social feed — ingest, pagination, unread tracking,
+ * saved items, tenant removal, and alarm-based pruning.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FeedDO } from "./FeedDO";
+import { createTestDOState, createMockSql, doPost, doRequest, doDelete } from "./test-helpers";
+
+describe("FeedDO", () => {
+	let doInstance: FeedDO;
+	let sql: ReturnType<typeof createMockSql>;
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		sql = createMockSql();
+		const { state } = createTestDOState("feed:test-user", sql);
+		doInstance = new FeedDO(state, {});
+	});
+
+	describe("POST /ingest", () => {
+		it("should ingest a feed item", async () => {
+			const res = await doInstance.fetch(
+				doPost("/ingest", {
+					tenantId: "tenant-1",
+					tenantName: "Autumn's Grove",
+					tenantSubdomain: "autumn",
+					postSlug: "hello-world",
+					postTitle: "Hello World",
+					postExcerpt: "A first post",
+					publishedAt: 1700000000000,
+				}),
+			);
+			const body = (await res.json()) as { success: boolean; id: string };
+
+			expect(res.status).toBe(200);
+			expect(body.success).toBe(true);
+			expect(body.id).toBeDefined();
+
+			// Verify INSERT was called
+			const insertCall = sql._calls.find((c) =>
+				c.query.includes("INSERT OR IGNORE INTO feed_items"),
+			);
+			expect(insertCall).toBeDefined();
+			expect(insertCall!.bindings).toContain("tenant-1");
+			expect(insertCall!.bindings).toContain("hello-world");
+		});
+
+		it("should reject missing required fields", async () => {
+			const res = await doInstance.fetch(doPost("/ingest", { tenantId: "tenant-1" }));
+
+			expect(res.status).toBe(400);
+		});
+
+		it("should handle empty payload gracefully", async () => {
+			const res = await doInstance.fetch(doPost("/ingest", {}));
+
+			expect(res.status).toBe(400);
+		});
+	});
+
+	describe("GET /feed", () => {
+		it("should return paginated feed items", async () => {
+			const items = [
+				{
+					id: "1",
+					tenant_id: "t1",
+					tenant_name: "Grove A",
+					tenant_subdomain: "a",
+					post_slug: "post-1",
+					post_title: "Post 1",
+					post_excerpt: null,
+					post_image: null,
+					published_at: 1700000000000,
+					ingested_at: 1700000001000,
+				},
+			];
+			sql._pushResults(items);
+
+			const res = await doInstance.fetch(doRequest("/feed?limit=25"));
+			const body = (await res.json()) as {
+				items: unknown[];
+				nextCursor: number | null;
+				hasMore: boolean;
+			};
+
+			expect(res.status).toBe(200);
+			expect(body.items).toHaveLength(1);
+			expect(body.hasMore).toBe(false);
+			expect(body.nextCursor).toBeNull();
+		});
+
+		it("should support cursor-based pagination", async () => {
+			// Return limit+1 items to indicate hasMore
+			const items = Array.from({ length: 3 }, (_, i) => ({
+				id: `id-${i}`,
+				tenant_id: "t1",
+				tenant_name: "Grove",
+				tenant_subdomain: "a",
+				post_slug: `post-${i}`,
+				post_title: `Post ${i}`,
+				post_excerpt: null,
+				post_image: null,
+				published_at: 1700000000000 - i * 1000,
+				ingested_at: 1700000000000,
+			}));
+			sql._pushResults(items);
+
+			const res = await doInstance.fetch(doRequest("/feed?limit=2"));
+			const body = (await res.json()) as {
+				items: unknown[];
+				nextCursor: number | null;
+				hasMore: boolean;
+			};
+
+			expect(body.items).toHaveLength(2);
+			expect(body.hasMore).toBe(true);
+			expect(body.nextCursor).toBe(1700000000000 - 1000);
+		});
+
+		it("should return empty feed", async () => {
+			// No results pushed → empty array default
+			const res = await doInstance.fetch(doRequest("/feed"));
+			const body = (await res.json()) as { items: unknown[]; hasMore: boolean };
+
+			expect(body.items).toHaveLength(0);
+			expect(body.hasMore).toBe(false);
+		});
+	});
+
+	describe("GET /feed/unread", () => {
+		it("should return unread count", async () => {
+			sql._pushResult({ count: 5 });
+
+			const res = await doInstance.fetch(doRequest("/feed/unread"));
+			const body = (await res.json()) as { unreadCount: number; lastReadAt: number };
+
+			expect(body.unreadCount).toBe(5);
+			expect(body.lastReadAt).toBe(0);
+		});
+	});
+
+	describe("POST /feed/mark-read", () => {
+		it("should update last-read timestamp", async () => {
+			const res = await doInstance.fetch(doPost("/feed/mark-read", {}));
+			const body = (await res.json()) as { success: boolean; lastReadAt: number };
+
+			expect(body.success).toBe(true);
+			expect(body.lastReadAt).toBeGreaterThan(0);
+
+			// Verify state was persisted to JsonStore
+			const storeCall = sql._calls.find(
+				(c) =>
+					c.query.includes("INSERT OR REPLACE INTO kv_store") && c.bindings.includes("feed_state"),
+			);
+			expect(storeCall).toBeDefined();
+		});
+	});
+
+	describe("POST /save", () => {
+		it("should save a bookmark", async () => {
+			const res = await doInstance.fetch(
+				doPost("/save", {
+					itemType: "bloom",
+					tenantId: "tenant-1",
+					tenantSubdomain: "autumn",
+					postSlug: "great-post",
+					postTitle: "A Great Post",
+				}),
+			);
+			const body = (await res.json()) as { success: boolean; id: string };
+
+			expect(res.status).toBe(201);
+			expect(body.success).toBe(true);
+
+			const insertCall = sql._calls.find((c) =>
+				c.query.includes("INSERT OR IGNORE INTO saved_items"),
+			);
+			expect(insertCall).toBeDefined();
+			expect(insertCall!.bindings).toContain("great-post");
+		});
+
+		it("should reject missing fields", async () => {
+			const res = await doInstance.fetch(doPost("/save", { tenantId: "t1" }));
+
+			expect(res.status).toBe(400);
+		});
+	});
+
+	describe("DELETE /save/:id", () => {
+		it("should remove a saved item", async () => {
+			const res = await doInstance.fetch(doDelete("/save/item-123"));
+			const body = (await res.json()) as { success: boolean };
+
+			expect(body.success).toBe(true);
+
+			const deleteCall = sql._calls.find(
+				(c) => c.query.includes("DELETE FROM saved_items") && c.bindings.includes("item-123"),
+			);
+			expect(deleteCall).toBeDefined();
+		});
+	});
+
+	describe("GET /saved", () => {
+		it("should return paginated saved items", async () => {
+			const items = [
+				{
+					id: "s1",
+					item_type: "bloom",
+					tenant_id: "t1",
+					tenant_subdomain: "autumn",
+					post_slug: "saved-post",
+					post_title: "Saved Post",
+					saved_at: 1700000000000,
+				},
+			];
+			sql._pushResults(items);
+
+			const res = await doInstance.fetch(doRequest("/saved"));
+			const body = (await res.json()) as { items: unknown[]; hasMore: boolean };
+
+			expect(body.items).toHaveLength(1);
+			expect(body.hasMore).toBe(false);
+		});
+	});
+
+	describe("DELETE /tenant/:tenantId", () => {
+		it("should remove all items from a tenant", async () => {
+			const res = await doInstance.fetch(doDelete("/tenant/tenant-123"));
+			const body = (await res.json()) as { success: boolean };
+
+			expect(body.success).toBe(true);
+
+			const deleteCall = sql._calls.find(
+				(c) => c.query.includes("DELETE FROM feed_items") && c.bindings.includes("tenant-123"),
+			);
+			expect(deleteCall).toBeDefined();
+		});
+	});
+
+	describe("GET /health", () => {
+		it("should return status and counts", async () => {
+			sql._pushResult({ count: 10 });
+			sql._pushResult({ count: 3 });
+
+			const res = await doInstance.fetch(doRequest("/health"));
+			const body = (await res.json()) as { status: string; feedItems: number; savedItems: number };
+
+			expect(body.status).toBe("ok");
+			expect(body.feedItems).toBe(10);
+			expect(body.savedItems).toBe(3);
+		});
+	});
+
+	describe("alarm (pruning)", () => {
+		it("should delete old feed items and reschedule if rows remain", async () => {
+			// DELETE result
+			sql._pushResult({});
+			// SELECT COUNT(*) — rows remain
+			sql._pushResult({ count: 50 });
+
+			await doInstance.alarm();
+
+			const deleteCall = sql._calls.find(
+				(c) => c.query.includes("DELETE FROM feed_items") && c.query.includes("published_at"),
+			);
+			expect(deleteCall).toBeDefined();
+		});
+
+		it("should not reschedule when feed is empty", async () => {
+			// DELETE result
+			sql._pushResult({});
+			// SELECT COUNT(*) — no rows
+			sql._pushResult({ count: 0 });
+
+			await doInstance.alarm();
+
+			const countCall = sql._calls.find((c) => c.query.includes("SELECT COUNT(*)"));
+			expect(countCall).toBeDefined();
+		});
+	});
+
+	describe("route matching", () => {
+		it("should return 404 for unknown routes", async () => {
+			const res = await doInstance.fetch(doRequest("/unknown"));
+			expect(res.status).toBe(404);
+		});
+
+		it("should return 404 for wrong method", async () => {
+			const res = await doInstance.fetch(doRequest("/ingest")); // GET instead of POST
+			expect(res.status).toBe(404);
+		});
+	});
+});

--- a/services/durable-objects/src/FeedDO.test.ts
+++ b/services/durable-objects/src/FeedDO.test.ts
@@ -30,7 +30,7 @@ describe("FeedDO", () => {
 					postSlug: "hello-world",
 					postTitle: "Hello World",
 					postExcerpt: "A first post",
-					publishedAt: 1700000000000,
+					publishedAt: 1700000000,
 				}),
 			);
 			const body = (await res.json()) as { success: boolean; id: string };
@@ -73,8 +73,8 @@ describe("FeedDO", () => {
 					post_title: "Post 1",
 					post_excerpt: null,
 					post_image: null,
-					published_at: 1700000000000,
-					ingested_at: 1700000001000,
+					published_at: 1700000000,
+					ingested_at: 1700000001,
 				},
 			];
 			sql._pushResults(items);
@@ -103,8 +103,8 @@ describe("FeedDO", () => {
 				post_title: `Post ${i}`,
 				post_excerpt: null,
 				post_image: null,
-				published_at: 1700000000000 - i * 1000,
-				ingested_at: 1700000000000,
+				published_at: 1700000000 - i,
+				ingested_at: 1700000000,
 			}));
 			sql._pushResults(items);
 
@@ -117,7 +117,7 @@ describe("FeedDO", () => {
 
 			expect(body.items).toHaveLength(2);
 			expect(body.hasMore).toBe(true);
-			expect(body.nextCursor).toBe(1700000000000 - 1000);
+			expect(body.nextCursor).toBe(1700000000 - 1);
 		});
 
 		it("should return empty feed", async () => {
@@ -213,7 +213,7 @@ describe("FeedDO", () => {
 					tenant_subdomain: "autumn",
 					post_slug: "saved-post",
 					post_title: "Saved Post",
-					saved_at: 1700000000000,
+					saved_at: 1700000000,
 				},
 			];
 			sql._pushResults(items);

--- a/services/durable-objects/src/FeedDO.ts
+++ b/services/durable-objects/src/FeedDO.ts
@@ -1,0 +1,401 @@
+/// <reference types="@cloudflare/workers-types" />
+
+/**
+ * FeedDO — Per-User Social Feed Durable Object
+ *
+ * Manages a user's personalized following feed and saved items list.
+ * Each user gets their own DO instance (ID pattern: feed:{userId}).
+ *
+ * Responsibilities:
+ * - Ingest published posts from followed groves (via queue consumer fan-out)
+ * - Serve paginated feed with cursor-based pagination
+ * - Track unread count since last-read timestamp
+ * - Manage a unified saved/bookmarked items list
+ * - Prune old feed items (1 year retention, alarm-based)
+ *
+ * Part of the Loom pattern — Grove's coordination layer.
+ *
+ * @see https://github.com/AutumnsGrove/Lattice/issues/1423
+ */
+
+import {
+	LoomDO,
+	type LoomRoute,
+	type LoomConfig,
+	type LoomRequestContext,
+	LoomResponse,
+	safeJsonParse,
+} from "@autumnsgrove/lattice/loom";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FeedState {
+	userId: string;
+	lastReadAt: number;
+}
+
+interface FeedEnv extends Record<string, unknown> {
+	DB?: D1Database;
+}
+
+/** Payload received from the queue consumer when a grove publishes a post. */
+export interface FeedIngestPayload {
+	tenantId: string;
+	tenantName: string;
+	tenantSubdomain: string;
+	postSlug: string;
+	postTitle: string;
+	postExcerpt?: string | null;
+	postImage?: string | null;
+	publishedAt: number;
+}
+
+/** Payload for saving/bookmarking an item. */
+export interface SaveItemPayload {
+	itemType: "bloom";
+	tenantId: string;
+	tenantSubdomain: string;
+	postSlug: string;
+	postTitle: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Daily alarm for pruning old feed items. */
+const ALARM_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Feed items older than this are pruned. */
+const RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** Default page size for feed and saved list queries. */
+const DEFAULT_PAGE_SIZE = 25;
+
+/** Maximum page size to prevent abuse. */
+const MAX_PAGE_SIZE = 100;
+
+// ============================================================================
+// FeedDO Class
+// ============================================================================
+
+export class FeedDO extends LoomDO<FeedState, FeedEnv> {
+	config(): LoomConfig {
+		return { name: "FeedDO" };
+	}
+
+	protected schema(): string {
+		return `
+      CREATE TABLE IF NOT EXISTS feed_items (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        tenant_name TEXT NOT NULL,
+        tenant_subdomain TEXT NOT NULL,
+        post_slug TEXT NOT NULL,
+        post_title TEXT NOT NULL,
+        post_excerpt TEXT,
+        post_image TEXT,
+        published_at INTEGER NOT NULL,
+        ingested_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_feed_published ON feed_items(published_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_feed_tenant ON feed_items(tenant_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_feed_dedup ON feed_items(tenant_id, post_slug);
+
+      CREATE TABLE IF NOT EXISTS saved_items (
+        id TEXT PRIMARY KEY,
+        item_type TEXT NOT NULL,
+        tenant_id TEXT NOT NULL,
+        tenant_subdomain TEXT NOT NULL,
+        post_slug TEXT NOT NULL,
+        post_title TEXT NOT NULL,
+        saved_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_saved_at ON saved_items(saved_at DESC);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_dedup ON saved_items(tenant_id, post_slug);
+    `;
+	}
+
+	protected async loadState(): Promise<FeedState | null> {
+		const stored = this.store.get<FeedState>("feed_state");
+		return stored;
+	}
+
+	routes(): LoomRoute[] {
+		return [
+			{ method: "POST", path: "/ingest", handler: (ctx) => this.handleIngest(ctx) },
+			{ method: "GET", path: "/feed", handler: (ctx) => this.handleGetFeed(ctx) },
+			{ method: "GET", path: "/feed/unread", handler: () => this.handleGetUnread() },
+			{ method: "POST", path: "/feed/mark-read", handler: () => this.handleMarkRead() },
+			{ method: "POST", path: "/save", handler: (ctx) => this.handleSave(ctx) },
+			{ method: "DELETE", path: "/save/:id", handler: (ctx) => this.handleUnsave(ctx) },
+			{ method: "GET", path: "/saved", handler: (ctx) => this.handleGetSaved(ctx) },
+			{
+				method: "DELETE",
+				path: "/tenant/:tenantId",
+				handler: (ctx) => this.handleRemoveTenant(ctx),
+			},
+			{ method: "GET", path: "/health", handler: () => this.handleHealth() },
+		];
+	}
+
+	// ════════════════════════════════════════════════════════════════════
+	// Route Handlers
+	// ════════════════════════════════════════════════════════════════════
+
+	/**
+	 * POST /ingest — Receive a new published post from the queue consumer.
+	 * Idempotent: duplicate tenant_id+post_slug is silently ignored.
+	 */
+	private async handleIngest(ctx: LoomRequestContext): Promise<Response> {
+		const data = safeJsonParse<FeedIngestPayload | null>(await ctx.request.text(), null);
+
+		if (!data?.tenantId || !data?.postSlug || !data?.postTitle) {
+			return LoomResponse.badRequest("Missing required fields: tenantId, postSlug, postTitle");
+		}
+
+		const id = crypto.randomUUID();
+		const now = Date.now();
+
+		try {
+			this.sql.exec(
+				`INSERT OR IGNORE INTO feed_items
+				 (id, tenant_id, tenant_name, tenant_subdomain, post_slug, post_title, post_excerpt, post_image, published_at, ingested_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				id,
+				data.tenantId,
+				data.tenantName || "",
+				data.tenantSubdomain || "",
+				data.postSlug,
+				data.postTitle,
+				data.postExcerpt || null,
+				data.postImage || null,
+				data.publishedAt || now,
+				now,
+			);
+		} catch (err) {
+			this.log.errorWithCause("Feed ingest failed", err);
+			return LoomResponse.error({
+				code: "GROVE-LOOM-080",
+				category: "bug",
+				userMessage: "Failed to save feed item.",
+				adminMessage: "Feed ingest INSERT failed in FeedDO.",
+			});
+		}
+
+		// Ensure pruning alarm is scheduled
+		await this.alarms.ensureScheduled(ALARM_INTERVAL_MS);
+
+		return Response.json({ success: true, id });
+	}
+
+	/**
+	 * GET /feed — Paginated feed, newest first.
+	 * Query params: ?cursor={published_at}&limit={number}
+	 */
+	private async handleGetFeed(ctx: LoomRequestContext): Promise<Response> {
+		const cursor = parseInt(ctx.query.get("cursor") || "0", 10) || 0;
+		const limit = Math.min(
+			parseInt(ctx.query.get("limit") || String(DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE,
+			MAX_PAGE_SIZE,
+		);
+
+		const items =
+			cursor > 0
+				? this.sql.queryAll<Record<string, unknown>>(
+						`SELECT id, tenant_id, tenant_name, tenant_subdomain, post_slug, post_title, post_excerpt, post_image, published_at, ingested_at
+					 FROM feed_items
+					 WHERE published_at < ?
+					 ORDER BY published_at DESC
+					 LIMIT ?`,
+						cursor,
+						limit + 1,
+					)
+				: this.sql.queryAll<Record<string, unknown>>(
+						`SELECT id, tenant_id, tenant_name, tenant_subdomain, post_slug, post_title, post_excerpt, post_image, published_at, ingested_at
+					 FROM feed_items
+					 ORDER BY published_at DESC
+					 LIMIT ?`,
+						limit + 1,
+					);
+
+		const hasMore = items.length > limit;
+		const page = hasMore ? items.slice(0, limit) : items;
+		const nextCursor = hasMore ? (page[page.length - 1].published_at as number) : null;
+
+		return Response.json({
+			items: page,
+			nextCursor,
+			hasMore,
+		});
+	}
+
+	/**
+	 * GET /feed/unread — Count of items since last-read timestamp.
+	 */
+	private handleGetUnread(): Response {
+		const lastReadAt = this.state_data?.lastReadAt || 0;
+
+		const result = this.sql.queryOne<{ count: number }>(
+			"SELECT COUNT(*) as count FROM feed_items WHERE published_at > ?",
+			lastReadAt,
+		);
+
+		return Response.json({
+			unreadCount: result?.count || 0,
+			lastReadAt,
+		});
+	}
+
+	/**
+	 * POST /feed/mark-read — Update last-read cursor to now.
+	 */
+	private handleMarkRead(): Response {
+		const now = Date.now();
+
+		if (!this.state_data) {
+			this.state_data = { userId: this.state.id.toString(), lastReadAt: now };
+		} else {
+			this.state_data.lastReadAt = now;
+		}
+
+		this.store.set("feed_state", this.state_data);
+
+		return Response.json({ success: true, lastReadAt: now });
+	}
+
+	/**
+	 * POST /save — Add an item to the user's saved list.
+	 * Idempotent: duplicate tenant_id+post_slug is silently ignored.
+	 */
+	private async handleSave(ctx: LoomRequestContext): Promise<Response> {
+		const data = safeJsonParse<SaveItemPayload | null>(await ctx.request.text(), null);
+
+		if (!data?.tenantId || !data?.postSlug || !data?.postTitle) {
+			return LoomResponse.badRequest("Missing required fields: tenantId, postSlug, postTitle");
+		}
+
+		const id = crypto.randomUUID();
+		const now = Date.now();
+
+		this.sql.exec(
+			`INSERT OR IGNORE INTO saved_items
+			 (id, item_type, tenant_id, tenant_subdomain, post_slug, post_title, saved_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			id,
+			data.itemType || "bloom",
+			data.tenantId,
+			data.tenantSubdomain || "",
+			data.postSlug,
+			data.postTitle,
+			now,
+		);
+
+		return Response.json({ success: true, id }, { status: 201 });
+	}
+
+	/**
+	 * DELETE /save/:id — Remove an item from the saved list.
+	 */
+	private handleUnsave(ctx: LoomRequestContext): Response {
+		const { id } = ctx.params;
+
+		this.sql.exec("DELETE FROM saved_items WHERE id = ?", id);
+
+		return Response.json({ success: true });
+	}
+
+	/**
+	 * GET /saved — Paginated saved list, newest first.
+	 * Query params: ?cursor={saved_at}&limit={number}
+	 */
+	private handleGetSaved(ctx: LoomRequestContext): Response {
+		const cursor = parseInt(ctx.query.get("cursor") || "0", 10) || 0;
+		const limit = Math.min(
+			parseInt(ctx.query.get("limit") || String(DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE,
+			MAX_PAGE_SIZE,
+		);
+
+		const items =
+			cursor > 0
+				? this.sql.queryAll<Record<string, unknown>>(
+						`SELECT id, item_type, tenant_id, tenant_subdomain, post_slug, post_title, saved_at
+					 FROM saved_items
+					 WHERE saved_at < ?
+					 ORDER BY saved_at DESC
+					 LIMIT ?`,
+						cursor,
+						limit + 1,
+					)
+				: this.sql.queryAll<Record<string, unknown>>(
+						`SELECT id, item_type, tenant_id, tenant_subdomain, post_slug, post_title, saved_at
+					 FROM saved_items
+					 ORDER BY saved_at DESC
+					 LIMIT ?`,
+						limit + 1,
+					);
+
+		const hasMore = items.length > limit;
+		const page = hasMore ? items.slice(0, limit) : items;
+		const nextCursor = hasMore ? (page[page.length - 1].saved_at as number) : null;
+
+		return Response.json({
+			items: page,
+			nextCursor,
+			hasMore,
+		});
+	}
+
+	/**
+	 * DELETE /tenant/:tenantId — Remove all feed items from an unfollowed tenant.
+	 * Called when a user unfollows a grove.
+	 */
+	private handleRemoveTenant(ctx: LoomRequestContext): Response {
+		const { tenantId } = ctx.params;
+
+		this.sql.exec("DELETE FROM feed_items WHERE tenant_id = ?", tenantId);
+
+		return Response.json({ success: true });
+	}
+
+	/**
+	 * GET /health — Health check with item counts.
+	 */
+	private handleHealth(): Response {
+		const feedCount = this.sql.queryOne<{ count: number }>(
+			"SELECT COUNT(*) as count FROM feed_items",
+		);
+		const savedCount = this.sql.queryOne<{ count: number }>(
+			"SELECT COUNT(*) as count FROM saved_items",
+		);
+
+		return Response.json({
+			status: "ok",
+			feedItems: feedCount?.count || 0,
+			savedItems: savedCount?.count || 0,
+			lastReadAt: this.state_data?.lastReadAt || 0,
+		});
+	}
+
+	// ════════════════════════════════════════════════════════════════════
+	// Alarm — Pruning
+	// ════════════════════════════════════════════════════════════════════
+
+	protected async onAlarm(): Promise<void> {
+		const cutoff = Date.now() - RETENTION_MS;
+
+		this.sql.exec("DELETE FROM feed_items WHERE published_at < ?", cutoff);
+		this.log.info("Pruned feed items", { cutoff });
+
+		// Check if there are still items to prune in the future
+		const remaining = this.sql.queryOne<{ count: number }>(
+			"SELECT COUNT(*) as count FROM feed_items",
+		);
+
+		if ((remaining?.count || 0) > 0) {
+			await this.alarms.schedule(ALARM_INTERVAL_MS);
+		}
+	}
+}

--- a/services/durable-objects/src/FeedDO.ts
+++ b/services/durable-objects/src/FeedDO.ts
@@ -68,14 +68,25 @@ export interface SaveItemPayload {
 /** Daily alarm for pruning old feed items. */
 const ALARM_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-/** Feed items older than this are pruned. */
-const RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
+/** Feed items older than this are pruned (seconds). */
+const RETENTION_SECONDS = 365 * 24 * 60 * 60;
 
 /** Default page size for feed and saved list queries. */
 const DEFAULT_PAGE_SIZE = 25;
 
 /** Maximum page size to prevent abuse. */
 const MAX_PAGE_SIZE = 100;
+
+/** Maximum string length for text fields to prevent storage abuse. */
+const MAX_TITLE_LENGTH = 500;
+const MAX_SLUG_LENGTH = 200;
+const MAX_EXCERPT_LENGTH = 1000;
+const MAX_NAME_LENGTH = 100;
+
+/** Truncate a string to a max length. */
+function truncate(value: string, max: number): string {
+	return value.length > max ? value.slice(0, max) : value;
+}
 
 // ============================================================================
 // FeedDO Class
@@ -157,7 +168,7 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 		}
 
 		const id = crypto.randomUUID();
-		const now = Date.now();
+		const now = Math.floor(Date.now() / 1000);
 
 		try {
 			this.sql.exec(
@@ -166,11 +177,11 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 				id,
 				data.tenantId,
-				data.tenantName || "",
-				data.tenantSubdomain || "",
-				data.postSlug,
-				data.postTitle,
-				data.postExcerpt || null,
+				truncate(data.tenantName || "", MAX_NAME_LENGTH),
+				truncate(data.tenantSubdomain || "", MAX_NAME_LENGTH),
+				truncate(data.postSlug, MAX_SLUG_LENGTH),
+				truncate(data.postTitle, MAX_TITLE_LENGTH),
+				data.postExcerpt ? truncate(data.postExcerpt, MAX_EXCERPT_LENGTH) : null,
 				data.postImage || null,
 				data.publishedAt || now,
 				now,
@@ -278,20 +289,30 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 		}
 
 		const id = crypto.randomUUID();
-		const now = Date.now();
+		const now = Math.floor(Date.now() / 1000);
 
-		this.sql.exec(
-			`INSERT OR IGNORE INTO saved_items
-			 (id, item_type, tenant_id, tenant_subdomain, post_slug, post_title, saved_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-			id,
-			data.itemType || "bloom",
-			data.tenantId,
-			data.tenantSubdomain || "",
-			data.postSlug,
-			data.postTitle,
-			now,
-		);
+		try {
+			this.sql.exec(
+				`INSERT OR IGNORE INTO saved_items
+				 (id, item_type, tenant_id, tenant_subdomain, post_slug, post_title, saved_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				id,
+				data.itemType || "bloom",
+				data.tenantId,
+				truncate(data.tenantSubdomain || "", MAX_NAME_LENGTH),
+				truncate(data.postSlug, MAX_SLUG_LENGTH),
+				truncate(data.postTitle, MAX_TITLE_LENGTH),
+				now,
+			);
+		} catch (err) {
+			this.log.errorWithCause("Save item failed", err);
+			return LoomResponse.error({
+				code: "GROVE-LOOM-080",
+				category: "bug",
+				userMessage: "Failed to save item.",
+				adminMessage: "Save item INSERT failed in FeedDO.",
+			});
+		}
 
 		return Response.json({ success: true, id }, { status: 201 });
 	}
@@ -384,7 +405,7 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 	// ════════════════════════════════════════════════════════════════════
 
 	protected async onAlarm(): Promise<void> {
-		const cutoff = Date.now() - RETENTION_MS;
+		const cutoff = Math.floor(Date.now() / 1000) - RETENTION_SECONDS;
 
 		this.sql.exec("DELETE FROM feed_items WHERE published_at < ?", cutoff);
 		this.log.info("Pruned feed items", { cutoff });

--- a/services/durable-objects/src/FeedDO.ts
+++ b/services/durable-objects/src/FeedDO.ts
@@ -207,38 +207,44 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 	 * Query params: ?cursor={published_at}&limit={number}
 	 */
 	private async handleGetFeed(ctx: LoomRequestContext): Promise<Response> {
-		const cursor = parseInt(ctx.query.get("cursor") || "0", 10) || 0;
+		const cursorTime = parseInt(ctx.query.get("cursor") || "0", 10) || 0;
+		const cursorId = ctx.query.get("cursor_id") || "";
 		const limit = Math.min(
 			parseInt(ctx.query.get("limit") || String(DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE,
 			MAX_PAGE_SIZE,
 		);
 
+		// Compound cursor: (published_at DESC, id DESC) for stable pagination
+		// when multiple items share the same published_at timestamp
 		const items =
-			cursor > 0
+			cursorTime > 0
 				? this.sql.queryAll<Record<string, unknown>>(
 						`SELECT id, tenant_id, tenant_name, tenant_subdomain, post_slug, post_title, post_excerpt, post_image, published_at, ingested_at
 					 FROM feed_items
-					 WHERE published_at < ?
-					 ORDER BY published_at DESC
+					 WHERE (published_at < ?) OR (published_at = ? AND id < ?)
+					 ORDER BY published_at DESC, id DESC
 					 LIMIT ?`,
-						cursor,
+						cursorTime,
+						cursorTime,
+						cursorId,
 						limit + 1,
 					)
 				: this.sql.queryAll<Record<string, unknown>>(
 						`SELECT id, tenant_id, tenant_name, tenant_subdomain, post_slug, post_title, post_excerpt, post_image, published_at, ingested_at
 					 FROM feed_items
-					 ORDER BY published_at DESC
+					 ORDER BY published_at DESC, id DESC
 					 LIMIT ?`,
 						limit + 1,
 					);
 
 		const hasMore = items.length > limit;
 		const page = hasMore ? items.slice(0, limit) : items;
-		const nextCursor = hasMore ? (page[page.length - 1].published_at as number) : null;
+		const lastItem = page.length > 0 ? page[page.length - 1] : null;
 
 		return Response.json({
 			items: page,
-			nextCursor,
+			nextCursor: hasMore && lastItem ? (lastItem.published_at as number) : null,
+			nextCursorId: hasMore && lastItem ? (lastItem.id as string) : null,
 			hasMore,
 		});
 	}
@@ -264,7 +270,7 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 	 * POST /feed/mark-read — Update last-read cursor to now.
 	 */
 	private handleMarkRead(): Response {
-		const now = Date.now();
+		const now = Math.floor(Date.now() / 1000);
 
 		if (!this.state_data) {
 			this.state_data = { userId: this.state.id.toString(), lastReadAt: now };
@@ -323,7 +329,17 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 	private handleUnsave(ctx: LoomRequestContext): Response {
 		const { id } = ctx.params;
 
-		this.sql.exec("DELETE FROM saved_items WHERE id = ?", id);
+		try {
+			this.sql.exec("DELETE FROM saved_items WHERE id = ?", id);
+		} catch (err) {
+			this.log.errorWithCause("Unsave failed", err);
+			return LoomResponse.error({
+				code: "GROVE-LOOM-080",
+				category: "bug",
+				userMessage: "Failed to remove saved item.",
+				adminMessage: "Unsave DELETE failed in FeedDO.",
+			});
+		}
 
 		return Response.json({ success: true });
 	}
@@ -333,38 +349,42 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 	 * Query params: ?cursor={saved_at}&limit={number}
 	 */
 	private handleGetSaved(ctx: LoomRequestContext): Response {
-		const cursor = parseInt(ctx.query.get("cursor") || "0", 10) || 0;
+		const cursorTime = parseInt(ctx.query.get("cursor") || "0", 10) || 0;
+		const cursorId = ctx.query.get("cursor_id") || "";
 		const limit = Math.min(
 			parseInt(ctx.query.get("limit") || String(DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE,
 			MAX_PAGE_SIZE,
 		);
 
 		const items =
-			cursor > 0
+			cursorTime > 0
 				? this.sql.queryAll<Record<string, unknown>>(
 						`SELECT id, item_type, tenant_id, tenant_subdomain, post_slug, post_title, saved_at
 					 FROM saved_items
-					 WHERE saved_at < ?
-					 ORDER BY saved_at DESC
+					 WHERE (saved_at < ?) OR (saved_at = ? AND id < ?)
+					 ORDER BY saved_at DESC, id DESC
 					 LIMIT ?`,
-						cursor,
+						cursorTime,
+						cursorTime,
+						cursorId,
 						limit + 1,
 					)
 				: this.sql.queryAll<Record<string, unknown>>(
 						`SELECT id, item_type, tenant_id, tenant_subdomain, post_slug, post_title, saved_at
 					 FROM saved_items
-					 ORDER BY saved_at DESC
+					 ORDER BY saved_at DESC, id DESC
 					 LIMIT ?`,
 						limit + 1,
 					);
 
 		const hasMore = items.length > limit;
 		const page = hasMore ? items.slice(0, limit) : items;
-		const nextCursor = hasMore ? (page[page.length - 1].saved_at as number) : null;
+		const lastItem = page.length > 0 ? page[page.length - 1] : null;
 
 		return Response.json({
 			items: page,
-			nextCursor,
+			nextCursor: hasMore && lastItem ? (lastItem.saved_at as number) : null,
+			nextCursorId: hasMore && lastItem ? (lastItem.id as string) : null,
 			hasMore,
 		});
 	}
@@ -373,10 +393,28 @@ export class FeedDO extends LoomDO<FeedState, FeedEnv> {
 	 * DELETE /tenant/:tenantId — Remove all feed items from an unfollowed tenant.
 	 * Called when a user unfollows a grove.
 	 */
+	/**
+	 * DELETE /tenant/:tenantId — Remove all feed items from an unfollowed tenant.
+	 * Called when a user unfollows a grove.
+	 *
+	 * AUTH NOTE: FeedDO is only addressable via service bindings from the DO worker.
+	 * The FeedDO namespace is never exposed to client-addressable code paths.
+	 * Security relies on the DO addressing invariant (feed:{userId}).
+	 */
 	private handleRemoveTenant(ctx: LoomRequestContext): Response {
 		const { tenantId } = ctx.params;
 
-		this.sql.exec("DELETE FROM feed_items WHERE tenant_id = ?", tenantId);
+		try {
+			this.sql.exec("DELETE FROM feed_items WHERE tenant_id = ?", tenantId);
+		} catch (err) {
+			this.log.errorWithCause("Remove tenant failed", err);
+			return LoomResponse.error({
+				code: "GROVE-LOOM-080",
+				category: "bug",
+				userMessage: "Failed to remove tenant items.",
+				adminMessage: "Remove tenant DELETE failed in FeedDO.",
+			});
+		}
 
 		return Response.json({ success: true });
 	}

--- a/services/durable-objects/src/index.ts
+++ b/services/durable-objects/src/index.ts
@@ -32,6 +32,7 @@ interface FeedQueueMessage {
 		excerpt?: string | null;
 		image?: string | null;
 		publishedAt: number;
+		_offset?: number;
 	};
 	timestamp: string;
 }
@@ -39,11 +40,59 @@ interface FeedQueueMessage {
 interface QueueEnv {
 	DB: D1Database;
 	FEED: DurableObjectNamespace;
+	FEED_QUEUE?: Queue;
 }
 
 // ============================================================================
 // Queue Consumer — Fan-out published posts to subscriber FeedDOs
 // ============================================================================
+
+/**
+ * Maximum followers to fan out per queue message.
+ * CF Workers have a 1000 subrequest limit; we stay well under with batched
+ * concurrency. If a tenant has more followers than this, the remaining are
+ * processed via a continuation message.
+ */
+const FAN_OUT_BATCH_SIZE = 200;
+
+/** Concurrent DO fetches per batch — prevents subrequest burst. */
+const FAN_OUT_CONCURRENCY = 50;
+
+/**
+ * Fan out to a slice of followers with bounded concurrency.
+ * Returns the number of successful deliveries.
+ */
+async function fanOutToFollowers(
+	followers: { user_id: string }[],
+	ingestPayload: string,
+	env: QueueEnv,
+): Promise<number> {
+	let delivered = 0;
+
+	for (let i = 0; i < followers.length; i += FAN_OUT_CONCURRENCY) {
+		const chunk = followers.slice(i, i + FAN_OUT_CONCURRENCY);
+		const results = await Promise.allSettled(
+			chunk.map(async (follower) => {
+				const feedId = env.FEED.idFromName(`feed:${follower.user_id}`);
+				const feedDO = env.FEED.get(feedId);
+				const res = await feedDO.fetch(
+					new Request("http://do/ingest", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: ingestPayload,
+					}),
+				);
+				if (!res.ok) {
+					console.warn(`[FeedQueue] Ingest failed for user ${follower.user_id}: ${res.status}`);
+				}
+				return res.ok;
+			}),
+		);
+		delivered += results.filter((r) => r.status === "fulfilled" && r.value).length;
+	}
+
+	return delivered;
+}
 
 async function handleFeedQueue(
 	batch: MessageBatch<FeedQueueMessage>,
@@ -71,11 +120,12 @@ async function handleFeedQueue(
 				continue;
 			}
 
-			// Find all users following this tenant
+			// Find followers in bounded batches
+			const offset = (payload as { _offset?: number })._offset || 0;
 			const followers = await env.DB.prepare(
-				"SELECT user_id FROM friends WHERE friend_tenant_id = ?",
+				"SELECT user_id FROM friends WHERE friend_tenant_id = ? LIMIT ? OFFSET ?",
 			)
-				.bind(payload.tenantId)
+				.bind(payload.tenantId, FAN_OUT_BATCH_SIZE + 1, offset)
 				.all<{ user_id: string }>();
 
 			if (!followers.results.length) {
@@ -83,7 +133,12 @@ async function handleFeedQueue(
 				continue;
 			}
 
-			// Fan out to each follower's FeedDO
+			// Check if there are more followers beyond this batch
+			const hasMore = followers.results.length > FAN_OUT_BATCH_SIZE;
+			const batch_followers = hasMore
+				? followers.results.slice(0, FAN_OUT_BATCH_SIZE)
+				: followers.results;
+
 			const ingestPayload = JSON.stringify({
 				tenantId: tenant.id,
 				tenantName: tenant.display_name || tenant.subdomain,
@@ -95,26 +150,21 @@ async function handleFeedQueue(
 				publishedAt: payload.publishedAt,
 			});
 
-			const fanOutPromises = followers.results.map(async (follower) => {
-				const feedId = env.FEED.idFromName(`feed:${follower.user_id}`);
-				const feedDO = env.FEED.get(feedId);
-				const res = await feedDO.fetch(
-					new Request("http://do/ingest", {
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: ingestPayload,
-					}),
-				);
-				if (!res.ok) {
-					console.warn(`[FeedQueue] Ingest failed for user ${follower.user_id}: ${res.status}`);
-				}
-			});
+			const delivered = await fanOutToFollowers(batch_followers, ingestPayload, env);
 
-			await Promise.allSettled(fanOutPromises);
+			// If more followers remain, re-enqueue with offset for next batch
+			if (hasMore && env.FEED_QUEUE) {
+				await env.FEED_QUEUE.send({
+					type: "post.published",
+					payload: { ...payload, _offset: offset + FAN_OUT_BATCH_SIZE },
+					timestamp: new Date().toISOString(),
+				});
+			}
+
 			message.ack();
 
 			console.log(
-				`[FeedQueue] Fanned out "${payload.title}" from ${tenant.subdomain} to ${followers.results.length} followers`,
+				`[FeedQueue] Delivered "${payload.title}" from ${tenant.subdomain} to ${delivered}/${batch_followers.length} followers (offset=${offset}${hasMore ? ", continuation queued" : ""})`,
 			);
 		} catch (err) {
 			console.error("[FeedQueue] Error processing message:", err);

--- a/services/durable-objects/src/index.ts
+++ b/services/durable-objects/src/index.ts
@@ -17,6 +17,115 @@ export { ExportDO } from "./ExportDO.js";
 export { TriageDO } from "./TriageDO.js";
 export { ThresholdDO } from "./ThresholdDO.js";
 export { ChatDO } from "./ChatDO.js";
+export { FeedDO } from "./FeedDO.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FeedQueueMessage {
+	type: string;
+	payload: {
+		tenantId: string;
+		slug: string;
+		title: string;
+		excerpt?: string | null;
+		image?: string | null;
+		publishedAt: number;
+	};
+	timestamp: string;
+}
+
+interface QueueEnv {
+	DB: D1Database;
+	FEED: DurableObjectNamespace;
+}
+
+// ============================================================================
+// Queue Consumer — Fan-out published posts to subscriber FeedDOs
+// ============================================================================
+
+async function handleFeedQueue(
+	batch: MessageBatch<FeedQueueMessage>,
+	env: QueueEnv,
+): Promise<void> {
+	for (const message of batch.messages) {
+		const { type, payload } = message.body;
+
+		if (type !== "post.published") {
+			message.ack();
+			continue;
+		}
+
+		try {
+			// Look up tenant info for enrichment
+			const tenant = await env.DB.prepare(
+				"SELECT id, subdomain, display_name FROM tenants WHERE id = ? AND active = 1",
+			)
+				.bind(payload.tenantId)
+				.first<{ id: string; subdomain: string; display_name: string }>();
+
+			if (!tenant) {
+				console.warn(`[FeedQueue] Tenant ${payload.tenantId} not found or inactive`);
+				message.ack();
+				continue;
+			}
+
+			// Find all users following this tenant
+			const followers = await env.DB.prepare(
+				"SELECT user_id FROM friends WHERE friend_tenant_id = ?",
+			)
+				.bind(payload.tenantId)
+				.all<{ user_id: string }>();
+
+			if (!followers.results.length) {
+				message.ack();
+				continue;
+			}
+
+			// Fan out to each follower's FeedDO
+			const ingestPayload = JSON.stringify({
+				tenantId: tenant.id,
+				tenantName: tenant.display_name || tenant.subdomain,
+				tenantSubdomain: tenant.subdomain,
+				postSlug: payload.slug,
+				postTitle: payload.title,
+				postExcerpt: payload.excerpt || null,
+				postImage: payload.image || null,
+				publishedAt: payload.publishedAt,
+			});
+
+			const fanOutPromises = followers.results.map(async (follower) => {
+				const feedId = env.FEED.idFromName(`feed:${follower.user_id}`);
+				const feedDO = env.FEED.get(feedId);
+				const res = await feedDO.fetch(
+					new Request("http://do/ingest", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: ingestPayload,
+					}),
+				);
+				if (!res.ok) {
+					console.warn(`[FeedQueue] Ingest failed for user ${follower.user_id}: ${res.status}`);
+				}
+			});
+
+			await Promise.allSettled(fanOutPromises);
+			message.ack();
+
+			console.log(
+				`[FeedQueue] Fanned out "${payload.title}" from ${tenant.subdomain} to ${followers.results.length} followers`,
+			);
+		} catch (err) {
+			console.error("[FeedQueue] Error processing message:", err);
+			message.retry();
+		}
+	}
+}
+
+// ============================================================================
+// Worker Export
+// ============================================================================
 
 // Minimal fetch handler for health checks
 export default {
@@ -36,6 +145,7 @@ export default {
 					"TriageDO",
 					"ThresholdDO",
 					"ChatDO",
+					"FeedDO",
 				],
 			});
 		}
@@ -43,5 +153,9 @@ export default {
 		return new Response("Grove Durable Objects Worker", {
 			headers: { "Content-Type": "text/plain" },
 		});
+	},
+
+	async queue(batch: MessageBatch<FeedQueueMessage>, env: QueueEnv): Promise<void> {
+		await handleFeedQueue(batch, env);
 	},
 };

--- a/services/durable-objects/src/index.ts
+++ b/services/durable-objects/src/index.ts
@@ -151,9 +151,15 @@ async function handleFeedQueue(
 			});
 
 			const delivered = await fanOutToFollowers(batch_followers, ingestPayload, env);
+			const failed = batch_followers.length - delivered;
 
-			// If more followers remain, re-enqueue with offset for next batch
-			if (hasMore && env.FEED_QUEUE) {
+			// If more followers remain, re-enqueue with offset for next batch.
+			// Throw on send failure so the message retries instead of silently
+			// truncating the fan-out for remaining followers.
+			if (hasMore) {
+				if (!env.FEED_QUEUE) {
+					throw new Error("[FeedQueue] FEED_QUEUE binding missing — cannot send continuation");
+				}
 				await env.FEED_QUEUE.send({
 					type: "post.published",
 					payload: { ...payload, _offset: offset + FAN_OUT_BATCH_SIZE },
@@ -161,11 +167,19 @@ async function handleFeedQueue(
 				});
 			}
 
-			message.ack();
-
-			console.log(
-				`[FeedQueue] Delivered "${payload.title}" from ${tenant.subdomain} to ${delivered}/${batch_followers.length} followers (offset=${offset}${hasMore ? ", continuation queued" : ""})`,
-			);
+			// Retry the entire message if any deliveries failed.
+			// INSERT OR IGNORE dedup makes retries safe for already-delivered followers.
+			if (failed > 0) {
+				console.warn(
+					`[FeedQueue] ${failed}/${batch_followers.length} deliveries failed for "${payload.title}" from ${tenant.subdomain} (offset=${offset}) — retrying`,
+				);
+				message.retry();
+			} else {
+				message.ack();
+				console.log(
+					`[FeedQueue] Delivered "${payload.title}" from ${tenant.subdomain} to ${delivered} followers (offset=${offset}${hasMore ? ", continuation queued" : ""})`,
+				);
+			}
 		} catch (err) {
 			console.error("[FeedQueue] Error processing message:", err);
 			message.retry();

--- a/services/durable-objects/wrangler.toml
+++ b/services/durable-objects/wrangler.toml
@@ -55,6 +55,11 @@ class_name = "ThresholdDO"
 name = "CHAT"
 class_name = "ChatDO"
 
+# FeedDO: Per-user social feed aggregation + saved items (Loom pattern)
+[[durable_objects.bindings]]
+name = "FEED"
+class_name = "FeedDO"
+
 # =============================================================================
 # DO Migrations - Declare new SQLite-backed classes
 # =============================================================================
@@ -85,6 +90,10 @@ new_sqlite_classes = ["ThresholdDO"]
 [[migrations]]
 tag = "v7"
 new_sqlite_classes = ["ChatDO"]
+
+[[migrations]]
+tag = "v8"
+new_sqlite_classes = ["FeedDO"]
 
 # =============================================================================
 # Zephyr Service Binding (email gateway — for ExportDO email delivery)
@@ -142,3 +151,15 @@ bucket_name = "grove-media"
 [[r2_buckets]]
 binding = "EXPORTS_BUCKET"
 bucket_name = "grove-exports"
+
+# =============================================================================
+# Queue - Feed events (post.published fan-out to subscriber FeedDOs)
+# =============================================================================
+[[queues.producers]]
+queue = "grove-feed-events"
+binding = "FEED_QUEUE"
+
+[[queues.consumers]]
+queue = "grove-feed-events"
+max_batch_size = 10
+max_retries = 3


### PR DESCRIPTION
## Summary

- **FeedDO**: Per-user Durable Object (`feed:{userId}`) for social feed aggregation + saved items, built on the Loom SDK
- **CF Queue pipeline**: Aspen emits `post.published` → `grove-feed-events` queue → DO worker fans out to subscriber FeedDOs via the `friends` table
- **Publish hook**: Fire-and-forget via `waitUntil` in bloom-service — zero impact on publish latency
- **Wiring**: v8 DO migration, queue producer/consumer bindings, Aspen env types

## FeedDO Routes

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/ingest` | Receive post from queue consumer (idempotent) |
| GET | `/feed` | Paginated feed (cursor = published_at) |
| GET | `/feed/unread` | Count since last-read |
| POST | `/feed/mark-read` | Update read cursor |
| POST | `/save` | Bookmark an item (idempotent) |
| DELETE | `/save/:id` | Remove bookmark |
| GET | `/saved` | Paginated saved list |
| DELETE | `/tenant/:tenantId` | Cleanup on unfollow |
| GET | `/health` | Status + counts |

## Architecture

```
Bloom published → Aspen waitUntil(FEED_QUEUE.send()) →
  grove-feed-events CF Queue →
    DO worker queue() consumer →
      queries D1 friends table for followers →
        fans out to FeedDO:userId /ingest for each
```

## Design decisions

- **Per-user** (not per-tenant): scales with readers, supports grove-less users
- **Blooms only** for v1 — Meadow notes later
- **CF Queues** via Loom SDK's emit pattern — sub-second, retryable, decoupled
- **Saved list in FeedDO** — unified bookmarks across domains; PostMetaDO keeps aggregate counts
- **Time-based retention** (1 year) via daily alarm

## Test plan

- [x] 14 FeedDO unit tests covering all routes, pagination, alarm pruning, error cases
- [x] 207 total DO tests passing
- [x] TypeScript type checks clean (both DO worker and Aspen)
- [x] Prettier + ESLint + pre-commit hooks pass
- [ ] Deploy to staging — publish a test bloom, verify queue delivery + fan-out
- [ ] Verify CF Queue created in dashboard after first deploy

## Related issues

Closes #1423 (FeedDO portion — NotificationDO and AnalyticsDO remain for future work)
Enables #1547 (subscriptions v1), #1548 (Lantern feed tab), #1529 (unified saved list)

🤖 Generated with [Claude Code](https://claude.ai/code)