### PR TITLE
feat: subscriptions v1 — email notifications for followed groves (#1547)

### DIFF
--- a/apps/aspen/src/routes/+page.svelte
+++ b/apps/aspen/src/routes/+page.svelte
@@ -4,11 +4,12 @@
 	import GlassCard from "@autumnsgrove/lattice/ui/components/ui/GlassCard.svelte";
 	import GroveTerm from "@autumnsgrove/lattice/components/terminology/GroveTerm.svelte";
 	import FollowButton from "@autumnsgrove/lattice/ui/components/chrome/FollowButton.svelte";
+	import SubscribeButton from "@autumnsgrove/lattice/ui/components/chrome/SubscribeButton.svelte";
 	import ShareButton from "@autumnsgrove/lattice/ui/components/chrome/ShareButton.svelte";
 
 	let { data } = $props();
 
-	// Show follow button when a logged-in visitor is on someone else's grove
+	// Show follow/subscribe buttons when a logged-in visitor is on someone else's grove
 	const showFollow = $derived(data.user && !data.isOwner && data.context?.type === "tenant");
 	// Show share button for the grove owner
 	const showShare = $derived(data.isOwner);
@@ -71,6 +72,7 @@
 							subdomain={data.context.tenant.subdomain}
 							name={data.context.tenant.name}
 						/>
+						<SubscribeButton tenantId={data.context.tenant.id} name={data.context.tenant.name} />
 					{/if}
 					{#if showShare && data.context?.type === "tenant"}
 						<ShareButton title={data.context.tenant.name} />

--- a/apps/aspen/src/routes/api/subscriptions/[tenantId]/+server.ts
+++ b/apps/aspen/src/routes/api/subscriptions/[tenantId]/+server.ts
@@ -1,0 +1,126 @@
+/**
+ * Subscriptions API — Email notification subscriptions
+ *
+ * POST   /api/subscriptions/[tenantId] — Subscribe to email notifications
+ * DELETE /api/subscriptions/[tenantId] — Unsubscribe
+ * GET    /api/subscriptions/[tenantId] — Check subscription status
+ *
+ * User-scoped: uses locals.user.id directly. No grove required.
+ */
+
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { API_ERRORS, throwGroveError, logGroveError } from "@autumnsgrove/lattice/errors";
+import {
+	subscribe,
+	unsubscribe,
+	isSubscribed,
+} from "@autumnsgrove/lattice/server/services/subscriptions";
+import { validateUUID } from "@autumnsgrove/lattice/utils/validation";
+import { createThreshold } from "@autumnsgrove/lattice/platform/threshold";
+import { thresholdCheck } from "@autumnsgrove/lattice/platform/threshold/sveltekit";
+
+export const POST: RequestHandler = async ({ params, request, platform, locals }) => {
+	if (!locals.user) throwGroveError(401, API_ERRORS.UNAUTHORIZED, "API");
+
+	const tenantId = params.tenantId;
+	if (!tenantId || !validateUUID(tenantId)) {
+		throwGroveError(400, API_ERRORS.MISSING_REQUIRED_FIELDS, "API");
+	}
+
+	const db = platform?.env?.DB;
+	if (!db) throwGroveError(500, API_ERRORS.DB_NOT_CONFIGURED, "API");
+
+	// Prevent subscribing to your own grove
+	if (locals.tenantId && tenantId === locals.tenantId) {
+		throwGroveError(400, API_ERRORS.INVALID_REQUEST_BODY, "API");
+	}
+
+	// Rate limit: 30 subscription actions per hour
+	const threshold = createThreshold(platform?.env, { identifier: locals.user.id });
+	if (threshold) {
+		const denied = await thresholdCheck(threshold, {
+			key: "subscriptions/toggle",
+			limit: 30,
+			windowSeconds: 3600,
+			failMode: "open",
+		});
+		if (denied) return denied;
+	}
+
+	try {
+		const body = await request.json().catch(() => ({}));
+		const timezone =
+			(body as Record<string, string>).timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+		const result = await subscribe(db, locals.user.id, locals.user.email, tenantId, timezone);
+		return json({ success: true, subscribed: true, created: result.created });
+	} catch (error) {
+		if (error && typeof error === "object" && "status" in error) throw error;
+		logGroveError("API", API_ERRORS.OPERATION_FAILED, {
+			detail: "Subscription create failed",
+			cause: error,
+		});
+		throwGroveError(500, API_ERRORS.OPERATION_FAILED, "API");
+	}
+};
+
+export const DELETE: RequestHandler = async ({ params, platform, locals }) => {
+	if (!locals.user) throwGroveError(401, API_ERRORS.UNAUTHORIZED, "API");
+
+	const tenantId = params.tenantId;
+	if (!tenantId || !validateUUID(tenantId)) {
+		throwGroveError(400, API_ERRORS.MISSING_REQUIRED_FIELDS, "API");
+	}
+
+	const db = platform?.env?.DB;
+	if (!db) throwGroveError(500, API_ERRORS.DB_NOT_CONFIGURED, "API");
+
+	// Rate limit
+	const threshold = createThreshold(platform?.env, { identifier: locals.user.id });
+	if (threshold) {
+		const denied = await thresholdCheck(threshold, {
+			key: "subscriptions/toggle",
+			limit: 30,
+			windowSeconds: 3600,
+			failMode: "open",
+		});
+		if (denied) return denied;
+	}
+
+	try {
+		const removed = await unsubscribe(db, locals.user.id, tenantId);
+		return json({ success: true, subscribed: false, removed });
+	} catch (error) {
+		if (error && typeof error === "object" && "status" in error) throw error;
+		logGroveError("API", API_ERRORS.OPERATION_FAILED, {
+			detail: "Subscription delete failed",
+			cause: error,
+		});
+		throwGroveError(500, API_ERRORS.OPERATION_FAILED, "API");
+	}
+};
+
+export const GET: RequestHandler = async ({ params, platform, locals }) => {
+	if (!locals.user) throwGroveError(401, API_ERRORS.UNAUTHORIZED, "API");
+
+	const tenantId = params.tenantId;
+	if (!tenantId || !validateUUID(tenantId)) {
+		throwGroveError(400, API_ERRORS.MISSING_REQUIRED_FIELDS, "API");
+	}
+
+	const db = platform?.env?.DB;
+	if (!db) throwGroveError(500, API_ERRORS.DB_NOT_CONFIGURED, "API");
+
+	try {
+		const subscribed = await isSubscribed(db, locals.user.id, tenantId);
+		return json({ subscribed });
+	} catch (error) {
+		if (error && typeof error === "object" && "status" in error) throw error;
+		logGroveError("API", API_ERRORS.OPERATION_FAILED, {
+			detail: "Subscription check failed",
+			cause: error,
+		});
+		throwGroveError(500, API_ERRORS.OPERATION_FAILED, "API");
+	}
+};

--- a/apps/aspen/src/routes/api/subscriptions/subscriptions.test.ts
+++ b/apps/aspen/src/routes/api/subscriptions/subscriptions.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Subscriptions API Tests
+ *
+ * Tests POST (subscribe), DELETE (unsubscribe), and GET (check status) endpoints.
+ * Mocks the subscriptions service at the boundary.
+ *
+ * User-scoped: endpoints use locals.user.id directly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST, DELETE, GET } from "./[tenantId]/+server";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("@autumnsgrove/lattice/platform/threshold/factory", () => ({
+	createThreshold: vi.fn(() => null),
+}));
+
+vi.mock("@autumnsgrove/lattice/platform/threshold/sveltekit", () => ({
+	thresholdCheck: vi.fn(),
+}));
+
+vi.mock("@autumnsgrove/lattice/server/services/subscriptions", () => ({
+	subscribe: vi.fn(),
+	unsubscribe: vi.fn(),
+	isSubscribed: vi.fn(),
+}));
+
+import {
+	subscribe,
+	unsubscribe,
+	isSubscribed,
+} from "@autumnsgrove/lattice/server/services/subscriptions";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const TEST_USER = { id: "user-1", email: "test@example.com" };
+const VALID_TENANT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+function createMockDB() {
+	return {
+		prepare: vi.fn(() => ({
+			bind: vi.fn().mockReturnThis(),
+			all: vi.fn().mockResolvedValue({ results: [] }),
+			first: vi.fn().mockResolvedValue(null),
+			run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } }),
+		})),
+	};
+}
+
+function createPOSTEvent(
+	tenantId: string,
+	db: ReturnType<typeof createMockDB>,
+	user = TEST_USER,
+	body: Record<string, unknown> = {},
+) {
+	return {
+		params: { tenantId },
+		request: new Request("https://example.com/api/subscriptions/" + tenantId, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		}),
+		platform: { env: { DB: db } },
+		locals: { user, tenantId: "user-own-tenant" },
+	} as unknown as Parameters<typeof POST>[0];
+}
+
+function createDELETEEvent(
+	tenantId: string,
+	db: ReturnType<typeof createMockDB>,
+	user = TEST_USER,
+) {
+	return {
+		params: { tenantId },
+		platform: { env: { DB: db } },
+		locals: { user },
+	} as unknown as Parameters<typeof DELETE>[0];
+}
+
+function createGETEvent(tenantId: string, db: ReturnType<typeof createMockDB>, user = TEST_USER) {
+	return {
+		params: { tenantId },
+		platform: { env: { DB: db } },
+		locals: { user },
+	} as unknown as Parameters<typeof GET>[0];
+}
+
+// ── POST /api/subscriptions/[tenantId] ─────────────────────────────────────
+
+describe("POST /api/subscriptions/[tenantId]", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should subscribe and return success", async () => {
+		vi.mocked(subscribe).mockResolvedValue({ created: true });
+
+		const db = createMockDB();
+		const response = await POST(createPOSTEvent(VALID_TENANT_ID, db));
+		const data = (await response.json()) as any;
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.subscribed).toBe(true);
+		expect(data.created).toBe(true);
+	});
+
+	it("should pass timezone from request body", async () => {
+		vi.mocked(subscribe).mockResolvedValue({ created: true });
+
+		const db = createMockDB();
+		await POST(createPOSTEvent(VALID_TENANT_ID, db, TEST_USER, { timezone: "Europe/London" }));
+
+		expect(subscribe).toHaveBeenCalledWith(
+			db,
+			"user-1",
+			"test@example.com",
+			VALID_TENANT_ID,
+			"Europe/London",
+		);
+	});
+
+	it("should reject unauthenticated requests", async () => {
+		const db = createMockDB();
+		const event = createPOSTEvent(VALID_TENANT_ID, db, null as any);
+
+		await expect(POST(event)).rejects.toThrow();
+	});
+
+	it("should reject invalid UUID tenant ID", async () => {
+		const db = createMockDB();
+		const event = createPOSTEvent("not-a-uuid", db);
+
+		await expect(POST(event)).rejects.toThrow();
+	});
+
+	it("should prevent self-subscription", async () => {
+		const db = createMockDB();
+		// Create event where the user's own tenantId matches the target
+		const event = {
+			params: { tenantId: "user-own-tenant" },
+			request: new Request("https://example.com/api/subscriptions/user-own-tenant", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({}),
+			}),
+			platform: { env: { DB: db } },
+			locals: { user: TEST_USER, tenantId: "user-own-tenant" },
+		} as unknown as Parameters<typeof POST>[0];
+
+		await expect(POST(event)).rejects.toThrow();
+	});
+
+	it("should handle idempotent subscription (already exists)", async () => {
+		vi.mocked(subscribe).mockResolvedValue({ created: false });
+
+		const db = createMockDB();
+		const response = await POST(createPOSTEvent(VALID_TENANT_ID, db));
+		const data = (await response.json()) as any;
+
+		expect(response.status).toBe(200);
+		expect(data.created).toBe(false);
+	});
+});
+
+// ── DELETE /api/subscriptions/[tenantId] ────────────────────────────────────
+
+describe("DELETE /api/subscriptions/[tenantId]", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should unsubscribe and return success", async () => {
+		vi.mocked(unsubscribe).mockResolvedValue(true);
+
+		const db = createMockDB();
+		const response = await DELETE(createDELETEEvent(VALID_TENANT_ID, db));
+		const data = (await response.json()) as any;
+
+		expect(response.status).toBe(200);
+		expect(data.success).toBe(true);
+		expect(data.subscribed).toBe(false);
+	});
+
+	it("should reject unauthenticated requests", async () => {
+		const db = createMockDB();
+		const event = createDELETEEvent(VALID_TENANT_ID, db, null as any);
+
+		await expect(DELETE(event)).rejects.toThrow();
+	});
+
+	it("should reject invalid UUID tenant ID", async () => {
+		const db = createMockDB();
+		const event = createDELETEEvent("not-a-uuid", db);
+
+		await expect(DELETE(event)).rejects.toThrow();
+	});
+
+	it("should call unsubscribe with user ID and tenant ID", async () => {
+		vi.mocked(unsubscribe).mockResolvedValue(true);
+
+		const db = createMockDB();
+		await DELETE(createDELETEEvent(VALID_TENANT_ID, db));
+
+		expect(unsubscribe).toHaveBeenCalledWith(db, "user-1", VALID_TENANT_ID);
+	});
+});
+
+// ── GET /api/subscriptions/[tenantId] ──────────────────────────────────────
+
+describe("GET /api/subscriptions/[tenantId]", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should return subscribed=true when subscribed", async () => {
+		vi.mocked(isSubscribed).mockResolvedValue(true);
+
+		const db = createMockDB();
+		const response = await GET(createGETEvent(VALID_TENANT_ID, db));
+		const data = (await response.json()) as any;
+
+		expect(response.status).toBe(200);
+		expect(data.subscribed).toBe(true);
+	});
+
+	it("should return subscribed=false when not subscribed", async () => {
+		vi.mocked(isSubscribed).mockResolvedValue(false);
+
+		const db = createMockDB();
+		const response = await GET(createGETEvent(VALID_TENANT_ID, db));
+		const data = (await response.json()) as any;
+
+		expect(response.status).toBe(200);
+		expect(data.subscribed).toBe(false);
+	});
+
+	it("should reject unauthenticated requests", async () => {
+		const db = createMockDB();
+		const event = createGETEvent(VALID_TENANT_ID, db, null as any);
+
+		await expect(GET(event)).rejects.toThrow();
+	});
+
+	it("should reject invalid UUID tenant ID", async () => {
+		const db = createMockDB();
+		const event = createGETEvent("not-a-uuid", db);
+
+		await expect(GET(event)).rejects.toThrow();
+	});
+
+	it("should call isSubscribed with user ID and tenant ID", async () => {
+		vi.mocked(isSubscribed).mockResolvedValue(false);
+
+		const db = createMockDB();
+		await GET(createGETEvent(VALID_TENANT_ID, db));
+
+		expect(isSubscribed).toHaveBeenCalledWith(db, "user-1", VALID_TENANT_ID);
+	});
+});

--- a/apps/aspen/src/routes/arbor/settings/+page.svelte
+++ b/apps/aspen/src/routes/arbor/settings/+page.svelte
@@ -255,10 +255,29 @@
 						<span class="status-line">Rings &middot; Trail &middot; Reeds</span>
 						<span class="status-line">Curios &middot; Reverie</span>
 						{#if curiosCount > 0}
-							<span class="status-line subtle">{curiosCount} curio{curiosCount === 1 ? "" : "s"} active</span>
+							<span class="status-line subtle"
+								>{curiosCount} curio{curiosCount === 1 ? "" : "s"} active</span
+							>
 						{/if}
 					</div>
 					<span class="card-action">Explore &rarr;</span>
+				</div>
+			</GlassCard>
+		</a>
+
+		<!-- Subscriptions Card -->
+		<a href="/arbor/subscriptions" class="card-link">
+			<GlassCard variant="frosted" hoverable flush class="h-full flex flex-col">
+				<div class="card-body">
+					<div class="card-header">
+						<featureIcons.mail class="card-icon" />
+						<h2 class="card-title">Subscriptions</h2>
+					</div>
+					<div class="card-status">
+						<span class="status-line">Email updates from groves you follow</span>
+						<span class="status-line subtle">Timezone &middot; schedule &middot; preferences</span>
+					</div>
+					<span class="card-action">Manage &rarr;</span>
 				</div>
 			</GlassCard>
 		</a>

--- a/apps/aspen/src/routes/arbor/subscriptions/+page.server.ts
+++ b/apps/aspen/src/routes/arbor/subscriptions/+page.server.ts
@@ -5,13 +5,26 @@
  * Allows managing preferences (timezone, preferred hour) and unsubscribing.
  */
 
+import { z } from "zod";
 import { fail } from "@sveltejs/kit";
 import type { Actions, PageServerLoad } from "./$types";
+import { parseFormData } from "@autumnsgrove/lattice/server/utils/form-data";
+import { validateUUID } from "@autumnsgrove/lattice/utils/validation";
 import {
 	getUserSubscriptions,
 	unsubscribe,
 	updatePreferences,
 } from "@autumnsgrove/lattice/server/services/subscriptions";
+
+const UnsubscribeSchema = z.object({
+	tenantId: z.string().min(1),
+});
+
+const PreferencesSchema = z.object({
+	tenantId: z.string().min(1),
+	timezone: z.string().optional(),
+	preferredHour: z.coerce.number().min(0).max(23).optional(),
+});
 
 export const load: PageServerLoad = async ({ locals, platform }) => {
 	if (!locals.user || !platform?.env?.DB) {
@@ -30,10 +43,14 @@ export const actions: Actions = {
 		}
 
 		const formData = await request.formData();
-		const tenantId = formData.get("tenantId")?.toString();
-		if (!tenantId) return fail(400, { error: "Missing tenant ID" });
+		const result = parseFormData(formData, UnsubscribeSchema);
+		if (!result.success) return fail(400, { error: "Invalid request" });
 
-		await unsubscribe(platform.env.DB, locals.user.id, tenantId);
+		if (!validateUUID(result.data.tenantId)) {
+			return fail(400, { error: "Invalid tenant ID" });
+		}
+
+		await unsubscribe(platform.env.DB, locals.user.id, result.data.tenantId);
 		return { success: true, action: "unsubscribed" };
 	},
 
@@ -43,20 +60,23 @@ export const actions: Actions = {
 		}
 
 		const formData = await request.formData();
-		const tenantId = formData.get("tenantId")?.toString();
-		const timezone = formData.get("timezone")?.toString();
-		const preferredHourStr = formData.get("preferredHour")?.toString();
+		const result = parseFormData(formData, PreferencesSchema);
+		if (!result.success) return fail(400, { error: "Invalid request" });
 
-		if (!tenantId) return fail(400, { error: "Missing tenant ID" });
-
-		const prefs: { preferredHour?: number; timezone?: string } = {};
-		if (timezone) prefs.timezone = timezone;
-		if (preferredHourStr) {
-			const hour = parseInt(preferredHourStr, 10);
-			if (hour >= 0 && hour <= 23) prefs.preferredHour = hour;
+		if (!validateUUID(result.data.tenantId)) {
+			return fail(400, { error: "Invalid tenant ID" });
 		}
 
-		const updated = await updatePreferences(platform.env.DB, locals.user.id, tenantId, prefs);
+		const prefs: { preferredHour?: number; timezone?: string } = {};
+		if (result.data.timezone) prefs.timezone = result.data.timezone;
+		if (result.data.preferredHour !== undefined) prefs.preferredHour = result.data.preferredHour;
+
+		const updated = await updatePreferences(
+			platform.env.DB,
+			locals.user.id,
+			result.data.tenantId,
+			prefs,
+		);
 		if (!updated) return fail(400, { error: "Could not update preferences" });
 
 		return { success: true, action: "updated" };

--- a/apps/aspen/src/routes/arbor/subscriptions/+page.server.ts
+++ b/apps/aspen/src/routes/arbor/subscriptions/+page.server.ts
@@ -1,0 +1,64 @@
+/**
+ * Arbor Subscriptions — Manage email notification subscriptions
+ *
+ * Lists all groves the current user has subscribed to for email updates.
+ * Allows managing preferences (timezone, preferred hour) and unsubscribing.
+ */
+
+import { fail } from "@sveltejs/kit";
+import type { Actions, PageServerLoad } from "./$types";
+import {
+	getUserSubscriptions,
+	unsubscribe,
+	updatePreferences,
+} from "@autumnsgrove/lattice/server/services/subscriptions";
+
+export const load: PageServerLoad = async ({ locals, platform }) => {
+	if (!locals.user || !platform?.env?.DB) {
+		return { subscriptions: [] };
+	}
+
+	const subscriptions = await getUserSubscriptions(platform.env.DB, locals.user.id);
+
+	return { subscriptions };
+};
+
+export const actions: Actions = {
+	unsubscribe: async ({ request, locals, platform }) => {
+		if (!locals.user || !platform?.env?.DB) {
+			return fail(401, { error: "Unauthorized" });
+		}
+
+		const formData = await request.formData();
+		const tenantId = formData.get("tenantId")?.toString();
+		if (!tenantId) return fail(400, { error: "Missing tenant ID" });
+
+		await unsubscribe(platform.env.DB, locals.user.id, tenantId);
+		return { success: true, action: "unsubscribed" };
+	},
+
+	updatePreferences: async ({ request, locals, platform }) => {
+		if (!locals.user || !platform?.env?.DB) {
+			return fail(401, { error: "Unauthorized" });
+		}
+
+		const formData = await request.formData();
+		const tenantId = formData.get("tenantId")?.toString();
+		const timezone = formData.get("timezone")?.toString();
+		const preferredHourStr = formData.get("preferredHour")?.toString();
+
+		if (!tenantId) return fail(400, { error: "Missing tenant ID" });
+
+		const prefs: { preferredHour?: number; timezone?: string } = {};
+		if (timezone) prefs.timezone = timezone;
+		if (preferredHourStr) {
+			const hour = parseInt(preferredHourStr, 10);
+			if (hour >= 0 && hour <= 23) prefs.preferredHour = hour;
+		}
+
+		const updated = await updatePreferences(platform.env.DB, locals.user.id, tenantId, prefs);
+		if (!updated) return fail(400, { error: "Could not update preferences" });
+
+		return { success: true, action: "updated" };
+	},
+};

--- a/apps/aspen/src/routes/arbor/subscriptions/+page.svelte
+++ b/apps/aspen/src/routes/arbor/subscriptions/+page.svelte
@@ -1,0 +1,273 @@
+<script lang="ts">
+	import GlassCard from "@autumnsgrove/lattice/ui/components/ui/GlassCard.svelte";
+	import Button from "@autumnsgrove/lattice/ui/components/ui/Button.svelte";
+	import { featureIcons, stateIcons } from "@autumnsgrove/prism/icons";
+	import { enhance } from "$app/forms";
+
+	let { data, form } = $props();
+
+	const subscriptions = $derived(data.subscriptions ?? []);
+
+	// Generate hour options for the dropdown
+	const hours = Array.from({ length: 24 }, (_, i) => {
+		const label =
+			i === 0 ? "12:00 AM" : i < 12 ? `${i}:00 AM` : i === 12 ? "12:00 PM" : `${i - 12}:00 PM`;
+		return { value: i, label };
+	});
+
+	// Get common timezones for the dropdown
+	let timezones: string[] = [];
+	try {
+		timezones = Intl.supportedValuesOf("timeZone");
+	} catch {
+		timezones = [
+			"America/New_York",
+			"America/Chicago",
+			"America/Denver",
+			"America/Los_Angeles",
+			"Europe/London",
+			"Europe/Paris",
+			"Asia/Tokyo",
+			"Australia/Sydney",
+		];
+	}
+</script>
+
+<svelte:head>
+	<title>Email Subscriptions — Arbor</title>
+</svelte:head>
+
+<div class="settings-page">
+	<header class="page-header">
+		<h1>
+			<featureIcons.mail class="inline-icon" />
+			Email Subscriptions
+		</h1>
+		<p class="subtitle">Manage email notifications from groves you follow.</p>
+	</header>
+
+	{#if form?.success}
+		<div class="notice success" role="status">
+			<stateIcons.check class="notice-icon" />
+			{form.action === "unsubscribed" ? "Unsubscribed successfully." : "Preferences updated."}
+		</div>
+	{/if}
+
+	{#if subscriptions.length === 0}
+		<GlassCard variant="frosted" hoverable={false}>
+			<div class="empty-state">
+				<featureIcons.mail class="empty-icon" />
+				<h2>No subscriptions yet</h2>
+				<p>
+					When you subscribe to email updates from other groves, they'll appear here. Visit another
+					grove and click "Subscribe" to get started.
+				</p>
+			</div>
+		</GlassCard>
+	{:else}
+		<div class="subscriptions-list">
+			{#each subscriptions as sub}
+				<GlassCard variant="frosted" hoverable={false} class="subscription-card">
+					<div class="sub-header">
+						<div class="sub-grove-info">
+							<a href="https://{sub.groveSubdomain}.grove.place" class="sub-grove-name">
+								{sub.groveName || sub.groveSubdomain}
+							</a>
+							<span class="sub-grove-url">{sub.groveSubdomain}.grove.place</span>
+						</div>
+						<form method="POST" action="?/unsubscribe" use:enhance>
+							<input type="hidden" name="tenantId" value={sub.targetTenantId} />
+							<Button type="submit" variant="outline" size="sm">Unsubscribe</Button>
+						</form>
+					</div>
+
+					<form method="POST" action="?/updatePreferences" use:enhance class="sub-prefs">
+						<input type="hidden" name="tenantId" value={sub.targetTenantId} />
+
+						<div class="pref-row">
+							<label for="hour-{sub.id}" class="pref-label">Send at</label>
+							<select
+								id="hour-{sub.id}"
+								name="preferredHour"
+								class="pref-select"
+								value={sub.preferredHour}
+							>
+								{#each hours as hour}
+									<option value={hour.value} selected={hour.value === sub.preferredHour}>
+										{hour.label}
+									</option>
+								{/each}
+							</select>
+						</div>
+
+						<div class="pref-row">
+							<label for="tz-{sub.id}" class="pref-label">Timezone</label>
+							<select
+								id="tz-{sub.id}"
+								name="timezone"
+								class="pref-select tz-select"
+								value={sub.timezone}
+							>
+								{#each timezones as tz}
+									<option value={tz} selected={tz === sub.timezone}>{tz.replace(/_/g, " ")}</option>
+								{/each}
+							</select>
+						</div>
+
+						<Button type="submit" variant="outline" size="sm">Save</Button>
+					</form>
+				</GlassCard>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.settings-page {
+		max-width: 48rem;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+
+	.page-header {
+		margin-bottom: 2rem;
+	}
+
+	.page-header h1 {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 1.5rem;
+		font-weight: 600;
+		color: hsl(var(--foreground));
+	}
+
+	.page-header .subtitle {
+		margin-top: 0.5rem;
+		color: hsl(var(--foreground-muted));
+		font-size: 0.875rem;
+	}
+
+	:global(.inline-icon) {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	.notice {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem 1rem;
+		border-radius: 0.5rem;
+		margin-bottom: 1.5rem;
+		font-size: 0.875rem;
+	}
+
+	.notice.success {
+		background: var(--grove-accent-6, hsl(142 71% 45% / 0.1));
+		color: var(--grove-accent, hsl(142 71% 45%));
+		border: 1px solid var(--grove-accent-15, hsl(142 71% 45% / 0.2));
+	}
+
+	:global(.notice-icon) {
+		width: 1rem;
+		height: 1rem;
+		flex-shrink: 0;
+	}
+
+	.empty-state {
+		text-align: center;
+		padding: 2rem;
+	}
+
+	:global(.empty-icon) {
+		width: 2.5rem;
+		height: 2.5rem;
+		color: hsl(var(--foreground-muted));
+		margin: 0 auto 1rem;
+	}
+
+	.empty-state h2 {
+		font-size: 1.125rem;
+		font-weight: 600;
+		color: hsl(var(--foreground));
+		margin-bottom: 0.5rem;
+	}
+
+	.empty-state p {
+		color: hsl(var(--foreground-muted));
+		font-size: 0.875rem;
+		max-width: 24rem;
+		margin: 0 auto;
+	}
+
+	.subscriptions-list {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.sub-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1rem;
+		padding-bottom: 1rem;
+		border-bottom: 1px solid hsl(var(--foreground) / 0.1);
+	}
+
+	.sub-grove-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+
+	.sub-grove-name {
+		font-weight: 600;
+		color: hsl(var(--foreground));
+		text-decoration: none;
+	}
+
+	.sub-grove-name:hover {
+		text-decoration: underline;
+	}
+
+	.sub-grove-url {
+		font-size: 0.75rem;
+		color: hsl(var(--foreground-muted));
+	}
+
+	.sub-prefs {
+		display: flex;
+		align-items: flex-end;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.pref-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.pref-label {
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: hsl(var(--foreground-muted));
+	}
+
+	.pref-select {
+		padding: 0.375rem 0.5rem;
+		border-radius: 0.375rem;
+		border: 1px solid hsl(var(--foreground) / 0.15);
+		background: hsl(var(--background));
+		color: hsl(var(--foreground));
+		font-size: 0.8125rem;
+		min-height: 36px;
+	}
+
+	.tz-select {
+		max-width: 16rem;
+	}
+</style>

--- a/apps/landing/src/routes/unsubscribe/grove/+page.server.ts
+++ b/apps/landing/src/routes/unsubscribe/grove/+page.server.ts
@@ -1,16 +1,21 @@
 /**
  * Grove Subscription Unsubscribe
  *
- * One-click, no-login unsubscribe for email subscription notifications.
+ * Two-step, no-login unsubscribe for email subscription notifications.
  * Token-based: URL contains a unique token that maps to a specific subscription.
  *
  * GET /unsubscribe/grove?token=<uuid>
- *   → Immediately unsubscribes and shows confirmation.
- *   → Shows error if token is invalid/expired.
+ *   → Shows confirmation page (no mutation — safe from prefetch/bots).
+ * POST (form action)
+ *   → Performs the actual unsubscribe.
  */
 
-import type { PageServerLoad } from "./$types";
-import { unsubscribeByToken } from "@autumnsgrove/lattice/server/services/subscriptions";
+import { fail } from "@sveltejs/kit";
+import type { Actions, PageServerLoad } from "./$types";
+import {
+	unsubscribeByToken,
+	lookupUnsubscribeToken,
+} from "@autumnsgrove/lattice/server/services/subscriptions";
 
 export const load: PageServerLoad = async ({ url, platform }) => {
 	const token = url.searchParams.get("token");
@@ -24,12 +29,32 @@ export const load: PageServerLoad = async ({ url, platform }) => {
 		return { status: "error" as const, groveName: null };
 	}
 
-	const result = await unsubscribeByToken(db, token);
+	// Read-only lookup — no mutation on GET
+	const lookup = await lookupUnsubscribeToken(db, token);
 
-	if (result.success) {
-		return { status: "success" as const, groveName: result.groveName ?? "this grove" };
+	if (!lookup) {
+		return { status: "already" as const, groveName: null };
 	}
 
-	// Token not found — could be already unsubscribed or invalid
-	return { status: "already" as const, groveName: null };
+	return { status: "confirm" as const, groveName: lookup.groveName, token };
+};
+
+export const actions: Actions = {
+	default: async ({ request, platform }) => {
+		const formData = await request.formData();
+		const token = formData.get("token")?.toString();
+
+		if (!token) return fail(400, { error: "Missing token" });
+
+		const db = platform?.env?.DB;
+		if (!db) return fail(503, { error: "Service unavailable" });
+
+		const result = await unsubscribeByToken(db, token);
+
+		if (result.success) {
+			return { success: true, groveName: result.groveName ?? "this grove" };
+		}
+
+		return { success: true, groveName: "this grove" }; // Show success even if already gone (prevent enumeration)
+	},
 };

--- a/apps/landing/src/routes/unsubscribe/grove/+page.server.ts
+++ b/apps/landing/src/routes/unsubscribe/grove/+page.server.ts
@@ -1,0 +1,35 @@
+/**
+ * Grove Subscription Unsubscribe
+ *
+ * One-click, no-login unsubscribe for email subscription notifications.
+ * Token-based: URL contains a unique token that maps to a specific subscription.
+ *
+ * GET /unsubscribe/grove?token=<uuid>
+ *   → Immediately unsubscribes and shows confirmation.
+ *   → Shows error if token is invalid/expired.
+ */
+
+import type { PageServerLoad } from "./$types";
+import { unsubscribeByToken } from "@autumnsgrove/lattice/server/services/subscriptions";
+
+export const load: PageServerLoad = async ({ url, platform }) => {
+	const token = url.searchParams.get("token");
+
+	if (!token) {
+		return { status: "invalid" as const, groveName: null };
+	}
+
+	const db = platform?.env?.DB;
+	if (!db) {
+		return { status: "error" as const, groveName: null };
+	}
+
+	const result = await unsubscribeByToken(db, token);
+
+	if (result.success) {
+		return { status: "success" as const, groveName: result.groveName ?? "this grove" };
+	}
+
+	// Token not found — could be already unsubscribed or invalid
+	return { status: "already" as const, groveName: null };
+};

--- a/apps/landing/src/routes/unsubscribe/grove/+page.svelte
+++ b/apps/landing/src/routes/unsubscribe/grove/+page.svelte
@@ -5,10 +5,12 @@
 	import { seasonStore } from "@autumnsgrove/lattice/ui/chrome";
 	import { Logo } from "@autumnsgrove/lattice/ui/nature";
 	import { stateIcons, featureIcons } from "@autumnsgrove/prism/icons";
+	import { enhance } from "$app/forms";
 	const Check = stateIcons.check;
 	const MailX = featureIcons.mailX;
 
-	let { data } = $props();
+	let { data, form } = $props();
+	let submitting = $state(false);
 </script>
 
 <SEO
@@ -28,7 +30,7 @@
 		</div>
 
 		<div class="glass-card rounded-2xl p-8 text-center">
-			{#if data.status === "success"}
+			{#if form?.success}
 				<div
 					class="w-16 h-16 mx-auto mb-6 rounded-full bg-accent-subtle/20 flex items-center justify-center"
 				>
@@ -36,7 +38,7 @@
 				</div>
 				<h1 class="text-xl font-serif text-foreground mb-3">You're unsubscribed</h1>
 				<p class="text-foreground-muted font-sans mb-6">
-					You won't receive email updates from {data.groveName} anymore.
+					You won't receive email updates from {form.groveName} anymore.
 				</p>
 				<a
 					href="/"
@@ -44,6 +46,35 @@
 				>
 					Back to Grove
 				</a>
+			{:else if data.status === "confirm"}
+				<div
+					class="w-16 h-16 mx-auto mb-6 rounded-full bg-accent-subtle/20 flex items-center justify-center"
+				>
+					<MailX class="w-8 h-8 text-accent-muted" />
+				</div>
+				<h1 class="text-xl font-serif text-foreground mb-3">Unsubscribe from {data.groveName}?</h1>
+				<p class="text-foreground-muted font-sans mb-6">
+					You'll stop receiving email updates when they publish new posts.
+				</p>
+				<form
+					method="POST"
+					use:enhance={() => {
+						submitting = true;
+						return async ({ update }) => {
+							await update();
+							submitting = false;
+						};
+					}}
+				>
+					<input type="hidden" name="token" value={data.token} />
+					<button
+						type="submit"
+						disabled={submitting}
+						class="inline-block px-6 py-3 bg-accent text-white rounded-lg font-sans font-medium hover:bg-accent-hover transition-colors disabled:opacity-50"
+					>
+						{submitting ? "Unsubscribing..." : "Unsubscribe"}
+					</button>
+				</form>
 			{:else if data.status === "already"}
 				<div
 					class="w-16 h-16 mx-auto mb-6 rounded-full bg-accent-subtle/20 flex items-center justify-center"

--- a/apps/landing/src/routes/unsubscribe/grove/+page.svelte
+++ b/apps/landing/src/routes/unsubscribe/grove/+page.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import Header from "$lib/components/Header.svelte";
+	import Footer from "$lib/components/Footer.svelte";
+	import SEO from "$lib/components/SEO.svelte";
+	import { seasonStore } from "@autumnsgrove/lattice/ui/chrome";
+	import { Logo } from "@autumnsgrove/lattice/ui/nature";
+	import { stateIcons, featureIcons } from "@autumnsgrove/prism/icons";
+	const Check = stateIcons.check;
+	const MailX = featureIcons.mailX;
+
+	let { data } = $props();
+</script>
+
+<SEO
+	title="Unsubscribe — Grove"
+	description="Manage your grove email subscription."
+	url="/unsubscribe/grove"
+/>
+
+<Header user={data.user} />
+
+<main class="min-h-screen flex flex-col items-center px-6 py-16">
+	<div class="max-w-md w-full">
+		<div class="text-center mb-10">
+			<div class="mb-6">
+				<Logo class="w-12 h-12 mx-auto" season={seasonStore.current} />
+			</div>
+		</div>
+
+		<div class="glass-card rounded-2xl p-8 text-center">
+			{#if data.status === "success"}
+				<div
+					class="w-16 h-16 mx-auto mb-6 rounded-full bg-accent-subtle/20 flex items-center justify-center"
+				>
+					<Check class="w-8 h-8 text-accent" />
+				</div>
+				<h1 class="text-xl font-serif text-foreground mb-3">You're unsubscribed</h1>
+				<p class="text-foreground-muted font-sans mb-6">
+					You won't receive email updates from {data.groveName} anymore.
+				</p>
+				<a
+					href="/"
+					class="inline-block px-6 py-3 bg-accent text-white rounded-lg font-sans font-medium hover:bg-accent-hover transition-colors"
+				>
+					Back to Grove
+				</a>
+			{:else if data.status === "already"}
+				<div
+					class="w-16 h-16 mx-auto mb-6 rounded-full bg-accent-subtle/20 flex items-center justify-center"
+				>
+					<MailX class="w-8 h-8 text-accent-muted" />
+				</div>
+				<h1 class="text-xl font-serif text-foreground mb-3">Already unsubscribed</h1>
+				<p class="text-foreground-muted font-sans mb-6">
+					It looks like you've already been unsubscribed, or this link has expired.
+				</p>
+				<a
+					href="/"
+					class="inline-block px-6 py-3 bg-accent text-white rounded-lg font-sans font-medium hover:bg-accent-hover transition-colors"
+				>
+					Back to Grove
+				</a>
+			{:else}
+				<div
+					class="w-16 h-16 mx-auto mb-6 rounded-full bg-accent-subtle/20 flex items-center justify-center"
+				>
+					<MailX class="w-8 h-8 text-accent-muted" />
+				</div>
+				<h1 class="text-xl font-serif text-foreground mb-3">Something went wrong</h1>
+				<p class="text-foreground-muted font-sans mb-6">
+					We couldn't process your unsubscribe request. Please try again or contact us.
+				</p>
+				<a
+					href="/"
+					class="inline-block px-6 py-3 bg-accent text-white rounded-lg font-sans font-medium hover:bg-accent-hover transition-colors"
+				>
+					Back to Grove
+				</a>
+			{/if}
+		</div>
+	</div>
+</main>
+
+<Footer />
+
+<style>
+	.glass-card {
+		background: rgba(255, 255, 255, 0.6);
+		backdrop-filter: blur(12px);
+		-webkit-backdrop-filter: blur(12px);
+		border: 1px solid var(--color-divider);
+	}
+
+	:global(.dark) .glass-card {
+		background: rgba(30, 41, 59, 0.5);
+	}
+</style>

--- a/libs/engine/migrations/106_subscriptions.sql
+++ b/libs/engine/migrations/106_subscriptions.sql
@@ -1,0 +1,43 @@
+-- Migration 106: Subscriptions v1
+-- Email notifications when followed groves publish new posts (#1547)
+
+-- Subscription records: wanderer subscribes to a grove's email notifications
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    target_tenant_id TEXT NOT NULL,
+    email TEXT NOT NULL,
+    preferred_hour INTEGER DEFAULT 9,
+    timezone TEXT DEFAULT 'America/New_York',
+    created_at INTEGER DEFAULT (unixepoch()),
+    UNIQUE(user_id, target_tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_target ON subscriptions(target_tenant_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user ON subscriptions(user_id);
+
+-- Pending notifications: captured on post publish, consumed by digest cron
+CREATE TABLE IF NOT EXISTS pending_notifications (
+    id TEXT PRIMARY KEY,
+    target_tenant_id TEXT NOT NULL,
+    tenant_name TEXT,
+    tenant_subdomain TEXT NOT NULL,
+    post_slug TEXT NOT NULL,
+    post_title TEXT NOT NULL,
+    post_excerpt TEXT,
+    post_image TEXT,
+    published_at INTEGER NOT NULL,
+    created_at INTEGER DEFAULT (unixepoch()),
+    UNIQUE(target_tenant_id, post_slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_tenant ON pending_notifications(target_tenant_id);
+
+-- Unsubscribe tokens: one-click, no-login-required unsubscribe via signed URL
+CREATE TABLE IF NOT EXISTS subscription_unsubscribe_tokens (
+    id TEXT PRIMARY KEY,
+    subscription_id TEXT NOT NULL,
+    token TEXT UNIQUE NOT NULL,
+    created_at INTEGER DEFAULT (unixepoch()),
+    FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+);

--- a/libs/engine/src/lib/server/services/subscriptions.test.ts
+++ b/libs/engine/src/lib/server/services/subscriptions.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Subscriptions Service Tests
+ *
+ * Tests subscribe/unsubscribe, token lifecycle (creation, lookup, TTL),
+ * timezone validation, and preference updates.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+	subscribe,
+	unsubscribe,
+	unsubscribeByToken,
+	lookupUnsubscribeToken,
+	isSubscribed,
+	getSubscribersForTenant,
+	getUserSubscriptions,
+	updatePreferences,
+	getOrCreateUnsubscribeToken,
+} from "./subscriptions";
+
+// ── Mock D1 ────────────────────────────────────────────────────────────────
+
+function createMockDB(overrides?: {
+	firstResult?: unknown;
+	allResults?: unknown[];
+	runChanges?: number;
+}) {
+	const runResult = {
+		success: true,
+		meta: { changes: overrides?.runChanges ?? 1 },
+	};
+
+	return {
+		prepare: vi.fn(() => ({
+			bind: vi.fn().mockReturnThis(),
+			first: vi.fn().mockResolvedValue(overrides?.firstResult ?? null),
+			all: vi.fn().mockResolvedValue({ results: overrides?.allResults ?? [] }),
+			run: vi.fn().mockResolvedValue(runResult),
+		})),
+	} as unknown as D1Database;
+}
+
+// ── subscribe ──────────────────────────────────────────────────────────────
+
+describe("subscribe", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should insert a subscription and return created=true", async () => {
+		const db = createMockDB({ runChanges: 1 });
+
+		const result = await subscribe(db, "user-1", "test@example.com", "tenant-1");
+
+		expect(result.created).toBe(true);
+		expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("INSERT OR IGNORE"));
+	});
+
+	it("should return created=false for duplicate subscription (INSERT OR IGNORE)", async () => {
+		const db = createMockDB({ runChanges: 0 });
+
+		const result = await subscribe(db, "user-1", "test@example.com", "tenant-1");
+
+		expect(result.created).toBe(false);
+	});
+
+	it("should use provided timezone when valid", async () => {
+		const db = createMockDB();
+
+		await subscribe(db, "user-1", "test@example.com", "tenant-1", "Europe/London");
+
+		const prepareCall = vi.mocked(db.prepare).mock.results[0].value;
+		const bindCall = prepareCall.bind.mock.calls[0];
+		expect(bindCall[4]).toBe("Europe/London");
+	});
+
+	it("should fall back to America/New_York for invalid timezone", async () => {
+		const db = createMockDB();
+
+		await subscribe(db, "user-1", "test@example.com", "tenant-1", "Invalid/Timezone");
+
+		const prepareCall = vi.mocked(db.prepare).mock.results[0].value;
+		const bindCall = prepareCall.bind.mock.calls[0];
+		expect(bindCall[4]).toBe("America/New_York");
+	});
+
+	it("should fall back to America/New_York when no timezone provided", async () => {
+		const db = createMockDB();
+
+		await subscribe(db, "user-1", "test@example.com", "tenant-1");
+
+		const prepareCall = vi.mocked(db.prepare).mock.results[0].value;
+		const bindCall = prepareCall.bind.mock.calls[0];
+		expect(bindCall[4]).toBe("America/New_York");
+	});
+});
+
+// ── unsubscribe ────────────────────────────────────────────────────────────
+
+describe("unsubscribe", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should delete and return true when subscription exists", async () => {
+		const db = createMockDB({ runChanges: 1 });
+
+		const result = await unsubscribe(db, "user-1", "tenant-1");
+
+		expect(result).toBe(true);
+		expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("DELETE FROM subscriptions"));
+	});
+
+	it("should return false when subscription doesn't exist", async () => {
+		const db = createMockDB({ runChanges: 0 });
+
+		const result = await unsubscribe(db, "user-1", "tenant-nonexistent");
+
+		expect(result).toBe(false);
+	});
+});
+
+// ── isSubscribed ───────────────────────────────────────────────────────────
+
+describe("isSubscribed", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should return true when subscription exists", async () => {
+		const db = createMockDB({ firstResult: { "1": 1 } });
+
+		const result = await isSubscribed(db, "user-1", "tenant-1");
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false when subscription doesn't exist", async () => {
+		const db = createMockDB({ firstResult: null });
+
+		const result = await isSubscribed(db, "user-1", "tenant-1");
+
+		expect(result).toBe(false);
+	});
+});
+
+// ── lookupUnsubscribeToken ─────────────────────────────────────────────────
+
+describe("lookupUnsubscribeToken", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should return grove name for valid token", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const db = createMockDB({
+			firstResult: { token_created: now - 100, grove_name: "Autumn's Grove" },
+		});
+
+		const result = await lookupUnsubscribeToken(db, "valid-token");
+
+		expect(result).toEqual({ groveName: "Autumn's Grove" });
+	});
+
+	it("should return null for nonexistent token", async () => {
+		const db = createMockDB({ firstResult: null });
+
+		const result = await lookupUnsubscribeToken(db, "bad-token");
+
+		expect(result).toBeNull();
+	});
+
+	it("should return null for expired token (>30 days)", async () => {
+		const thirtyOneDaysAgo = Math.floor(Date.now() / 1000) - 31 * 24 * 60 * 60;
+		const db = createMockDB({
+			firstResult: { token_created: thirtyOneDaysAgo, grove_name: "Old Grove" },
+		});
+
+		const result = await lookupUnsubscribeToken(db, "expired-token");
+
+		expect(result).toBeNull();
+	});
+
+	it("should return grove name for token at exactly 30 days (still valid)", async () => {
+		const exactlyThirtyDays = Math.floor(Date.now() / 1000) - 30 * 24 * 60 * 60;
+		const db = createMockDB({
+			firstResult: { token_created: exactlyThirtyDays, grove_name: "Edge Grove" },
+		});
+
+		const result = await lookupUnsubscribeToken(db, "edge-token");
+
+		expect(result).toEqual({ groveName: "Edge Grove" });
+	});
+
+	it("should fall back to 'this grove' when display_name is null", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const db = createMockDB({
+			firstResult: { token_created: now - 100, grove_name: null },
+		});
+
+		const result = await lookupUnsubscribeToken(db, "valid-token");
+
+		expect(result).toEqual({ groveName: "this grove" });
+	});
+});
+
+// ── unsubscribeByToken ─────────────────────────────────────────────────────
+
+describe("unsubscribeByToken", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should delete subscription for valid token", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const db = createMockDB({
+			firstResult: { id: "sub-1", token_created: now - 100, grove_name: "Test Grove" },
+		});
+
+		const result = await unsubscribeByToken(db, "valid-token");
+
+		expect(result.success).toBe(true);
+		expect(result.groveName).toBe("Test Grove");
+		// Should have called prepare twice: first for lookup, then for delete
+		expect(db.prepare).toHaveBeenCalledTimes(2);
+	});
+
+	it("should return success=false for nonexistent token", async () => {
+		const db = createMockDB({ firstResult: null });
+
+		const result = await unsubscribeByToken(db, "bad-token");
+
+		expect(result.success).toBe(false);
+	});
+
+	it("should return success=false for expired token", async () => {
+		const thirtyOneDaysAgo = Math.floor(Date.now() / 1000) - 31 * 24 * 60 * 60;
+		const db = createMockDB({
+			firstResult: { id: "sub-1", token_created: thirtyOneDaysAgo, grove_name: "Old" },
+		});
+
+		const result = await unsubscribeByToken(db, "expired-token");
+
+		expect(result.success).toBe(false);
+		// Should NOT have called delete
+		expect(db.prepare).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ── getSubscribersForTenant ────────────────────────────────────────────────
+
+describe("getSubscribersForTenant", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should return mapped subscriber list", async () => {
+		const db = createMockDB({
+			allResults: [
+				{
+					id: "sub-1",
+					user_id: "user-1",
+					email: "test@example.com",
+					preferred_hour: 9,
+					timezone: "America/New_York",
+				},
+			],
+		});
+
+		const result = await getSubscribersForTenant(db, "tenant-1");
+
+		expect(result).toEqual([
+			{
+				subscriptionId: "sub-1",
+				userId: "user-1",
+				email: "test@example.com",
+				preferredHour: 9,
+				timezone: "America/New_York",
+			},
+		]);
+	});
+
+	it("should return empty array when no subscribers", async () => {
+		const db = createMockDB({ allResults: [] });
+
+		const result = await getSubscribersForTenant(db, "tenant-empty");
+
+		expect(result).toEqual([]);
+	});
+});
+
+// ── getUserSubscriptions ───────────────────────────────────────────────────
+
+describe("getUserSubscriptions", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should return subscriptions with grove info", async () => {
+		const db = createMockDB({
+			allResults: [
+				{
+					id: "sub-1",
+					user_id: "user-1",
+					target_tenant_id: "tenant-1",
+					email: "test@example.com",
+					preferred_hour: 9,
+					timezone: "America/New_York",
+					created_at: 1700000000,
+					grove_name: "Autumn's Grove",
+					grove_subdomain: "autumn",
+				},
+			],
+		});
+
+		const result = await getUserSubscriptions(db, "user-1");
+
+		expect(result).toHaveLength(1);
+		expect(result[0].groveName).toBe("Autumn's Grove");
+		expect(result[0].groveSubdomain).toBe("autumn");
+		expect(result[0].preferredHour).toBe(9);
+	});
+});
+
+// ── updatePreferences ──────────────────────────────────────────────────────
+
+describe("updatePreferences", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should update preferred hour", async () => {
+		const db = createMockDB({ runChanges: 1 });
+
+		const result = await updatePreferences(db, "user-1", "tenant-1", { preferredHour: 14 });
+
+		expect(result).toBe(true);
+	});
+
+	it("should reject hour < 0", async () => {
+		const db = createMockDB();
+
+		const result = await updatePreferences(db, "user-1", "tenant-1", { preferredHour: -1 });
+
+		expect(result).toBe(false);
+	});
+
+	it("should reject hour > 23", async () => {
+		const db = createMockDB();
+
+		const result = await updatePreferences(db, "user-1", "tenant-1", { preferredHour: 24 });
+
+		expect(result).toBe(false);
+	});
+
+	it("should reject invalid timezone", async () => {
+		const db = createMockDB();
+
+		const result = await updatePreferences(db, "user-1", "tenant-1", {
+			timezone: "Not/A/Timezone",
+		});
+
+		expect(result).toBe(false);
+	});
+
+	it("should accept valid timezone", async () => {
+		const db = createMockDB({ runChanges: 1 });
+
+		const result = await updatePreferences(db, "user-1", "tenant-1", {
+			timezone: "Asia/Tokyo",
+		});
+
+		expect(result).toBe(true);
+	});
+
+	it("should return false when no preferences provided", async () => {
+		const db = createMockDB();
+
+		const result = await updatePreferences(db, "user-1", "tenant-1", {});
+
+		expect(result).toBe(false);
+	});
+
+	it("should update both hour and timezone together", async () => {
+		const db = createMockDB({ runChanges: 1 });
+
+		const result = await updatePreferences(db, "user-1", "tenant-1", {
+			preferredHour: 8,
+			timezone: "Europe/Berlin",
+		});
+
+		expect(result).toBe(true);
+	});
+});
+
+// ── getOrCreateUnsubscribeToken ────────────────────────────────────────────
+
+describe("getOrCreateUnsubscribeToken", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("should return existing token when one exists", async () => {
+		const db = createMockDB({ firstResult: { token: "existing-token-uuid" } });
+
+		const token = await getOrCreateUnsubscribeToken(db, "sub-1");
+
+		expect(token).toBe("existing-token-uuid");
+		// Should only prepare once (the SELECT), not the INSERT
+		expect(db.prepare).toHaveBeenCalledTimes(1);
+	});
+
+	it("should create new token when none exists", async () => {
+		const db = createMockDB({ firstResult: null });
+
+		const token = await getOrCreateUnsubscribeToken(db, "sub-1");
+
+		expect(token).toBeTruthy();
+		expect(typeof token).toBe("string");
+		// Should prepare twice: SELECT then INSERT
+		expect(db.prepare).toHaveBeenCalledTimes(2);
+	});
+});

--- a/libs/engine/src/lib/server/services/subscriptions.ts
+++ b/libs/engine/src/lib/server/services/subscriptions.ts
@@ -7,6 +7,22 @@
  * Tokens are generated for one-click, no-login unsubscribe (RFC 8058).
  */
 
+/** Maximum age (in seconds) for unsubscribe tokens. 30 days. */
+const TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * Validate an IANA timezone string.
+ * Returns the timezone if valid, null otherwise.
+ */
+function validateTimezone(tz: string): string | null {
+	try {
+		Intl.DateTimeFormat("en-US", { timeZone: tz });
+		return tz;
+	} catch {
+		return null;
+	}
+}
+
 export interface Subscription {
 	id: string;
 	userId: string;
@@ -42,7 +58,7 @@ export async function subscribe(
 	timezone?: string,
 ): Promise<{ created: boolean }> {
 	const id = crypto.randomUUID();
-	const tz = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? "America/New_York";
+	const tz = (timezone && validateTimezone(timezone)) ?? "America/New_York";
 
 	const result = await db
 		.prepare(
@@ -72,8 +88,38 @@ export async function unsubscribe(
 }
 
 /**
- * Unsubscribe via a signed token (no login required).
+ * Read-only lookup of an unsubscribe token.
+ * Returns grove info if valid and not expired, null otherwise.
+ * Used by the GET handler to show a confirmation page without mutating.
+ */
+export async function lookupUnsubscribeToken(
+	db: D1Database,
+	token: string,
+): Promise<{ groveName: string } | null> {
+	const row = await db
+		.prepare(
+			`SELECT ut.created_at as token_created, t.display_name as grove_name
+			 FROM subscription_unsubscribe_tokens ut
+			 JOIN subscriptions s ON s.id = ut.subscription_id
+			 LEFT JOIN tenants t ON t.id = s.target_tenant_id
+			 WHERE ut.token = ?`,
+		)
+		.bind(token)
+		.first<{ token_created: number; grove_name: string }>();
+
+	if (!row) return null;
+
+	// Check TTL — reject expired tokens
+	const age = Math.floor(Date.now() / 1000) - row.token_created;
+	if (age > TOKEN_TTL_SECONDS) return null;
+
+	return { groveName: row.grove_name ?? "this grove" };
+}
+
+/**
+ * Unsubscribe via a token (no login required).
  * Deletes the subscription and all associated tokens.
+ * Checks TTL before proceeding.
  */
 export async function unsubscribeByToken(
 	db: D1Database,
@@ -81,16 +127,20 @@ export async function unsubscribeByToken(
 ): Promise<{ success: boolean; groveName?: string }> {
 	const row = await db
 		.prepare(
-			`SELECT s.id, s.target_tenant_id, t.display_name as grove_name
+			`SELECT s.id, ut.created_at as token_created, t.display_name as grove_name
 			 FROM subscription_unsubscribe_tokens ut
 			 JOIN subscriptions s ON s.id = ut.subscription_id
 			 LEFT JOIN tenants t ON t.id = s.target_tenant_id
 			 WHERE ut.token = ?`,
 		)
 		.bind(token)
-		.first<{ id: string; target_tenant_id: string; grove_name: string }>();
+		.first<{ id: string; token_created: number; grove_name: string }>();
 
 	if (!row) return { success: false };
+
+	// Check TTL — reject expired tokens
+	const age = Math.floor(Date.now() / 1000) - row.token_created;
+	if (age > TOKEN_TTL_SECONDS) return { success: false };
 
 	await db.prepare(`DELETE FROM subscriptions WHERE id = ?`).bind(row.id).run();
 
@@ -206,8 +256,10 @@ export async function updatePreferences(
 	}
 
 	if (prefs.timezone !== undefined) {
+		const validTz = validateTimezone(prefs.timezone);
+		if (!validTz) return false;
 		sets.push("timezone = ?");
-		values.push(prefs.timezone);
+		values.push(validTz);
 	}
 
 	if (sets.length === 0) return false;

--- a/libs/engine/src/lib/server/services/subscriptions.ts
+++ b/libs/engine/src/lib/server/services/subscriptions.ts
@@ -1,0 +1,253 @@
+/**
+ * Subscriptions Service — email notification subscriptions.
+ *
+ * Independent from the friends system. A wanderer subscribes to a grove
+ * to receive email digests when new posts are published.
+ *
+ * Tokens are generated for one-click, no-login unsubscribe (RFC 8058).
+ */
+
+export interface Subscription {
+	id: string;
+	userId: string;
+	targetTenantId: string;
+	email: string;
+	preferredHour: number;
+	timezone: string;
+	createdAt: number;
+}
+
+export interface SubscriptionWithGrove extends Subscription {
+	groveName: string;
+	groveSubdomain: string;
+}
+
+export interface SubscriberInfo {
+	subscriptionId: string;
+	userId: string;
+	email: string;
+	preferredHour: number;
+	timezone: string;
+}
+
+/**
+ * Subscribe a user to a grove's email notifications.
+ * INSERT OR IGNORE — safe to call multiple times.
+ */
+export async function subscribe(
+	db: D1Database,
+	userId: string,
+	email: string,
+	targetTenantId: string,
+	timezone?: string,
+): Promise<{ created: boolean }> {
+	const id = crypto.randomUUID();
+	const tz = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? "America/New_York";
+
+	const result = await db
+		.prepare(
+			`INSERT OR IGNORE INTO subscriptions (id, user_id, target_tenant_id, email, timezone)
+			 VALUES (?, ?, ?, ?, ?)`,
+		)
+		.bind(id, userId, targetTenantId, email, tz)
+		.run();
+
+	return { created: ((result.meta as Record<string, number>)?.changes ?? 0) > 0 };
+}
+
+/**
+ * Unsubscribe a user from a grove (authenticated).
+ */
+export async function unsubscribe(
+	db: D1Database,
+	userId: string,
+	targetTenantId: string,
+): Promise<boolean> {
+	const result = await db
+		.prepare(`DELETE FROM subscriptions WHERE user_id = ? AND target_tenant_id = ?`)
+		.bind(userId, targetTenantId)
+		.run();
+
+	return ((result.meta as Record<string, number>)?.changes ?? 0) > 0;
+}
+
+/**
+ * Unsubscribe via a signed token (no login required).
+ * Deletes the subscription and all associated tokens.
+ */
+export async function unsubscribeByToken(
+	db: D1Database,
+	token: string,
+): Promise<{ success: boolean; groveName?: string }> {
+	const row = await db
+		.prepare(
+			`SELECT s.id, s.target_tenant_id, t.display_name as grove_name
+			 FROM subscription_unsubscribe_tokens ut
+			 JOIN subscriptions s ON s.id = ut.subscription_id
+			 LEFT JOIN tenants t ON t.id = s.target_tenant_id
+			 WHERE ut.token = ?`,
+		)
+		.bind(token)
+		.first<{ id: string; target_tenant_id: string; grove_name: string }>();
+
+	if (!row) return { success: false };
+
+	await db.prepare(`DELETE FROM subscriptions WHERE id = ?`).bind(row.id).run();
+
+	return { success: true, groveName: row.grove_name };
+}
+
+/**
+ * Check if a user is subscribed to a grove.
+ */
+export async function isSubscribed(
+	db: D1Database,
+	userId: string,
+	targetTenantId: string,
+): Promise<boolean> {
+	const existing = await db
+		.prepare(`SELECT 1 FROM subscriptions WHERE user_id = ? AND target_tenant_id = ? LIMIT 1`)
+		.bind(userId, targetTenantId)
+		.first();
+
+	return !!existing;
+}
+
+/**
+ * Get all subscribers for a tenant (for sending notifications).
+ */
+export async function getSubscribersForTenant(
+	db: D1Database,
+	targetTenantId: string,
+): Promise<SubscriberInfo[]> {
+	const result = await db
+		.prepare(
+			`SELECT id, user_id, email, preferred_hour, timezone
+			 FROM subscriptions
+			 WHERE target_tenant_id = ?`,
+		)
+		.bind(targetTenantId)
+		.all<{
+			id: string;
+			user_id: string;
+			email: string;
+			preferred_hour: number;
+			timezone: string;
+		}>();
+
+	return (result.results ?? []).map((row) => ({
+		subscriptionId: row.id,
+		userId: row.user_id,
+		email: row.email,
+		preferredHour: row.preferred_hour,
+		timezone: row.timezone,
+	}));
+}
+
+/**
+ * Get all subscriptions for a user (for managing preferences).
+ */
+export async function getUserSubscriptions(
+	db: D1Database,
+	userId: string,
+): Promise<SubscriptionWithGrove[]> {
+	const result = await db
+		.prepare(
+			`SELECT s.id, s.user_id, s.target_tenant_id, s.email,
+			        s.preferred_hour, s.timezone, s.created_at,
+			        t.display_name as grove_name, t.subdomain as grove_subdomain
+			 FROM subscriptions s
+			 LEFT JOIN tenants t ON t.id = s.target_tenant_id
+			 WHERE s.user_id = ?
+			 ORDER BY s.created_at DESC`,
+		)
+		.bind(userId)
+		.all<{
+			id: string;
+			user_id: string;
+			target_tenant_id: string;
+			email: string;
+			preferred_hour: number;
+			timezone: string;
+			created_at: number;
+			grove_name: string;
+			grove_subdomain: string;
+		}>();
+
+	return (result.results ?? []).map((row) => ({
+		id: row.id,
+		userId: row.user_id,
+		targetTenantId: row.target_tenant_id,
+		email: row.email,
+		preferredHour: row.preferred_hour,
+		timezone: row.timezone,
+		createdAt: row.created_at,
+		groveName: row.grove_name,
+		groveSubdomain: row.grove_subdomain,
+	}));
+}
+
+/**
+ * Update subscription preferences (timezone, preferred hour).
+ */
+export async function updatePreferences(
+	db: D1Database,
+	userId: string,
+	targetTenantId: string,
+	prefs: { preferredHour?: number; timezone?: string },
+): Promise<boolean> {
+	const sets: string[] = [];
+	const values: (string | number)[] = [];
+
+	if (prefs.preferredHour !== undefined) {
+		if (prefs.preferredHour < 0 || prefs.preferredHour > 23) return false;
+		sets.push("preferred_hour = ?");
+		values.push(prefs.preferredHour);
+	}
+
+	if (prefs.timezone !== undefined) {
+		sets.push("timezone = ?");
+		values.push(prefs.timezone);
+	}
+
+	if (sets.length === 0) return false;
+
+	values.push(userId, targetTenantId);
+
+	const result = await db
+		.prepare(
+			`UPDATE subscriptions SET ${sets.join(", ")} WHERE user_id = ? AND target_tenant_id = ?`,
+		)
+		.bind(...values)
+		.run();
+
+	return ((result.meta as Record<string, number>)?.changes ?? 0) > 0;
+}
+
+/**
+ * Generate a one-time unsubscribe token for a subscription.
+ * Reuses existing token if one already exists.
+ */
+export async function getOrCreateUnsubscribeToken(
+	db: D1Database,
+	subscriptionId: string,
+): Promise<string> {
+	const existing = await db
+		.prepare(`SELECT token FROM subscription_unsubscribe_tokens WHERE subscription_id = ? LIMIT 1`)
+		.bind(subscriptionId)
+		.first<{ token: string }>();
+
+	if (existing) return existing.token;
+
+	const token = crypto.randomUUID();
+	const id = crypto.randomUUID();
+
+	await db
+		.prepare(
+			`INSERT INTO subscription_unsubscribe_tokens (id, subscription_id, token) VALUES (?, ?, ?)`,
+		)
+		.bind(id, subscriptionId, token)
+		.run();
+
+	return token;
+}

--- a/libs/engine/src/lib/ui/components/chrome/SubscribeButton.svelte
+++ b/libs/engine/src/lib/ui/components/chrome/SubscribeButton.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import { featureIcons } from "@autumnsgrove/prism/icons";
+	import GlassButton from "$lib/ui/components/ui/GlassButton.svelte";
+	import { subscriptionsStore } from "$lib/ui/stores/subscriptions.svelte";
+
+	interface Props {
+		/** The tenant ID of the grove to subscribe to */
+		tenantId: string;
+		/** Display name of the grove owner */
+		name: string;
+	}
+
+	let { tenantId, name }: Props = $props();
+
+	let error = $state("");
+	let isSub = $derived(subscriptionsStore.isSubscribed(tenantId));
+	let isLoading = $derived(subscriptionsStore.isLoading(tenantId));
+
+	// Check subscription status on mount
+	$effect(() => {
+		if (tenantId) {
+			subscriptionsStore.checkAndCache(tenantId);
+		}
+	});
+
+	// Clear error after a delay
+	$effect(() => {
+		if (!error) return;
+		const timeout = setTimeout(() => (error = ""), 4000);
+		return () => clearTimeout(timeout);
+	});
+
+	async function handleClick() {
+		error = "";
+		let success: boolean;
+		if (isSub) {
+			success = await subscriptionsStore.unsubscribe(tenantId);
+		} else {
+			success = await subscriptionsStore.subscribe(tenantId);
+		}
+		if (!success) {
+			error = isSub ? "Could not unsubscribe. Try again." : "Could not subscribe. Try again.";
+		}
+	}
+
+	let label = $derived(
+		isLoading
+			? "Loading..."
+			: isSub
+				? `Unsubscribe from ${name} emails`
+				: `Subscribe to ${name} emails`,
+	);
+	let displayText = $derived(isSub ? "Subscribed" : "Subscribe");
+	let variant = $derived<"accent" | "outline">(isSub ? "outline" : "accent");
+</script>
+
+<span class="subscribe-button-inline">
+	<GlassButton
+		{variant}
+		size="sm"
+		disabled={isLoading}
+		onclick={handleClick}
+		aria-label={label}
+		aria-pressed={isSub}
+		class="subscribe-pill"
+	>
+		{#if isLoading}
+			<span class="subscribe-spinner" aria-hidden="true"></span>
+		{:else}
+			<featureIcons.mail size={16} aria-hidden="true" />
+		{/if}
+		<span class="subscribe-text">{displayText}</span>
+	</GlassButton>
+
+	{#if error}
+		<span class="subscribe-error" role="alert" aria-live="assertive">
+			{error}
+		</span>
+	{/if}
+</span>
+
+<style>
+	.subscribe-button-inline {
+		display: inline-flex;
+		align-items: center;
+		position: relative;
+	}
+
+	.subscribe-button-inline :global(.subscribe-pill) {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		min-height: 44px;
+		min-width: 44px;
+		padding: 0.5rem 1rem;
+		border-radius: 9999px;
+		font-size: 0.875rem;
+		font-weight: 500;
+		transition: all 0.2s ease;
+		cursor: pointer;
+	}
+
+	.subscribe-text {
+		line-height: 1;
+	}
+
+	.subscribe-spinner {
+		width: 16px;
+		height: 16px;
+		border: 2px solid currentColor;
+		border-top-color: transparent;
+		border-radius: 50%;
+		animation: subscribe-spin 0.6s linear infinite;
+	}
+
+	.subscribe-error {
+		position: absolute;
+		top: calc(100% + 0.5rem);
+		left: 50%;
+		transform: translateX(-50%);
+		background: hsl(var(--destructive, 0 84% 60%));
+		color: white;
+		padding: 0.375rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: 0.8125rem;
+		white-space: nowrap;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	}
+
+	@keyframes subscribe-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.subscribe-spinner {
+			animation: subscribe-pulse 1s ease-in-out infinite;
+		}
+
+		@keyframes subscribe-pulse {
+			0%,
+			100% {
+				opacity: 0.4;
+			}
+			50% {
+				opacity: 1;
+			}
+		}
+
+		.subscribe-button-inline :global(.subscribe-pill) {
+			transition: none;
+		}
+	}
+</style>

--- a/libs/engine/src/lib/ui/components/chrome/index.ts
+++ b/libs/engine/src/lib/ui/components/chrome/index.ts
@@ -14,6 +14,7 @@ export { default as AdminHeader } from "./AdminHeader.svelte";
 export { default as AccountStatus } from "./AccountStatus.svelte";
 export { default as FooterMinimal } from "./FooterMinimal.svelte";
 export { default as FollowButton } from "./FollowButton.svelte";
+export { default as SubscribeButton } from "./SubscribeButton.svelte";
 export { default as ShareButton } from "./ShareButton.svelte";
 export { default as FriendsLoader } from "./FriendsLoader.svelte";
 export { default as Lantern } from "./lantern/Lantern.svelte";

--- a/libs/engine/src/lib/ui/components/chrome/lantern/LanternVisitingCard.svelte
+++ b/libs/engine/src/lib/ui/components/chrome/lantern/LanternVisitingCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { authIcons } from "@autumnsgrove/prism/icons";
+	import { authIcons, featureIcons } from "@autumnsgrove/prism/icons";
 	import { friendsStore } from "$lib/ui/stores/friends.svelte";
+	import { subscriptionsStore } from "$lib/ui/stores/subscriptions.svelte";
 	import { api } from "$lib/utils/api";
 	import type { VisitingGrove } from "./types";
 
@@ -11,6 +12,16 @@
 	let { grove }: Props = $props();
 	let adding = $state(false);
 	let status = $state<"idle" | "added" | "error">("idle");
+
+	let isSubLoading = $derived(subscriptionsStore.isLoading(grove.tenantId));
+	let isSub = $derived(subscriptionsStore.isSubscribed(grove.tenantId));
+
+	// Check subscription status on mount
+	$effect(() => {
+		if (grove.tenantId) {
+			subscriptionsStore.checkAndCache(grove.tenantId);
+		}
+	});
 
 	async function addFriend() {
 		if (adding) return;
@@ -31,6 +42,14 @@
 			adding = false;
 		}
 	}
+
+	async function toggleSubscription() {
+		if (isSub) {
+			await subscriptionsStore.unsubscribe(grove.tenantId);
+		} else {
+			await subscriptionsStore.subscribe(grove.tenantId);
+		}
+	}
 </script>
 
 <div class="visiting-card">
@@ -38,21 +57,42 @@
 		<span class="visiting-label">You're visiting</span>
 		<span class="visiting-name">{grove.name}</span>
 	</div>
-	<button
-		type="button"
-		class="visiting-add"
-		disabled={adding}
-		onclick={addFriend}
-		aria-label={adding ? `Adding ${grove.name}…` : `Add ${grove.name} as a friend`}
-		aria-busy={adding}
-	>
-		{#if adding}
-			<span class="visiting-spinner" aria-hidden="true"></span>
-		{:else}
-			<authIcons.userPlus size={14} aria-hidden="true" />
-		{/if}
-		<span>Add Friend</span>
-	</button>
+	<div class="visiting-actions">
+		<button
+			type="button"
+			class="visiting-add"
+			disabled={adding}
+			onclick={addFriend}
+			aria-label={adding ? `Adding ${grove.name}…` : `Add ${grove.name} as a friend`}
+			aria-busy={adding}
+		>
+			{#if adding}
+				<span class="visiting-spinner" aria-hidden="true"></span>
+			{:else}
+				<authIcons.userPlus size={14} aria-hidden="true" />
+			{/if}
+			<span>Add Friend</span>
+		</button>
+		<button
+			type="button"
+			class="visiting-subscribe"
+			class:subscribed={isSub}
+			disabled={isSubLoading}
+			onclick={toggleSubscription}
+			aria-label={isSub
+				? `Unsubscribe from ${grove.name} emails`
+				: `Get email updates from ${grove.name}`}
+			aria-pressed={isSub}
+			aria-busy={isSubLoading}
+		>
+			{#if isSubLoading}
+				<span class="visiting-spinner" aria-hidden="true"></span>
+			{:else}
+				<featureIcons.mail size={14} aria-hidden="true" />
+			{/if}
+			<span>{isSub ? "Subscribed" : "Email updates"}</span>
+		</button>
+	</div>
 	<span class="sr-only" role="status" aria-live="polite">
 		{#if status === "added"}
 			{grove.name} added as a friend.
@@ -96,8 +136,14 @@
 		text-overflow: ellipsis;
 	}
 
-	.visiting-add {
+	.visiting-actions {
 		flex-shrink: 0;
+		display: flex;
+		gap: 0.25rem;
+	}
+
+	.visiting-add,
+	.visiting-subscribe {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.25rem;
@@ -113,6 +159,16 @@
 		min-height: 44px;
 	}
 
+	.visiting-subscribe {
+		background: var(--grove-accent-25, var(--grove-accent));
+	}
+
+	.visiting-subscribe.subscribed {
+		background: var(--grove-accent-15);
+		color: hsl(var(--foreground));
+		border: 1px solid var(--grove-accent-25);
+	}
+
 	.sr-only {
 		position: absolute;
 		width: 1px;
@@ -125,16 +181,19 @@
 		border-width: 0;
 	}
 
-	.visiting-add:hover:not(:disabled) {
+	.visiting-add:hover:not(:disabled),
+	.visiting-subscribe:hover:not(:disabled) {
 		opacity: 0.9;
 	}
 
-	.visiting-add:focus-visible {
+	.visiting-add:focus-visible,
+	.visiting-subscribe:focus-visible {
 		outline: 2px solid var(--grove-accent);
 		outline-offset: 2px;
 	}
 
-	.visiting-add:disabled {
+	.visiting-add:disabled,
+	.visiting-subscribe:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
 	}

--- a/libs/engine/src/lib/ui/stores/subscriptions.svelte.ts
+++ b/libs/engine/src/lib/ui/stores/subscriptions.svelte.ts
@@ -1,0 +1,77 @@
+/**
+ * Subscriptions store — client-side state for email notification subscriptions.
+ *
+ * Independent of the friends store. Tracks which groves the current user
+ * has subscribed to for email notifications.
+ *
+ * Follows the friends.svelte.ts pattern: module-level $state variables,
+ * exported as a plain object with getters and methods.
+ */
+
+import { api } from "$lib/utils/api";
+
+let subscribed = $state<Set<string>>(new Set());
+let loading = $state<Set<string>>(new Set());
+
+export const subscriptionsStore = {
+	isSubscribed(tenantId: string): boolean {
+		return subscribed.has(tenantId);
+	},
+
+	isLoading(tenantId: string): boolean {
+		return loading.has(tenantId);
+	},
+
+	/** Mark a tenant as subscribed (from server-side load). */
+	setSubscribed(tenantId: string, value: boolean) {
+		if (value) {
+			subscribed = new Set([...subscribed, tenantId]);
+		} else {
+			subscribed = new Set([...subscribed].filter((id) => id !== tenantId));
+		}
+	},
+
+	async subscribe(tenantId: string): Promise<boolean> {
+		if (loading.has(tenantId)) return false;
+		loading = new Set([...loading, tenantId]);
+
+		try {
+			const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+			await api.post(`/api/subscriptions/${tenantId}`, { timezone: tz });
+			subscribed = new Set([...subscribed, tenantId]);
+			return true;
+		} catch {
+			return false;
+		} finally {
+			loading = new Set([...loading].filter((id) => id !== tenantId));
+		}
+	},
+
+	async unsubscribe(tenantId: string): Promise<boolean> {
+		if (loading.has(tenantId)) return false;
+		loading = new Set([...loading, tenantId]);
+
+		try {
+			await api.delete(`/api/subscriptions/${tenantId}`);
+			subscribed = new Set([...subscribed].filter((id) => id !== tenantId));
+			return true;
+		} catch {
+			return false;
+		} finally {
+			loading = new Set([...loading].filter((id) => id !== tenantId));
+		}
+	},
+
+	async checkAndCache(tenantId: string): Promise<boolean> {
+		try {
+			const result = await api.get<{ subscribed: boolean }>(`/api/subscriptions/${tenantId}`);
+			if (result) {
+				this.setSubscribed(tenantId, result.subscribed);
+				return result.subscribed;
+			}
+			return false;
+		} catch {
+			return false;
+		}
+	},
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1746,6 +1746,25 @@ importers:
         specifier: ^4.76.0
         version: 4.76.0(@cloudflare/workers-types@4.20260317.1)
 
+  workers/subscription-digest:
+    dependencies:
+      '@autumnsgrove/lattice':
+        specifier: workspace:*
+        version: link:../../libs/engine
+      '@date-fns/tz':
+        specifier: ^1.2.0
+        version: 1.4.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250327.0
+        version: 4.20260317.1
+      wrangler:
+        specifier: ^4.14.1
+        version: 4.76.0(@cloudflare/workers-types@4.20260317.1)
+
   workers/timeline-sync:
     dependencies:
       '@autumnsgrove/infra':
@@ -2088,6 +2107,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -4400,6 +4422,9 @@ packages:
   data-urls@6.0.1:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
     engines: {node: '>=20'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -7370,6 +7395,8 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@date-fns/tz@1.4.1': {}
+
   '@drizzle-team/brocli@0.10.2': {}
 
   '@emnapi/runtime@1.8.1':
@@ -9669,6 +9696,8 @@ snapshots:
     dependencies:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
+
+  date-fns@4.1.0: {}
 
   de-indent@1.0.2: {}
 

--- a/services/durable-objects/src/index.ts
+++ b/services/durable-objects/src/index.ts
@@ -120,8 +120,35 @@ async function handleFeedQueue(
 				continue;
 			}
 
-			// Find followers in bounded batches
+			// Record pending notification for email digest (INSERT OR IGNORE for dedup).
+			// Only on the first batch (offset=0) to avoid duplicate inserts on continuation.
 			const offset = (payload as { _offset?: number })._offset || 0;
+			if (offset === 0) {
+				try {
+					await env.DB.prepare(
+						`INSERT OR IGNORE INTO pending_notifications
+						 (id, target_tenant_id, tenant_name, tenant_subdomain, post_slug, post_title, post_excerpt, post_image, published_at)
+						 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+					)
+						.bind(
+							crypto.randomUUID(),
+							tenant.id,
+							tenant.display_name || tenant.subdomain,
+							tenant.subdomain,
+							payload.slug,
+							payload.title,
+							payload.excerpt || null,
+							payload.image || null,
+							payload.publishedAt,
+						)
+						.run();
+				} catch (err) {
+					// Non-fatal — digest will just miss this post
+					console.warn("[FeedQueue] Failed to record pending notification:", err);
+				}
+			}
+
+			// Find followers in bounded batches
 			const followers = await env.DB.prepare(
 				"SELECT user_id FROM friends WHERE friend_tenant_id = ? LIMIT ? OFFSET ?",
 			)

--- a/services/email-render/src/worker.ts
+++ b/services/email-render/src/worker.ts
@@ -29,6 +29,7 @@ import { Day7Email } from "./templates/Day7Email";
 import { Day14Email } from "./templates/Day14Email";
 import { Day30Email } from "./templates/Day30Email";
 import { BetaInviteEmail } from "./templates/BetaInviteEmail";
+import { SubscriptionDigestEmail } from "./templates/SubscriptionDigestEmail";
 import type { AudienceType } from "./templates/types";
 
 // =============================================================================
@@ -36,16 +37,16 @@ import type { AudienceType } from "./templates/types";
 // =============================================================================
 
 interface RenderRequest {
-  template: string;
-  audienceType?: AudienceType;
-  name?: string | null;
-  /** Template-specific data (used by templates that don't follow the audience pattern) */
-  data?: Record<string, unknown>;
+	template: string;
+	audienceType?: AudienceType;
+	name?: string | null;
+	/** Template-specific data (used by templates that don't follow the audience pattern) */
+	data?: Record<string, unknown>;
 }
 
 interface RenderResponse {
-  html: string;
-  text: string;
+	html: string;
+	text: string;
 }
 
 // =============================================================================
@@ -53,77 +54,66 @@ interface RenderResponse {
 // =============================================================================
 
 type SequenceTemplateProps = {
-  name?: string;
-  audienceType: AudienceType;
+	name?: string;
+	audienceType: AudienceType;
 };
 
 type TemplateComponent = (props: Record<string, unknown>) => React.ReactElement;
 
 /** Sequence templates use audienceType + name */
-const SEQUENCE_TEMPLATES: Record<
-  string,
-  (props: SequenceTemplateProps) => React.ReactElement
-> = {
-  WelcomeEmail: WelcomeEmail as (
-    props: SequenceTemplateProps,
-  ) => React.ReactElement,
-  Day1Email: Day1Email as (props: SequenceTemplateProps) => React.ReactElement,
-  Day7Email: Day7Email as (props: SequenceTemplateProps) => React.ReactElement,
-  Day14Email: Day14Email as (
-    props: SequenceTemplateProps,
-  ) => React.ReactElement,
-  Day30Email: Day30Email as (
-    props: SequenceTemplateProps,
-  ) => React.ReactElement,
+const SEQUENCE_TEMPLATES: Record<string, (props: SequenceTemplateProps) => React.ReactElement> = {
+	WelcomeEmail: WelcomeEmail as (props: SequenceTemplateProps) => React.ReactElement,
+	Day1Email: Day1Email as (props: SequenceTemplateProps) => React.ReactElement,
+	Day7Email: Day7Email as (props: SequenceTemplateProps) => React.ReactElement,
+	Day14Email: Day14Email as (props: SequenceTemplateProps) => React.ReactElement,
+	Day30Email: Day30Email as (props: SequenceTemplateProps) => React.ReactElement,
 };
 
 /** Data-driven templates receive props via the data field */
 const DATA_TEMPLATES: Record<string, TemplateComponent> = {
-  BetaInviteEmail: BetaInviteEmail as TemplateComponent,
+	BetaInviteEmail: BetaInviteEmail as TemplateComponent,
+	SubscriptionDigestEmail: SubscriptionDigestEmail as TemplateComponent,
 };
 
-const ALL_TEMPLATE_NAMES = [
-  ...Object.keys(SEQUENCE_TEMPLATES),
-  ...Object.keys(DATA_TEMPLATES),
-];
+const ALL_TEMPLATE_NAMES = [...Object.keys(SEQUENCE_TEMPLATES), ...Object.keys(DATA_TEMPLATES)];
 
 // =============================================================================
 // Worker Handler
 // =============================================================================
 
 export default {
-  async fetch(request: Request): Promise<Response> {
-    const url = new URL(request.url);
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
 
-    // CORS preflight
-    if (request.method === "OPTIONS") {
-      return new Response(null, {
-        headers: corsHeaders(),
-      });
-    }
+		// CORS preflight
+		if (request.method === "OPTIONS") {
+			return new Response(null, {
+				headers: corsHeaders(),
+			});
+		}
 
-    // Health check
-    if (url.pathname === "/health") {
-      return json({ status: "ok", templates: ALL_TEMPLATE_NAMES });
-    }
+		// Health check
+		if (url.pathname === "/health") {
+			return json({ status: "ok", templates: ALL_TEMPLATE_NAMES });
+		}
 
-    // Render endpoint
-    if (url.pathname === "/render" && request.method === "POST") {
-      return handleRender(request);
-    }
+		// Render endpoint
+		if (url.pathname === "/render" && request.method === "POST") {
+			return handleRender(request);
+		}
 
-    // List available templates
-    if (url.pathname === "/templates" && request.method === "GET") {
-      return json({
-        templates: ALL_TEMPLATE_NAMES,
-        sequenceTemplates: Object.keys(SEQUENCE_TEMPLATES),
-        dataTemplates: Object.keys(DATA_TEMPLATES),
-        audienceTypes: ["wanderer", "promo", "rooted"],
-      });
-    }
+		// List available templates
+		if (url.pathname === "/templates" && request.method === "GET") {
+			return json({
+				templates: ALL_TEMPLATE_NAMES,
+				sequenceTemplates: Object.keys(SEQUENCE_TEMPLATES),
+				dataTemplates: Object.keys(DATA_TEMPLATES),
+				audienceTypes: ["wanderer", "promo", "rooted"],
+			});
+		}
 
-    return json({ error: "Not found" }, 404);
-  },
+		return json({ error: "Not found" }, 404);
+	},
 };
 
 // =============================================================================
@@ -131,85 +121,81 @@ export default {
 // =============================================================================
 
 async function handleRender(request: Request): Promise<Response> {
-  try {
-    const body = (await request.json()) as RenderRequest;
+	try {
+		const body = (await request.json()) as RenderRequest;
 
-    // Validate request
-    if (!body.template) {
-      return json({ error: "Missing template parameter" }, 400);
-    }
+		// Validate request
+		if (!body.template) {
+			return json({ error: "Missing template parameter" }, 400);
+		}
 
-    let element: React.ReactElement;
+		let element: React.ReactElement;
 
-    // Check if it's a data-driven template (e.g. BetaInviteEmail)
-    const DataTemplate = DATA_TEMPLATES[body.template];
-    if (DataTemplate) {
-      // Data templates receive props from the data field and/or top-level fields.
-      // Zephyr spreads request.data at top level when calling us, so extra fields
-      // like tier/inviteType/customMessage arrive as top-level JSON properties.
-      // We re-parse the raw body to capture everything beyond RenderRequest's type.
-      const rawBody = JSON.parse(JSON.stringify(body)) as Record<
-        string,
-        unknown
-      >;
-      const props: Record<string, unknown> = { name: body.name || undefined };
+		// Check if it's a data-driven template (e.g. BetaInviteEmail)
+		const DataTemplate = DATA_TEMPLATES[body.template];
+		if (DataTemplate) {
+			// Data templates receive props from the data field and/or top-level fields.
+			// Zephyr spreads request.data at top level when calling us, so extra fields
+			// like tier/inviteType/customMessage arrive as top-level JSON properties.
+			// We re-parse the raw body to capture everything beyond RenderRequest's type.
+			const rawBody = JSON.parse(JSON.stringify(body)) as Record<string, unknown>;
+			const props: Record<string, unknown> = { name: body.name || undefined };
 
-      // Merge nested data (if sent directly with a data field)
-      if (body.data) {
-        Object.assign(props, body.data);
-      }
+			// Merge nested data (if sent directly with a data field)
+			if (body.data) {
+				Object.assign(props, body.data);
+			}
 
-      // Merge top-level extras (from Zephyr's spread)
-      for (const [key, value] of Object.entries(rawBody)) {
-        if (!["template", "audienceType", "name", "data"].includes(key)) {
-          props[key] = value;
-        }
-      }
+			// Merge top-level extras (from Zephyr's spread)
+			for (const [key, value] of Object.entries(rawBody)) {
+				if (!["template", "audienceType", "name", "data"].includes(key)) {
+					props[key] = value;
+				}
+			}
 
-      element = React.createElement(DataTemplate, props);
-    } else {
-      // Sequence templates require audienceType
-      const SequenceTemplate = SEQUENCE_TEMPLATES[body.template];
-      if (!SequenceTemplate) {
-        return json(
-          {
-            error: `Unknown template: ${body.template}`,
-            available: ALL_TEMPLATE_NAMES,
-          },
-          400,
-        );
-      }
+			element = React.createElement(DataTemplate, props);
+		} else {
+			// Sequence templates require audienceType
+			const SequenceTemplate = SEQUENCE_TEMPLATES[body.template];
+			if (!SequenceTemplate) {
+				return json(
+					{
+						error: `Unknown template: ${body.template}`,
+						available: ALL_TEMPLATE_NAMES,
+					},
+					400,
+				);
+			}
 
-      if (!body.audienceType) {
-        return json(
-          {
-            error:
-              "Missing audienceType parameter (required for sequence templates)",
-          },
-          400,
-        );
-      }
+			if (!body.audienceType) {
+				return json(
+					{
+						error: "Missing audienceType parameter (required for sequence templates)",
+					},
+					400,
+				);
+			}
 
-      if (!["wanderer", "promo", "rooted"].includes(body.audienceType)) {
-        return json({ error: "Invalid audienceType" }, 400);
-      }
+			if (!["wanderer", "promo", "rooted"].includes(body.audienceType)) {
+				return json({ error: "Invalid audienceType" }, 400);
+			}
 
-      element = React.createElement(SequenceTemplate, {
-        name: body.name || undefined,
-        audienceType: body.audienceType,
-      });
-    }
+			element = React.createElement(SequenceTemplate, {
+				name: body.name || undefined,
+				audienceType: body.audienceType,
+			});
+		}
 
-    const html = await render(element);
-    const text = await render(element, { plainText: true });
+		const html = await render(element);
+		const text = await render(element, { plainText: true });
 
-    const response: RenderResponse = { html, text };
-    return json(response);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error("Render error:", message);
-    return json({ error: `Render failed: ${message}` }, 500);
-  }
+		const response: RenderResponse = { html, text };
+		return json(response);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error("Render error:", message);
+		return json({ error: `Render failed: ${message}` }, 500);
+	}
 }
 
 // =============================================================================
@@ -217,19 +203,19 @@ async function handleRender(request: Request): Promise<Response> {
 // =============================================================================
 
 function json(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: {
-      "Content-Type": "application/json",
-      ...corsHeaders(),
-    },
-  });
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+			...corsHeaders(),
+		},
+	});
 }
 
 function corsHeaders(): Record<string, string> {
-  return {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-  };
+	return {
+		"Access-Control-Allow-Origin": "*",
+		"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+		"Access-Control-Allow-Headers": "Content-Type",
+	};
 }

--- a/workers/subscription-digest/package.json
+++ b/workers/subscription-digest/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@autumnsgrove/subscription-digest",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module",
+	"scripts": {
+		"dev": "wrangler dev --test-scheduled",
+		"deploy": "wrangler deploy"
+	},
+	"dependencies": {
+		"@autumnsgrove/lattice": "workspace:*",
+		"date-fns": "^4.1.0",
+		"@date-fns/tz": "^1.2.0"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20250327.0",
+		"wrangler": "^4.14.1"
+	}
+}

--- a/workers/subscription-digest/src/worker.ts
+++ b/workers/subscription-digest/src/worker.ts
@@ -1,0 +1,233 @@
+/**
+ * Subscription Digest Worker
+ *
+ * Hourly cron that sends timezone-aware email digests to subscribers.
+ * Each hour, it identifies subscribers whose local time matches their
+ * preferred notification hour, then sends a batched digest of new posts
+ * from the groves they follow.
+ *
+ * Flow:
+ * 1. Query subscriptions where current UTC hour = preferred_hour in their timezone
+ * 2. For each eligible subscriber, query pending_notifications for their subscribed groves
+ * 3. Group by grove, send one digest email per grove via Zephyr
+ * 4. Clean up sent notifications
+ */
+
+import { TZDate } from "@date-fns/tz";
+import { ZephyrClient } from "@autumnsgrove/lattice/zephyr";
+import { getOrCreateUnsubscribeToken } from "@autumnsgrove/lattice/server/services/subscriptions";
+
+interface Env {
+	DB: D1Database;
+	ZEPHYR: Fetcher;
+	ZEPHYR_API_KEY: string;
+	ZEPHYR_URL: string;
+	UNSUBSCRIBE_BASE_URL: string;
+}
+
+interface EligibleSubscriber {
+	subscription_id: string;
+	user_id: string;
+	email: string;
+	target_tenant_id: string;
+}
+
+interface PendingPost {
+	id: string;
+	tenant_name: string;
+	tenant_subdomain: string;
+	post_slug: string;
+	post_title: string;
+	post_excerpt: string | null;
+	post_image: string | null;
+	published_at: number;
+}
+
+/**
+ * Get all distinct timezones that have subscribers, then check which ones
+ * have their current local hour matching any subscriber's preferred_hour.
+ *
+ * Returns subscription IDs of eligible subscribers.
+ */
+async function getEligibleSubscribers(db: D1Database): Promise<EligibleSubscriber[]> {
+	// Get distinct timezone + preferred_hour combos
+	const combos = await db
+		.prepare(`SELECT DISTINCT timezone, preferred_hour FROM subscriptions`)
+		.all<{ timezone: string; preferred_hour: number }>();
+
+	if (!combos.results?.length) return [];
+
+	// Check which combos match the current hour
+	const matchingTimezones: { tz: string; hour: number }[] = [];
+	for (const combo of combos.results) {
+		try {
+			const now = new TZDate(new Date(), combo.timezone);
+			const currentHour = now.getHours();
+			if (currentHour === combo.preferred_hour) {
+				matchingTimezones.push({ tz: combo.timezone, hour: combo.preferred_hour });
+			}
+		} catch {
+			// Invalid timezone — skip
+			console.warn(`[Digest] Invalid timezone: ${combo.timezone}`);
+		}
+	}
+
+	if (!matchingTimezones.length) return [];
+
+	// Query all eligible subscribers
+	const conditions = matchingTimezones
+		.map(() => "(timezone = ? AND preferred_hour = ?)")
+		.join(" OR ");
+	const binds = matchingTimezones.flatMap((m) => [m.tz, m.hour]);
+
+	const result = await db
+		.prepare(
+			`SELECT id as subscription_id, user_id, email, target_tenant_id
+			 FROM subscriptions
+			 WHERE ${conditions}`,
+		)
+		.bind(...binds)
+		.all<EligibleSubscriber>();
+
+	return result.results ?? [];
+}
+
+/**
+ * Get pending notifications for a specific tenant.
+ */
+async function getPendingForTenant(db: D1Database, tenantId: string): Promise<PendingPost[]> {
+	const result = await db
+		.prepare(
+			`SELECT id, tenant_name, tenant_subdomain, post_slug, post_title,
+			        post_excerpt, post_image, published_at
+			 FROM pending_notifications
+			 WHERE target_tenant_id = ?
+			 ORDER BY published_at DESC`,
+		)
+		.bind(tenantId)
+		.all<PendingPost>();
+
+	return result.results ?? [];
+}
+
+/**
+ * Send a digest email for one subscriber + one grove's pending posts.
+ */
+async function sendDigestEmail(
+	zephyr: ZephyrClient,
+	subscriber: EligibleSubscriber,
+	posts: PendingPost[],
+	unsubscribeUrl: string,
+): Promise<boolean> {
+	const groveName = posts[0].tenant_name;
+	const groveSubdomain = posts[0].tenant_subdomain;
+	const today = new Date().toISOString().split("T")[0];
+
+	try {
+		const result = await zephyr.send({
+			type: "notification",
+			template: "SubscriptionDigestEmail",
+			to: subscriber.email,
+			subject:
+				posts.length === 1
+					? `New from ${groveName}: ${posts[0].post_title}`
+					: `${posts.length} new posts from ${groveName}`,
+			data: {
+				groveName,
+				groveSubdomain,
+				posts: posts.map((p) => ({
+					title: p.post_title,
+					excerpt: p.post_excerpt,
+					slug: p.post_slug,
+					image: p.post_image,
+					url: `https://${groveSubdomain}.grove.place/garden/${p.post_slug}`,
+				})),
+				unsubscribeUrl,
+			},
+			source: "subscription-digest",
+			idempotencyKey: `sub-digest:${subscriber.user_id}:${subscriber.target_tenant_id}:${today}`,
+			headers: {
+				"List-Unsubscribe": `<${unsubscribeUrl}>`,
+				"List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+			},
+		});
+
+		return result.success;
+	} catch (err) {
+		console.error(`[Digest] Failed to send to ${subscriber.email} for ${groveSubdomain}:`, err);
+		return false;
+	}
+}
+
+export default {
+	async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
+		console.log("[Digest] Starting subscription digest run");
+
+		const zephyr = new ZephyrClient({
+			baseUrl: env.ZEPHYR_URL,
+			apiKey: env.ZEPHYR_API_KEY,
+			fetcher: env.ZEPHYR,
+		});
+
+		// 1. Find eligible subscribers (whose local time matches their preferred hour)
+		const eligible = await getEligibleSubscribers(env.DB);
+		if (!eligible.length) {
+			console.log("[Digest] No eligible subscribers this hour");
+			return;
+		}
+		console.log(`[Digest] Found ${eligible.length} eligible subscribers`);
+
+		// 2. Group subscribers by target tenant
+		const byTenant = new Map<string, EligibleSubscriber[]>();
+		for (const sub of eligible) {
+			const group = byTenant.get(sub.target_tenant_id) ?? [];
+			group.push(sub);
+			byTenant.set(sub.target_tenant_id, group);
+		}
+
+		// 3. For each tenant, get pending posts and send digests
+		let sent = 0;
+		let failed = 0;
+		const processedNotificationIds = new Set<string>();
+
+		for (const [tenantId, subscribers] of byTenant) {
+			const posts = await getPendingForTenant(env.DB, tenantId);
+			if (!posts.length) continue;
+
+			// Track notification IDs for cleanup
+			for (const post of posts) {
+				processedNotificationIds.add(post.id);
+			}
+
+			// Send to each subscriber for this tenant
+			for (const subscriber of subscribers) {
+				const token = await getOrCreateUnsubscribeToken(env.DB, subscriber.subscription_id);
+				const unsubscribeUrl = `${env.UNSUBSCRIBE_BASE_URL}?token=${token}`;
+
+				const success = await sendDigestEmail(zephyr, subscriber, posts, unsubscribeUrl);
+				if (success) {
+					sent++;
+				} else {
+					failed++;
+				}
+			}
+		}
+
+		// 4. Clean up processed pending notifications
+		if (processedNotificationIds.size > 0) {
+			const ids = [...processedNotificationIds];
+			// D1 doesn't support IN with > 100 binds, batch if needed
+			for (let i = 0; i < ids.length; i += 100) {
+				const batch = ids.slice(i, i + 100);
+				const placeholders = batch.map(() => "?").join(",");
+				await env.DB.prepare(`DELETE FROM pending_notifications WHERE id IN (${placeholders})`)
+					.bind(...batch)
+					.run();
+			}
+		}
+
+		console.log(
+			`[Digest] Complete: ${sent} sent, ${failed} failed, ${processedNotificationIds.size} notifications cleared`,
+		);
+	},
+};

--- a/workers/subscription-digest/src/worker.ts
+++ b/workers/subscription-digest/src/worker.ts
@@ -154,7 +154,10 @@ async function sendDigestEmail(
 
 		return result.success;
 	} catch (err) {
-		console.error(`[Digest] Failed to send to ${subscriber.email} for ${groveSubdomain}:`, err);
+		console.error(
+			`[Digest] Failed to send digest for user ${subscriber.user_id} / ${groveSubdomain}:`,
+			err,
+		);
 		return false;
 	}
 }

--- a/workers/subscription-digest/tsconfig.json
+++ b/workers/subscription-digest/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"types": ["@cloudflare/workers-types"],
+		"strict": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/workers/subscription-digest/wrangler.toml
+++ b/workers/subscription-digest/wrangler.toml
@@ -1,0 +1,35 @@
+# Subscription Digest Worker
+#
+# Hourly cron that sends timezone-aware email digests to subscribers
+# when groves they follow publish new posts.
+#
+# Deploy: wrangler deploy
+# Logs: wrangler tail
+# Test manually: wrangler dev --test-scheduled
+
+name = "grove-subscription-digest"
+main = "src/worker.ts"
+compatibility_date = "2025-12-01"
+
+# Hourly — checks which subscribers' local time matches their preferred hour
+[triggers]
+crons = ["0 * * * *"]
+
+# D1 Database binding (same as engine)
+[[d1_databases]]
+binding = "DB"
+database_name = "grove-engine-db"
+database_id = "a6394da2-b7a6-48ce-b7fe-b1eb3e730e68"
+
+# Service binding for Zephyr email gateway
+[[services]]
+binding = "ZEPHYR"
+service = "grove-zephyr"
+
+# Environment variables
+[vars]
+ZEPHYR_URL = "https://grove-zephyr.m7jv4v7npb.workers.dev"
+UNSUBSCRIBE_BASE_URL = "https://grove.place/unsubscribe/grove"
+
+# Secrets (set via wrangler secret put)
+# - ZEPHYR_API_KEY: API key for authenticating with Zephyr


### PR DESCRIPTION
## Summary

When a wanderer follows a grove, they can now subscribe to receive email notifications when that grove publishes new posts. Email-first, feed later.

- **Subscribe UI** in Lantern visiting card + standalone button on grove home page
- **Subscription service** independent from friends system (separate `subscriptions` table)
- **Daily digest emails** batched per grove, sent at the subscriber's preferred hour in their timezone
- **One-click unsubscribe** via signed token URL (two-step: GET confirms, POST deletes)
- **Arbor settings page** for managing subscriptions, timezone, and preferred send hour
- **44 tests** covering service layer and API routes

### Architecture

```
Subscribe (Lantern / grove page)
  → subscriptions table (D1)
  → Post published → FEED_QUEUE → pending_notifications table
  → Hourly cron worker (timezone-aware) → batch digest per grove
  → Zephyr → email-render (SubscriptionDigestEmail) → Resend
  → One-click unsubscribe (/unsubscribe/grove on landing)
```

### New dependency
- `date-fns` + `@date-fns/tz` (~1 KB gzipped) in subscription-digest worker for timezone scheduling math

### Audit remediation included
- Two-step unsubscribe (no GET mutation — safe from prefetch/bots)
- 30-day TTL on unsubscribe tokens
- Timezone validated against `Intl` before DB storage
- Zod schemas + `parseFormData()` on Arbor form actions
- PII scrubbed from worker logs

Closes #1547

## Test plan

- [ ] Subscribe to a grove via Lantern visiting card
- [ ] Subscribe via grove home page button
- [ ] Verify subscription shows in Arbor /subscriptions page
- [ ] Publish a post on subscribed grove
- [ ] Run digest cron → verify email sent via Zephyr
- [ ] Click unsubscribe link in email → confirm page → unsubscribe
- [ ] Verify re-subscribe works after unsubscribe
- [ ] Update timezone/hour preferences in Arbor
- [ ] Run `vitest` — 44 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)