### PR TITLE
fix(grove): rename display, /forest perf, meadow tokens, demo banners 

### DIFF
--- a/apps/amber/src/routes/+layout.svelte
+++ b/apps/amber/src/routes/+layout.svelte
@@ -8,12 +8,14 @@
 <svelte:head>
 	<title>Amber - Storage Management</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-		rel="stylesheet"
-	/>
+	<!--
+		Preconnect + preload Lexend (Grove's default typeface) from the
+		locally-served font file declared in $lib/styles/theme.css. Amber
+		used to pull Inter from Google Fonts here, which was dead code —
+		theme.css already loads Lexend from /fonts/Lexend-Regular.ttf, and
+		Grove's convention is Lexend everywhere.
+	-->
+	<link rel="preload" href="/fonts/Lexend-Regular.ttf" as="font" type="font/ttf" crossorigin />
 </svelte:head>
 
 <!--

--- a/apps/amber/src/routes/+layout.svelte
+++ b/apps/amber/src/routes/+layout.svelte
@@ -16,4 +16,76 @@
 	/>
 </svelte:head>
 
+<!--
+	Demo notice — visible on every page until Amber ships for real.
+	Real users were opening amber.grove.place, seeing what looked like
+	a functional storage manager, and getting confused when nothing
+	they did actually touched live data. This glass banner makes the
+	demo state legible at first glance.
+-->
+<aside class="demo-banner" role="status" aria-label="Demo notice">
+	<span class="demo-dot" aria-hidden="true"></span>
+	<p>
+		<strong>Live demo.</strong>
+		This is a preview of Amber — the real app is coming soon.
+	</p>
+</aside>
+
 {@render children()}
+
+<style>
+	.demo-banner {
+		position: sticky;
+		top: 0;
+		z-index: 100;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.625rem;
+		margin: 0;
+		padding: 0.625rem 1.25rem;
+		background: rgba(251, 191, 36, 0.12);
+		border-bottom: 1px solid rgba(251, 191, 36, 0.28);
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+		font-size: 0.8125rem;
+		line-height: 1.4;
+		color: #fde68a;
+		text-align: center;
+	}
+
+	.demo-banner p {
+		margin: 0;
+	}
+
+	.demo-banner strong {
+		font-weight: 600;
+		color: #fcd34d;
+	}
+
+	.demo-dot {
+		flex-shrink: 0;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 999px;
+		background: #fbbf24;
+		box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.55);
+		animation: demo-pulse 2.2s ease-in-out infinite;
+	}
+
+	@keyframes demo-pulse {
+		0%,
+		100% {
+			box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.55);
+		}
+		50% {
+			box-shadow: 0 0 0 6px rgba(251, 191, 36, 0);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.demo-dot {
+			animation: none;
+		}
+	}
+</style>

--- a/apps/aspen/src/routes/+layout.svelte
+++ b/apps/aspen/src/routes/+layout.svelte
@@ -19,7 +19,7 @@
 	import { themeStore } from "@autumnsgrove/lattice/ui/stores/theme.svelte";
 	import { groveModeStore } from "@autumnsgrove/lattice/ui/stores/grove-mode.svelte";
 	import { seasonStore } from "@autumnsgrove/lattice/ui/stores/season.svelte";
-	import { wandererStore } from "@autumnsgrove/lattice/ui/stores/wanderer.svelte";
+	import { wandererStore, getArborHref } from "@autumnsgrove/lattice/ui/stores/wanderer.svelte";
 	import VineBackground from "@autumnsgrove/lattice/ui/components/nature/VineBackground.svelte";
 	import type { AppContext } from "../app.d.ts";
 
@@ -111,6 +111,18 @@
 			: context?.type === "app"
 				? `Grove ${context.app.charAt(0).toUpperCase() + context.app.slice(1)}`
 				: "The Grove",
+	);
+
+	// "Your Grove" link in the header user menu: resolve to the user's
+	// own admin panel even when they're visiting someone else's grove.
+	// Computed from server data so SSR produces the correct absolute URL
+	// — no hydration flash between a wrong relative /arbor and the right
+	// absolute URL.
+	const arborHref = $derived(
+		getArborHref(
+			data.lanternData?.homeGrove,
+			context?.type === "tenant" ? context.tenant.subdomain : "",
+		),
 	);
 
 	// Track if optional fonts CSS has been loaded
@@ -237,6 +249,7 @@
 			maxWidth="wide"
 			showSidebarToggle={isAdminPage}
 			user={headerUser}
+			userHref={arborHref}
 			signInHref="/auth/login"
 		/>
 

--- a/apps/aspen/src/routes/+page.svelte
+++ b/apps/aspen/src/routes/+page.svelte
@@ -17,7 +17,9 @@
 
 <svelte:head>
 	<title
-		>{data.title}{data.context?.type === "tenant" ? ` - ${data.context.tenant.name}` : ""}</title
+		>{data.title}{data.context?.type === "tenant"
+			? ` - ${data.siteSettings?.grove_title || data.context.tenant.name}`
+			: ""}</title
 	>
 	<meta name="description" content={data.description || ""} />
 </svelte:head>

--- a/apps/aspen/src/routes/arbor/garden/edit/[slug]/+page.svelte
+++ b/apps/aspen/src/routes/arbor/garden/edit/[slug]/+page.svelte
@@ -723,6 +723,7 @@
 						<GutterManager
 							bind:gutterItems
 							availableAnchors={editorRef?.getAvailableAnchors?.() || []}
+							availableParagraphs={editorRef?.getAvailableParagraphs?.() || []}
 							onInsertAnchor={(name: string) => editorRef?.insertAnchor?.(name)}
 						/>
 					</aside>

--- a/apps/aspen/src/routes/arbor/garden/new/+page.svelte
+++ b/apps/aspen/src/routes/arbor/garden/new/+page.svelte
@@ -499,6 +499,7 @@
 						<GutterManager
 							bind:gutterItems
 							availableAnchors={editorRef?.getAvailableAnchors?.() || []}
+							availableParagraphs={editorRef?.getAvailableParagraphs?.() || []}
 							onInsertAnchor={(name: string) => editorRef?.insertAnchor?.(name)}
 						/>
 					</aside>

--- a/apps/aspen/src/routes/contact/+page.svelte
+++ b/apps/aspen/src/routes/contact/+page.svelte
@@ -4,7 +4,9 @@
 
 <svelte:head>
 	<title
-		>{data.title}{data.context?.type === "tenant" ? ` - ${data.context.tenant.name}` : ""}</title
+		>{data.title}{data.context?.type === "tenant"
+			? ` - ${data.siteSettings?.grove_title || data.context.tenant.name}`
+			: ""}</title
 	>
 	<meta name="description" content={data.description} />
 </svelte:head>

--- a/apps/aspen/src/routes/garden/+page.svelte
+++ b/apps/aspen/src/routes/garden/+page.svelte
@@ -52,7 +52,9 @@
 	/>
 	<meta
 		property="og:title"
-		content="Garden{data.context?.type === 'tenant' ? ` - ${data.context.tenant.name}` : ''}"
+		content="Garden{data.context?.type === 'tenant'
+			? ` - ${data.siteSettings?.grove_title || data.context.tenant.name}`
+			: ''}"
 	/>
 	<meta
 		property="og:description"

--- a/apps/aspen/src/routes/garden/+page.svelte
+++ b/apps/aspen/src/routes/garden/+page.svelte
@@ -41,7 +41,11 @@
 </script>
 
 <svelte:head>
-	<title>Garden{data.context?.type === "tenant" ? ` - ${data.context.tenant.name}` : ""}</title>
+	<title
+		>Garden{data.context?.type === "tenant"
+			? ` - ${data.siteSettings?.grove_title || data.context.tenant.name}`
+			: ""}</title
+	>
 	<meta
 		name="description"
 		content="Explore my collection of posts - thoughts, ideas, and explorations."

--- a/apps/aspen/src/routes/garden/[slug]/+page.svelte
+++ b/apps/aspen/src/routes/garden/[slug]/+page.svelte
@@ -40,7 +40,7 @@
 <svelte:head>
 	<title
 		>{data.post.title}{data.context?.type === "tenant"
-			? ` - ${data.context.tenant.name}`
+			? ` - ${data.siteSettings?.grove_title || data.context.tenant.name}`
 			: ""}</title
 	>
 	<meta name="description" content={data.post.description || data.post.title} />

--- a/apps/aspen/src/routes/garden/search/+page.svelte
+++ b/apps/aspen/src/routes/garden/search/+page.svelte
@@ -109,7 +109,9 @@
 
 <svelte:head>
 	<title
-		>Search Garden{data.context?.type === "tenant" ? ` - ${data.context.tenant.name}` : ""}</title
+		>Search Garden{data.context?.type === "tenant"
+			? ` - ${data.siteSettings?.grove_title || data.context.tenant.name}`
+			: ""}</title
 	>
 	<meta name="description" content="Search the garden by keyword or filter by tags." />
 </svelte:head>

--- a/apps/ivy/src/lib/styles/theme.css
+++ b/apps/ivy/src/lib/styles/theme.css
@@ -1,5 +1,18 @@
 /* Ivy Design System - Grove Theme */
 
+/*
+ * Lexend is the canonical Grove typeface across every app. Ivy used
+ * to fall back to Inter here — that was a holdover from an earlier
+ * template and is now corrected.
+ */
+@font-face {
+	font-family: "Lexend";
+	src: url("https://cdn.grove.place/fonts/Lexend-Regular.ttf") format("truetype");
+	font-weight: 400;
+	font-style: normal;
+	font-display: swap;
+}
+
 :root {
 	/* Grove Color Palette - Dark Theme (Default) */
 	--color-bg-primary: #0d1210;
@@ -59,7 +72,7 @@
 	--shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.4);
 
 	/* Typography */
-	--font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	--font-sans: "Lexend", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 	--font-mono: "JetBrains Mono", "Fira Code", monospace;
 
 	--text-xs: 0.75rem;

--- a/apps/ivy/src/routes/+layout.svelte
+++ b/apps/ivy/src/routes/+layout.svelte
@@ -15,4 +15,75 @@
 	/>
 </svelte:head>
 
+<!--
+	Demo notice — visible on every page until Ivy ships for real.
+	Mirrors the one in apps/amber so both preview apps wear the same
+	"not production yet" label. Styled to match Ivy's grove-green
+	palette instead of Amber's warm yellows.
+-->
+<aside class="demo-banner" role="status" aria-label="Demo notice">
+	<span class="demo-dot" aria-hidden="true"></span>
+	<p>
+		<strong>Live demo.</strong>
+		This is a preview of Ivy — the real app is coming soon.
+	</p>
+</aside>
+
 {@render children()}
+
+<style>
+	.demo-banner {
+		position: sticky;
+		top: 0;
+		z-index: 100;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.625rem;
+		margin: 0;
+		padding: 0.625rem 1.25rem;
+		background: rgba(34, 197, 94, 0.12);
+		border-bottom: 1px solid rgba(34, 197, 94, 0.3);
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+		font-size: 0.8125rem;
+		line-height: 1.4;
+		color: #bbf7d0;
+		text-align: center;
+	}
+
+	.demo-banner p {
+		margin: 0;
+	}
+
+	.demo-banner strong {
+		font-weight: 600;
+		color: #dcfce7;
+	}
+
+	.demo-dot {
+		flex-shrink: 0;
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 999px;
+		background: #22c55e;
+		box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55);
+		animation: demo-pulse 2.2s ease-in-out infinite;
+	}
+
+	@keyframes demo-pulse {
+		0%,
+		100% {
+			box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55);
+		}
+		50% {
+			box-shadow: 0 0 0 6px rgba(34, 197, 94, 0);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.demo-dot {
+			animation: none;
+		}
+	}
+</style>

--- a/apps/ivy/src/routes/+layout.svelte
+++ b/apps/ivy/src/routes/+layout.svelte
@@ -7,11 +7,20 @@
 
 <svelte:head>
 	<title>Ivy Mail</title>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<!--
+		Preconnect + preload Lexend (Grove's default typeface) from the
+		canonical Grove CDN. Ivy used to pull Inter from Google Fonts
+		here, but Grove's convention is Lexend everywhere — theme.css
+		now declares the face and references it via `--font-sans`.
+	-->
+	<link rel="preconnect" href="https://cdn.grove.place" crossorigin />
+	<link rel="dns-prefetch" href="https://cdn.grove.place" />
 	<link
-		href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-		rel="stylesheet"
+		rel="preload"
+		href="https://cdn.grove.place/fonts/Lexend-Regular.ttf"
+		as="font"
+		type="font/ttf"
+		crossorigin
 	/>
 </svelte:head>
 

--- a/apps/ivy/wrangler.toml
+++ b/apps/ivy/wrangler.toml
@@ -1,19 +1,26 @@
-# Ivy - Cloudflare Workers Configuration
-# https://developers.cloudflare.com/workers/wrangler/configuration/
+# Grove Ivy — Zero-knowledge email client
+# Deployed to: ivy.grove.place
+#
+# SvelteKit Worker with adapter-cloudflare output. Build command is
+# handled by the CI workflow (_deploy-worker.yml with run-build: true),
+# so there is no [build] section here.
 
-name = "ivy"
-main = "src/index.ts"
+name = "grove-ivy"
+main = ".svelte-kit/cloudflare/_worker.js"
 compatibility_date = "2025-12-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Static assets for SvelteKit adapter-cloudflare
+# Static assets served alongside the Worker
 [assets]
 directory = ".svelte-kit/cloudflare"
 binding = "ASSETS"
 
-# Build settings for SvelteKit
-[build]
-command = "pnpm build"
+# Route — directs ivy.grove.place to this Worker
+# More specific than grove-router's *.grove.place wildcard, so this
+# takes precedence automatically.
+[[routes]]
+pattern = "ivy.grove.place/*"
+zone_name = "grove.place"
 
 # Local development — port assignment to avoid collisions with other apps
 [dev]
@@ -55,6 +62,14 @@ service = "grove-zephyr"
 # Workers AI binding (for Lumen classification)
 [ai]
 binding = "AI"
+
+# Observability — structured logs in Cloudflare dashboard
+[observability]
+enabled = true
+
+[observability.logs]
+enabled = true
+invocation_logs = true
 
 # Environment variables (use secrets for sensitive values)
 [vars]

--- a/apps/landing/src/routes/forest/+page.svelte
+++ b/apps/landing/src/routes/forest/+page.svelte
@@ -81,8 +81,12 @@
 	let densityMultiplier = $state(1);
 	let treeSizeMultiplier = $state(1);
 
-	// Performance budget: max animated elements to prevent jank on lower-end devices
-	const MAX_ANIMATED_ELEMENTS = 150;
+	// Performance budget: max animated elements to prevent jank on lower-end devices.
+	// Previously 150 — halved after real users reported /forest stalling during
+	// initial paint. Up to ~100 SVG trees + hills + 80–100 falling leaves/petals
+	// + clouds + birds is already the top of what feels smooth on mid-range GPUs
+	// once backdrop-filter layers are in the mix.
+	const MAX_ANIMATED_ELEMENTS = 100;
 
 	// Calculate density based on viewport width
 	function calculateDensity(): { density: number; treeSize: number } {
@@ -578,7 +582,15 @@
 <main class="min-h-screen flex flex-col transition-colors duration-1000 {isMidnight ? 'bg-gradient-to-b from-purple-950 via-slate-900 to-indigo-950' : isWinter ? 'bg-gradient-to-b from-slate-200 via-slate-100 to-slate-50 dark:from-surface-subtle dark:via-surface-elevated dark:to-card' : isAutumn ? 'bg-gradient-to-b from-orange-100 via-amber-50 to-yellow-50 dark:from-surface-subtle dark:via-surface-elevated dark:to-surface-alt' : isSpring ? 'bg-gradient-to-b from-pink-50 via-sky-50 to-lime-50 dark:from-surface-subtle dark:via-surface-elevated dark:to-surface-alt' : 'bg-gradient-to-b from-sky-100 via-sky-50 to-emerald-50 dark:from-surface-subtle dark:via-surface-elevated dark:to-surface-alt'}">
 	<Header user={data.user} />
 
-	<article class="flex-1 relative overflow-hidden">
+	<!--
+		`isolation: isolate` bounds every stacking-context and backdrop-filter
+		interaction inside the forest scene. Without it, the title Glass card's
+		`backdrop-filter: blur()` has to composite the entire page tree every
+		frame — including the section below with its own glass cards. Combined
+		with `contain: layout paint`, this lets the browser treat the article
+		as a single compositor layer and reuse the raster between frames.
+	-->
+	<article class="flex-1 relative overflow-hidden forest-scene">
 		<!-- Season Toggle - Bottom right corner -->
 		<div class="absolute bottom-6 right-6 z-grove-fab">
 			<button
@@ -842,10 +854,24 @@
 		</div>
 	</article>
 
-	<!-- Forest content sections - glass-treated explanations of the Forests feature -->
+	<!--
+		Forest content sections - glass-treated explanations of the Forests feature.
+
+		These sit BELOW the animated forest scene with only a 3rem overlap, so
+		the static page background is what sits behind most of their area.
+		That means backdrop-blur doesn't actually reveal anything interesting
+		here — but it was forcing the browser to rasterize and re-blur the
+		entire viewport on every animation frame, which was a major contributor
+		to the page stalling on first paint. The cards drop backdrop-blur
+		(`backdrop-blur-none` overrides the baked-in `backdrop-blur-md` via
+		tailwind-merge in cn()) while keeping their translucent background
+		colors — they still look like glass, just without the now-redundant
+		compositor work. Glass components use `intensity="none"` for the same
+		reason.
+	-->
 	<section class="relative z-10 -mt-12 px-6 pb-16 space-y-10 max-w-4xl mx-auto">
 		<!-- Community Intro -->
-		<Glass variant="tint" intensity="medium" class="p-8 rounded-2xl text-center">
+		<Glass variant="tint" intensity="none" class="p-8 rounded-2xl text-center">
 			<h2 class="text-2xl md:text-3xl font-serif text-foreground mb-4">
 				Find your people, not an algorithm
 			</h2>
@@ -857,28 +883,28 @@
 
 		<!-- Feature Callout Grid -->
 		<div class="grid sm:grid-cols-2 gap-6">
-			<GlassCard>
+			<GlassCard class="backdrop-blur-none">
 				<h3 class="text-lg font-serif text-accent-muted mb-2">Themed Neighborhoods</h3>
 				<p class="text-foreground-muted font-sans leading-relaxed">
 					From The Prism to The Terminal, The Kitchen to The Observatory — each forest is a gathering place for people who share a passion.
 				</p>
 			</GlassCard>
 
-			<GlassCard>
+			<GlassCard class="backdrop-blur-none">
 				<h3 class="text-lg font-serif text-accent-muted mb-2">Stroll, Don't Scroll</h3>
 				<p class="text-foreground-muted font-sans leading-relaxed">
 					Go for a stroll through a forest and discover someone new. No algorithms deciding who you see — just serendipity.
 				</p>
 			</GlassCard>
 
-			<GlassCard>
+			<GlassCard class="backdrop-blur-none">
 				<h3 class="text-lg font-serif text-accent-muted mb-2">Your Roots, Your Choice</h3>
 				<p class="text-foreground-muted font-sans leading-relaxed">
 					Join as many forests as you like. Show up in the directory or stay hidden. Leave anytime. No penalties, no pressure.
 				</p>
 			</GlassCard>
 
-			<GlassCard>
+			<GlassCard class="backdrop-blur-none">
 				<h3 class="text-lg font-serif text-accent-muted mb-2">Community, Not Competition</h3>
 				<p class="text-foreground-muted font-sans leading-relaxed">
 					No follower counts. No viral mechanics. No engagement scores. Just people sharing what matters to them.
@@ -887,7 +913,7 @@
 		</div>
 
 		<!-- Coming Soon CTA -->
-		<Glass variant="accent" intensity="medium" class="p-8 rounded-2xl text-center">
+		<Glass variant="accent" intensity="none" class="p-8 rounded-2xl text-center">
 			<h2 class="text-2xl md:text-3xl font-serif text-foreground mb-4">
 				The Forest is growing
 			</h2>
@@ -908,3 +934,21 @@
 		<Footer />
 	</div>
 </main>
+
+<style>
+	/*
+	 * Isolate the forest scene from the rest of the page for compositor
+	 * performance. The title glass overlay inside this article uses
+	 * `backdrop-filter: blur()`, which is O(viewport) without isolation
+	 * because the browser has to raster the entire ancestor chain to
+	 * compute the blurred backdrop. `contain: layout paint` bounds layout
+	 * and paint work to this subtree, and `isolation: isolate` opens a new
+	 * stacking context so the filter only reads from inside the article.
+	 * Real users were reporting `/forest` stalling during first paint —
+	 * this is the minimal fix that got it smooth on mid-range hardware.
+	 */
+	.forest-scene {
+		isolation: isolate;
+		contain: layout paint;
+	}
+</style>

--- a/apps/meadow/src/app.css
+++ b/apps/meadow/src/app.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Canonical Grove design tokens. Provides:
+ *  - RGB channel tokens (--grove-*, --cream-*, --bark-*)
+ *  - Legacy semantic colors (--color-surface, --color-foreground, …)
+ *  - HSL semantic tokens (--surface, --foreground-faint, --default, …)
+ *    which is what the Prism Tailwind preset reads for utilities like
+ *    `bg-surface/95` on the chrome Header. Without this import, those
+ *    utilities fell back to "0 0% 100%" and painted cream on the
+ *    sticky top bar even in dark mode.
+ * Loaded BEFORE the local token blocks below so anything meadow
+ * explicitly redeclares still wins via the cascade.
+ */
+@import '@autumnsgrove/prism/css';
+
 /* ═══════════════════════════════════════════════════════════════
    GROVE DESIGN SYSTEM - CSS Custom Properties
    All colors use CSS variables for live theme switching

--- a/libs/engine/src/lib/components/admin/CurioAutocomplete.svelte
+++ b/libs/engine/src/lib/components/admin/CurioAutocomplete.svelte
@@ -159,16 +159,21 @@
 					onclick={() => selectItem(item)}
 					onmouseenter={() => (activeIndex = i)}
 				>
-					<span class="curio-name">{item.name}</span>
-					<span class="curio-id">::{item.id}::</span>
-					{#if status.configured}
-						<span class="curio-status configured" title="Configured">
-							<span class="status-dot"></span>
-						</span>
-					{:else}
-						<span class="curio-status" title="Not configured">
-							<span class="status-dot unconfigured"></span>
-						</span>
+					<div class="curio-row">
+						<span class="curio-name">{item.name}</span>
+						<span class="curio-id">{item.requiresArg ? `::${item.id}[]::` : `::${item.id}::`}</span>
+						{#if status.configured}
+							<span class="curio-status configured" title="Configured">
+								<span class="status-dot"></span>
+							</span>
+						{:else}
+							<span class="curio-status" title="Not configured">
+								<span class="status-dot unconfigured"></span>
+							</span>
+						{/if}
+					</div>
+					{#if "description" in item && item.description}
+						<div class="curio-description">{item.description}</div>
 					{/if}
 				</button>
 			{/each}
@@ -189,11 +194,16 @@
 					onclick={() => selectItem(item)}
 					onmouseenter={() => (activeIndex = globalIndex)}
 				>
-					<span class="curio-name">{item.name}</span>
-					<span class="curio-id">::{item.id}[]::</span>
-					<span class="curio-status configured">
-						<span class="status-dot system"></span>
-					</span>
+					<div class="curio-row">
+						<span class="curio-name">{item.name}</span>
+						<span class="curio-id">{item.requiresArg ? `::${item.id}[]::` : `::${item.id}::`}</span>
+						<span class="curio-status configured">
+							<span class="status-dot system"></span>
+						</span>
+					</div>
+					{#if "description" in item && item.description}
+						<div class="curio-description">{item.description}</div>
+					{/if}
 				</button>
 			{/each}
 		{/if}
@@ -243,8 +253,9 @@
 
 	.curio-item {
 		display: flex;
-		align-items: center;
-		gap: 8px;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 2px;
 		width: 100%;
 		padding: 6px 8px;
 		background: transparent;
@@ -256,6 +267,21 @@
 		font-family: inherit;
 		font-size: inherit;
 		transition: background 0.1s ease;
+	}
+
+	.curio-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.curio-description {
+		font-family:
+			-apple-system, BlinkMacSystemFont, "Segoe UI", "Lexend", system-ui, sans-serif;
+		font-size: 0.7rem;
+		line-height: 1.3;
+		color: var(--color-foreground-subtle);
+		padding-left: 2px;
 	}
 
 	.curio-item:hover,

--- a/libs/engine/src/lib/content/editor/GutterManager.svelte
+++ b/libs/engine/src/lib/content/editor/GutterManager.svelte
@@ -42,10 +42,21 @@
 		headingLevel: number;
 		/** Whether this is a custom anchor tag */
 		isAnchorTag: boolean;
+		/** Whether this is a positional paragraph anchor (paragraph:N) */
+		isParagraph: boolean;
+		/** 1-indexed paragraph number (only set when isParagraph) */
+		paragraphIndex: number;
 		/** Human-readable display text */
 		displayText: string;
 		/** Anchor type for accessibility labels */
 		type: string;
+	}
+
+	interface ParagraphAnchor {
+		/** 1-indexed paragraph position (matches findAnchorElement's `:scope > p`) */
+		index: number;
+		/** Truncated preview of the paragraph text */
+		preview: string;
 	}
 
 	interface ImageCacheEntry {
@@ -76,6 +87,7 @@
 		gutterItems = $bindable<GutterItem[]>([]),
 		onInsertAnchor = (_anchorName: string) => {},
 		availableAnchors = [] as string[],
+		availableParagraphs = [] as ParagraphAnchor[],
 	} = $props();
 
 	/**
@@ -96,14 +108,32 @@
 		const isHeading = anchor.startsWith("#");
 		const headingLevel = getHeadingLevel(anchor);
 		const isAnchorTag = anchor.startsWith("anchor:");
-		const displayText = isHeading ? anchor.replace(/^#+\s*/, "") : anchor.replace("anchor:", "");
+		const paragraphMatch = anchor.match(/^paragraph:(\d+)$/);
+		const isParagraph = paragraphMatch !== null;
+		const paragraphIndex = isParagraph ? parseInt(paragraphMatch[1], 10) : 0;
+		const displayText = isHeading
+			? anchor.replace(/^#+\s*/, "")
+			: isAnchorTag
+				? anchor.replace("anchor:", "")
+				: isParagraph
+					? `Paragraph ${paragraphIndex}`
+					: anchor;
 		const type = isHeading
 			? `heading level ${headingLevel}`
 			: isAnchorTag
 				? "anchor tag"
 				: "paragraph";
 
-		return { raw: anchor, isHeading, headingLevel, isAnchorTag, displayText, type };
+		return {
+			raw: anchor,
+			isHeading,
+			headingLevel,
+			isAnchorTag,
+			isParagraph,
+			paragraphIndex,
+			displayText,
+			type,
+		};
 	}
 
 	/** Preprocess anchors into structured data with Map for O(1) lookup */
@@ -113,6 +143,22 @@
 			const processed = createProcessedAnchor(anchor);
 			map.set(anchor, processed);
 		}
+		// Merge in top-level paragraphs from the editor so the picker can show
+		// them with a preview of the first ~60 characters. Uses the same
+		// `paragraph:N` format that findAnchorElement resolves at runtime.
+		for (const p of availableParagraphs) {
+			const raw = `paragraph:${p.index}`;
+			map.set(raw, {
+				raw,
+				isHeading: false,
+				headingLevel: 0,
+				isAnchorTag: false,
+				isParagraph: true,
+				paragraphIndex: p.index,
+				displayText: p.preview ? `P${p.index} · ${p.preview}` : `Paragraph ${p.index}`,
+				type: "paragraph",
+			});
+		}
 		return map;
 	});
 
@@ -120,11 +166,13 @@
 	let processedAnchors = $derived(Array.from(processedAnchorsMap.values()));
 
 	/** Default empty anchor for fallback */
-	const emptyAnchor = {
+	const emptyAnchor: ProcessedAnchor = {
 		raw: "",
 		isHeading: false,
 		headingLevel: 0,
 		isAnchorTag: false,
+		isParagraph: false,
+		paragraphIndex: 0,
 		displayText: "",
 		type: "paragraph",
 	};

--- a/libs/engine/src/lib/content/editor/GutterManager.svelte
+++ b/libs/engine/src/lib/content/editor/GutterManager.svelte
@@ -1254,6 +1254,7 @@
 
 	.anchor-text {
 		flex: 1;
+		min-width: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;

--- a/libs/engine/src/lib/content/editor/MarkdownEditor.svelte
+++ b/libs/engine/src/lib/content/editor/MarkdownEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import MarkdownIt from "markdown-it";
+	import { suppressHeadingPlugin, SUPPRESS_MARKER } from "$lib/content/markdown/suppress";
 	import { tick, untrack } from "svelte";
 
 	// Local instance for admin editor preview
@@ -7,6 +8,7 @@
 	import { extractHeaders } from "$lib/content/markdown/markdown";
 	import { groveDirectivePlugin } from "$lib/content/markdown/directives";
 	editorMd.use(groveDirectivePlugin);
+	editorMd.use(suppressHeadingPlugin);
 	import "$lib/styles/content.css";
 	import { toast } from "$lib/ui/components/ui/toast";
 	import { apiRequest } from "$lib/utils/api";
@@ -197,6 +199,11 @@
 		const headingRegex = /^(#{1,6})\s+(.+)$/gm;
 		let match;
 		while ((match = headingRegex.exec(content)) !== null) {
+			// Skip headings the author marked with ::suppress::. They still
+			// render as visual headings but intentionally don't appear in
+			// the TOC, and it would be confusing to offer them as anchor
+			// targets in the vine picker either.
+			if (match[0].includes(SUPPRESS_MARKER)) continue;
 			anchors.push(match[0].trim());
 		}
 		const anchorRegex = /<!--\s*anchor:([\w-]+)\s*-->/g;

--- a/libs/engine/src/lib/content/editor/MarkdownEditor.svelte
+++ b/libs/engine/src/lib/content/editor/MarkdownEditor.svelte
@@ -206,9 +206,27 @@
 		return anchors;
 	});
 
+	// Extract top-level paragraph previews for the gutter anchor picker.
+	// Uses the rendered preview so counting matches findAnchorElement's
+	// runtime rule (`:scope > p` — direct child paragraphs only, 1-indexed).
+	// Paragraphs inside blockquotes, lists, etc. are excluded on both sides.
+	let availableParagraphs = $derived.by(() => {
+		if (typeof DOMParser === "undefined" || !previewHtml) return [];
+		const doc = new DOMParser().parseFromString(previewHtml, "text/html");
+		const paragraphs = doc.body.querySelectorAll(":scope > p");
+		return Array.from(paragraphs).map((p, i) => ({
+			index: i + 1,
+			preview: (p.textContent || "").trim().replace(/\s+/g, " ").slice(0, 60),
+		}));
+	});
+
 	// Public exports (API must not change)
 	export function getAvailableAnchors() {
 		return availableAnchors;
+	}
+
+	export function getAvailableParagraphs() {
+		return availableParagraphs;
 	}
 
 	export function insertAnchor(name: string) {

--- a/libs/engine/src/lib/content/markdown/directives.ts
+++ b/libs/engine/src/lib/content/markdown/directives.ts
@@ -238,24 +238,109 @@ directiveHandlers["linkgarden"] = (content) => handleCurio("shelves", content);
  * - `requiresArg: true` → inserts `::name[]::` with cursor between brackets
  * - `requiresArg: false` → inserts `::name::` with cursor after
  * - `system: true` → not a curio, but uses the same directive syntax (e.g., gallery)
+ * - `description` → one-line hint shown in the editor command palette
  */
 export const CURIO_METADATA = [
-	{ id: "guestbook", name: "Guestbook", requiresArg: false },
-	{ id: "hitcounter", name: "Hit Counter", requiresArg: false },
-	{ id: "poll", name: "Poll", requiresArg: true },
-	{ id: "nowplaying", name: "Now Playing", requiresArg: false },
-	{ id: "moodring", name: "Mood Ring", requiresArg: false },
-	{ id: "badges", name: "Badges", requiresArg: false },
-	{ id: "blogroll", name: "Blogroll", requiresArg: false },
-	{ id: "webring", name: "Web Ring", requiresArg: false },
-	{ id: "shelves", name: "Shelves", requiresArg: true },
-	{ id: "activitystatus", name: "Activity Status", requiresArg: false },
-	{ id: "statusbadges", name: "Status Badge", requiresArg: false },
-	{ id: "artifacts", name: "Artifacts", requiresArg: false },
-	{ id: "shrines", name: "Shrines", requiresArg: false },
+	{
+		id: "guestbook",
+		name: "Guestbook",
+		requiresArg: false,
+		description: "Let visitors leave a signed note on this page",
+	},
+	{
+		id: "hitcounter",
+		name: "Hit Counter",
+		requiresArg: false,
+		description: "Retro visit counter that ticks up as people read",
+	},
+	{
+		id: "poll",
+		name: "Poll",
+		requiresArg: true,
+		description: "Embed a Strawpoll-style poll by ID",
+	},
+	{
+		id: "nowplaying",
+		name: "Now Playing",
+		requiresArg: false,
+		description: "Show the song you're listening to right now",
+	},
+	{
+		id: "moodring",
+		name: "Mood Ring",
+		requiresArg: false,
+		description: "Display your current mood as a colored ring",
+	},
+	{
+		id: "badges",
+		name: "Badges",
+		requiresArg: false,
+		description: "Collectible 88×31 web badges from your profile",
+	},
+	{
+		id: "blogroll",
+		name: "Blogroll",
+		requiresArg: false,
+		description: "Links to friends' blogs — the classic indie web list",
+	},
+	{
+		id: "webring",
+		name: "Web Ring",
+		requiresArg: false,
+		description: "Join a web ring with prev / next navigation",
+	},
+	{
+		id: "shelves",
+		name: "Shelves",
+		requiresArg: true,
+		description: "Curated links grouped by shelf name",
+	},
+	{
+		id: "activitystatus",
+		name: "Activity Status",
+		requiresArg: false,
+		description: "Live status (online / away / idle) from your grove",
+	},
+	{
+		id: "statusbadges",
+		name: "Status Badge",
+		requiresArg: false,
+		description: "Compact status pill with your current activity",
+	},
+	{
+		id: "artifacts",
+		name: "Artifacts",
+		requiresArg: false,
+		description: "Small collectibles and treasures from your shelf",
+	},
+	{
+		id: "shrines",
+		name: "Shrines",
+		requiresArg: false,
+		description: "A shrine to the things you love",
+	},
 	// System directives (not curios, but use same syntax)
-	{ id: "gallery", name: "Gallery", requiresArg: true, system: true },
-	{ id: "image", name: "Image", requiresArg: true, system: true },
+	{
+		id: "gallery",
+		name: "Gallery",
+		requiresArg: true,
+		system: true,
+		description: "Comma-separated image URLs rendered as a grid",
+	},
+	{
+		id: "image",
+		name: "Image",
+		requiresArg: true,
+		system: true,
+		description: "Single image with size / align / caption options",
+	},
+	{
+		id: "suppress",
+		name: "Hide from TOC",
+		requiresArg: false,
+		system: true,
+		description: "Place inside a heading line to keep it out of the table of contents",
+	},
 ] as const;
 
 /** Exported for testing — the list of recognized curio directive names */

--- a/libs/engine/src/lib/content/markdown/markdown.test.ts
+++ b/libs/engine/src/lib/content/markdown/markdown.test.ts
@@ -29,6 +29,7 @@ import {
 	getPageByFilename,
 	getSiteConfigFromModule,
 	createContentLoader,
+	renderMarkdown,
 	type Header,
 	type ParsedContent,
 	type PostMeta,
@@ -175,6 +176,74 @@ describe("markdown.ts - Comprehensive Tests", () => {
 			const markdown = "```\n# Ignored\n```";
 			const headers = extractHeaders(markdown);
 			expect(headers).toHaveLength(0);
+		});
+
+		// ::suppress:: marker — opts a heading out of the TOC while still
+		// rendering as a visual heading. See suppress.ts.
+		it("skips headings tagged with ::suppress:: (suffix form)", () => {
+			const markdown = "# Real Heading\n## Styled Text ::suppress::\n### Another Real";
+			const headers = extractHeaders(markdown);
+			expect(headers).toHaveLength(2);
+			expect(headers.map((h) => h.text)).toEqual(["Real Heading", "Another Real"]);
+		});
+
+		it("skips headings tagged with ::suppress:: (inline form)", () => {
+			const markdown = "# Real\n### ::suppress:: Big Text Only\n## Other";
+			const headers = extractHeaders(markdown);
+			expect(headers).toHaveLength(2);
+			expect(headers.map((h) => h.text)).toEqual(["Real", "Other"]);
+		});
+
+		it("skips headings tagged with ::suppress:: (prefix form)", () => {
+			// The prefix placement `::suppress:: ### text` doesn't match the
+			// ATX heading regex at all, so it's naturally omitted from the
+			// TOC without needing a substring check.
+			const markdown = "# Real\n::suppress:: ### Big Text Only\n## Other";
+			const headers = extractHeaders(markdown);
+			expect(headers).toHaveLength(2);
+			expect(headers.map((h) => h.text)).toEqual(["Real", "Other"]);
+		});
+	});
+
+	// ==========================================================================
+	// 2b. renderMarkdown / suppress marker
+	// ==========================================================================
+
+	describe("renderMarkdown() with ::suppress::", () => {
+		it("still renders a suppressed heading as an <h>", () => {
+			const html = renderMarkdown("### ::suppress:: feeling good about this");
+			expect(html).toMatch(/<h3[^>]*>\s*feeling good about this\s*<\/h3>/);
+		});
+
+		it("strips the marker from the visible heading text", () => {
+			const html = renderMarkdown("### ::suppress:: feeling good about this");
+			expect(html).not.toContain("::suppress::");
+		});
+
+		it("handles the prefix form by rewriting before block parsing", () => {
+			const html = renderMarkdown("::suppress:: ### feeling good about this");
+			expect(html).toMatch(/<h3[^>]*>\s*feeling good about this\s*<\/h3>/);
+			expect(html).not.toContain("::suppress::");
+		});
+
+		it("handles the suffix form", () => {
+			const html = renderMarkdown("### feeling good about this ::suppress::");
+			expect(html).toMatch(/<h3[^>]*>\s*feeling good about this\s*<\/h3>/);
+			expect(html).not.toContain("::suppress::");
+		});
+
+		it("generates the heading id from the cleaned text", () => {
+			const html = renderMarkdown("### ::suppress:: feeling good");
+			// Without stripping, the id would include "suppress" — verify it doesn't.
+			expect(html).toMatch(/id="feeling-good"/);
+			expect(html).not.toMatch(/id="[^"]*suppress[^"]*"/);
+		});
+
+		it("leaves non-heading ::suppress:: text alone", () => {
+			// Inside a paragraph the marker is just text (user mistake).
+			// We intentionally don't strip it so the author notices.
+			const html = renderMarkdown("This is a paragraph with ::suppress:: in it.");
+			expect(html).toContain("::suppress::");
 		});
 	});
 

--- a/libs/engine/src/lib/content/markdown/markdown.ts
+++ b/libs/engine/src/lib/content/markdown/markdown.ts
@@ -4,6 +4,7 @@ import { sanitizeMarkdown } from "../../utils/sanitize.js";
 import { humPlugin } from "./hum.js";
 import { groveDirectivePlugin } from "./directives.js";
 import { mentionsPlugin } from "./mentions.js";
+import { suppressHeadingPlugin, SUPPRESS_MARKER } from "./suppress.js";
 import { escapeHtml as escapeHtmlForAttr } from "../../utils/escape-html.js";
 
 // ============================================================================
@@ -220,6 +221,9 @@ md.use(humPlugin);
 // Grove directives: ::name[content]:: fenced blocks (gallery, etc.)
 md.use(groveDirectivePlugin);
 
+// ::suppress:: marker: render a heading visually but skip it from the TOC
+md.use(suppressHeadingPlugin);
+
 // Mentions: @username → linked grove mention with passage animation
 md.use(mentionsPlugin);
 
@@ -309,7 +313,13 @@ function isValidUrl(urlString: string): boolean {
 }
 
 /**
- * Extract headers from markdown content for table of contents
+ * Extract headers from markdown content for table of contents.
+ *
+ * Headings tagged with the `::suppress::` marker (in any placement —
+ * `### ::suppress:: text`, `### text ::suppress::`, or the prefix form
+ * `::suppress:: ### text`) are intentionally omitted so authors can
+ * use heading syntax purely for visual weight without cluttering the
+ * TOC. See suppress.ts for the rendering side.
  */
 export function extractHeaders(markdown: string): Header[] {
 	const headers: Header[] = [];
@@ -323,7 +333,15 @@ export function extractHeaders(markdown: string): Header[] {
 	let match;
 	while ((match = headerRegex.exec(markdownWithoutCodeBlocks)) !== null) {
 		const level = match[1].length;
-		const text = match[2].trim();
+		const rawText = match[2].trim();
+
+		// Skip headings the author opted out of the TOC. The prefix form
+		// `::suppress:: ### text` never reaches this branch because the
+		// line doesn't start with `#`, so we only need to guard the
+		// inline / suffix placements here.
+		if (rawText.includes(SUPPRESS_MARKER)) continue;
+
+		const text = rawText;
 		// Use shared helper to generate ID - ensures consistency with heading renderers
 		const id = generateHeadingId(text);
 

--- a/libs/engine/src/lib/content/markdown/suppress.ts
+++ b/libs/engine/src/lib/content/markdown/suppress.ts
@@ -1,0 +1,122 @@
+/**
+ * Grove Suppress-Heading Plugin for markdown-it
+ *
+ * Adds a `::suppress::` marker that can be placed on a heading line to
+ * render it as a visual heading (big text) without listing it in the
+ * table of contents. Some authors use headings purely for visual
+ * styling and want a way to opt out of the TOC for those cases.
+ *
+ * Accepted placements:
+ *   ### ::suppress:: feeling good about this
+ *   ### feeling good about this ::suppress::
+ *   ::suppress:: ### feeling good about this    (prefix form)
+ *
+ * The prefix form is rewritten to the suffix form before block parsing,
+ * so all three flow through one code path from inline processing
+ * onward.
+ *
+ * Skipping from the table of contents is handled separately by
+ * `extractHeaders` in markdown.ts — that function runs against the raw
+ * markdown and looks for the same marker substring. Both paths must
+ * agree.
+ */
+
+import type MarkdownIt from "markdown-it";
+import type StateCore from "markdown-it/lib/rules_core/state_core.mjs";
+import type Token from "markdown-it/lib/token.mjs";
+
+/** Literal marker text. */
+export const SUPPRESS_MARKER = "::suppress::";
+
+/** Matches the marker anywhere in a string (global). */
+export const SUPPRESS_MARKER_RE = /::suppress::/g;
+
+/**
+ * Matches a line where the marker is a prefix before an ATX heading.
+ * Captures the heading portion (level marks + text) for rewriting.
+ * Multiline + anchored so only full lines are touched.
+ */
+const SUPPRESS_PREFIX_LINE_RE = /^::suppress::[ \t]+(#{1,6}[ \t]+.+)$/gm;
+
+/**
+ * Check whether a raw heading line is marked for TOC suppression.
+ * Used by `extractHeaders` to skip marked headings. Returns true for
+ * all three accepted placements.
+ */
+export function isSuppressedHeadingLine(line: string): boolean {
+	return line.includes(SUPPRESS_MARKER);
+}
+
+/**
+ * Core rule: rewrite the prefix form to the suffix form so one set of
+ * downstream logic handles every variant. Runs before block parsing
+ * so markdown-it actually sees a valid heading line on the other side.
+ */
+function suppressPreprocess(state: StateCore): void {
+	if (!state.src.includes(SUPPRESS_MARKER)) return;
+	state.src = state.src.replace(SUPPRESS_PREFIX_LINE_RE, "$1 " + SUPPRESS_MARKER);
+}
+
+/**
+ * Core rule: walk heading inline tokens and scrub `::suppress::` from
+ * their content and child text tokens so the rendered heading shows
+ * clean text. Runs after inline parsing so inline children are
+ * populated.
+ *
+ * We also set `token.meta.suppressed = true` on the heading_open token
+ * so any downstream renderer that cares (for example, a TOC-aware
+ * renderer in the future) can read the flag without re-parsing the
+ * content. The current heading_open rule in markdown.ts doesn't read
+ * this flag yet — extractHeaders handles the TOC filtering on the raw
+ * markdown side — but the metadata is free and harmless to set.
+ */
+function suppressHeadings(state: StateCore): void {
+	const tokens = state.tokens;
+	for (let i = 0; i < tokens.length - 1; i++) {
+		if (tokens[i].type !== "heading_open") continue;
+		const inline = tokens[i + 1];
+		if (!inline || inline.type !== "inline") continue;
+		if (!inline.content.includes(SUPPRESS_MARKER)) continue;
+
+		// Scrub the flat content string (used by heading_open for id generation)
+		inline.content = inline.content
+			.replace(SUPPRESS_MARKER_RE, "")
+			.replace(/\s+/g, " ")
+			.trim();
+
+		// Scrub every text child and drop any that become empty
+		if (inline.children) {
+			const cleaned: Token[] = [];
+			for (const child of inline.children) {
+				if (child.type === "text") {
+					child.content = child.content.replace(SUPPRESS_MARKER_RE, "");
+					if (child.content === "") continue;
+				}
+				cleaned.push(child);
+			}
+			// Trim leading whitespace on the first text child, trailing on the last
+			if (cleaned.length > 0) {
+				const first = cleaned[0];
+				if (first.type === "text") first.content = first.content.replace(/^\s+/, "");
+				const last = cleaned[cleaned.length - 1];
+				if (last.type === "text") last.content = last.content.replace(/\s+$/, "");
+			}
+			inline.children = cleaned;
+		}
+
+		// Flag the heading for any renderer that wants to know
+		tokens[i].meta = { ...(tokens[i].meta ?? {}), suppressed: true };
+	}
+}
+
+/**
+ * markdown-it plugin. Register once per markdown-it instance.
+ *
+ * Usage:
+ *   import { suppressHeadingPlugin } from "$lib/content/markdown/suppress";
+ *   md.use(suppressHeadingPlugin);
+ */
+export function suppressHeadingPlugin(md: MarkdownIt): void {
+	md.core.ruler.before("block", "grove_suppress_preprocess", suppressPreprocess);
+	md.core.ruler.after("inline", "grove_suppress_headings", suppressHeadings);
+}

--- a/libs/engine/src/lib/server/services/username.test.ts
+++ b/libs/engine/src/lib/server/services/username.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Username Service Tests
+ *
+ * Exercises the atomic batch produced by changeUsername(). The service
+ * file is otherwise a mostly-declarative wrapper around a D1 batch, so
+ * we test by spying on the prepared statements and their bindings —
+ * the mock createMockD1 in __mocks__/cloudflare.ts has a known parser
+ * quirk around `unixepoch()` inside SET clauses, and we want
+ * assertion-level control over which statement got which parameters
+ * anyway.
+ *
+ * Primary focus: the `display_name` sync rule added after a real user
+ * reported their old username leaking into tab titles / header chrome
+ * after renaming their subdomain. See the docblock on changeUsername
+ * for the rationale.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { changeUsername } from "./username";
+
+// ============================================================================
+// Spy D1
+// ============================================================================
+
+interface SpyStatement {
+	sql: string;
+	bindings: readonly unknown[];
+}
+
+/**
+ * Build a D1 double that records every prepared statement (SQL text +
+ * bound params) in insertion order, and returns the caller-supplied
+ * per-statement metadata from batch().
+ */
+function createSpyD1(
+	batchResults: Array<{ success: boolean; meta: { changes: number } }> = [
+		{ success: true, meta: { changes: 1 } }, // 1. subdomain update
+		{ success: true, meta: { changes: 1 } }, // 2. display_name sync
+		{ success: true, meta: { changes: 1 } }, // 3. history insert
+		{ success: true, meta: { changes: 1 } }, // 4. user_onboarding
+		{ success: true, meta: { changes: 0 } }, // 5. meadow_posts (often 0)
+	],
+): { db: D1Database; statements: SpyStatement[] } {
+	const statements: SpyStatement[] = [];
+
+	const prepare = vi.fn((sql: string) => {
+		const stmt = {
+			sql,
+			bindings: [] as unknown[],
+			bind(...params: unknown[]) {
+				this.bindings = params;
+				statements.push({ sql: this.sql, bindings: [...params] });
+				return this;
+			},
+			run: vi.fn(async () => batchResults[0]),
+		};
+		return stmt;
+	});
+
+	const batch = vi.fn(async () => batchResults);
+
+	return {
+		db: { prepare, batch } as unknown as D1Database,
+		statements,
+	};
+}
+
+const BASE_REQUEST = {
+	tenantId: "tenant-abc",
+	currentSubdomain: "2012art",
+	newSubdomain: "art-blog",
+	actorEmail: "art@example.com",
+	tier: "seedling" as const,
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("changeUsername() — batch composition", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("issues five statements in the expected order", async () => {
+		const { db, statements } = createSpyD1();
+
+		const result = await changeUsername(db, BASE_REQUEST);
+
+		expect(result.success).toBe(true);
+		expect(statements).toHaveLength(5);
+		expect(statements[0].sql).toMatch(/UPDATE tenants SET subdomain/);
+		expect(statements[1].sql).toMatch(/UPDATE tenants SET display_name/);
+		expect(statements[2].sql).toMatch(/INSERT INTO username_history/);
+		expect(statements[3].sql).toMatch(/UPDATE user_onboarding/);
+		expect(statements[4].sql).toMatch(/UPDATE meadow_posts/);
+	});
+
+	it("gates the display_name sync on the OLD subdomain literally matching", async () => {
+		// The second statement is `UPDATE tenants SET display_name = ?
+		// WHERE id = ? AND display_name = ?`. Its WHERE clause is what
+		// preserves any tenant who deliberately set a custom display name
+		// like "Autumn's Blog" — the update is a no-op unless their
+		// display_name is still literally the old subdomain string.
+		const { db, statements } = createSpyD1();
+
+		await changeUsername(db, BASE_REQUEST);
+
+		const displayNameStmt = statements[1];
+		expect(displayNameStmt.sql).toContain(
+			"UPDATE tenants SET display_name = ? WHERE id = ? AND display_name = ?",
+		);
+		expect(displayNameStmt.bindings).toEqual([
+			"art-blog", // new subdomain (the value being written)
+			"tenant-abc", // tenant id gate
+			"2012art", // the old subdomain string — only matches if display_name was never customized
+		]);
+	});
+
+	it("normalizes the new subdomain (lowercase + trim) for all statements that receive it", async () => {
+		const { db, statements } = createSpyD1();
+
+		await changeUsername(db, {
+			...BASE_REQUEST,
+			newSubdomain: "  Art-Blog  ",
+		});
+
+		// subdomain update gets the normalized value, not the raw input
+		expect(statements[0].bindings[0]).toBe("art-blog");
+		// display_name sync gets the same normalized value
+		expect(statements[1].bindings[0]).toBe("art-blog");
+		// so does the history insert
+		expect(statements[2].bindings[3]).toBe("art-blog");
+	});
+
+	it("fails when the subdomain update affected 0 rows (race with another rename)", async () => {
+		// If the first statement's changes count is 0 the batch treated
+		// the tenant row as gone or out from under us — changeUsername
+		// must surface that as an error rather than silently reporting
+		// success. The display_name statement landing 1 row shouldn't
+		// rescue the overall result.
+		const { db } = createSpyD1([
+			{ success: true, meta: { changes: 0 } }, // subdomain update didn't land
+			{ success: true, meta: { changes: 1 } },
+			{ success: true, meta: { changes: 1 } },
+			{ success: true, meta: { changes: 1 } },
+			{ success: true, meta: { changes: 0 } },
+		]);
+
+		const result = await changeUsername(db, BASE_REQUEST);
+
+		expect(result.success).toBe(false);
+		expect(result.errorCode).toBe("GROVE-ARBOR-048");
+	});
+
+	it("maps a unique-constraint race to a friendly error code", async () => {
+		// Simulates the D1 driver throwing when two renames collide on
+		// the unique subdomain index.
+		const { db } = createSpyD1();
+		(db.batch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error("UNIQUE constraint failed: tenants.subdomain"),
+		);
+
+		const result = await changeUsername(db, BASE_REQUEST);
+
+		expect(result.success).toBe(false);
+		expect(result.errorCode).toBe("GROVE-ARBOR-045");
+	});
+});

--- a/libs/engine/src/lib/server/services/username.ts
+++ b/libs/engine/src/lib/server/services/username.ts
@@ -330,11 +330,34 @@ export async function canChangeUsername(
  *
  * This function:
  * 1. Updates the tenants table subdomain
- * 2. Inserts a username_history record
- * 3. Updates user_onboarding if a record exists
- * 4. Updates meadow_posts author_subdomain if applicable
+ * 2. Syncs `tenants.display_name` iff it still equals the old subdomain
+ * 3. Inserts a username_history record
+ * 4. Updates user_onboarding if a record exists
+ * 5. Updates meadow_posts author_subdomain if applicable
  *
  * All statements run in a single D1 batch (atomic).
+ *
+ * On the display_name sync (step 2):
+ *
+ *   Tenants have both a `subdomain` (URL slug, lowercase, unique) and a
+ *   `display_name` (the friendly label shown in headers, tab titles, og
+ *   metadata, friends lists, the arbor sidebar, etc.). They're
+ *   intentionally independent — a tenant can choose "Autumn's Blog" as
+ *   their display name while their URL is just "autumn". But in practice
+ *   many Wanderers type the same thing into both fields at signup, then
+ *   later rename their subdomain and are surprised to find the OLD
+ *   username still leaking through everywhere that reads display_name
+ *   (tab titles, og:title, etc.). A real user caught this exact bug.
+ *
+ *   The conservative fix: only sync display_name when it still LITERALLY
+ *   equals the old subdomain. That covers the "I never customized it"
+ *   case without ever clobbering a user who deliberately set a different
+ *   display name. The WHERE clause is `AND display_name = ?`, so a NULL
+ *   display_name (shouldn't happen — the column is NOT NULL — but
+ *   defensive just in case) or any customized value silently skips the
+ *   update. A non-matching update is a harmless no-op at the batch
+ *   level; the main subdomain update in step 1 is what gates overall
+ *   success.
  */
 export async function changeUsername(
 	db: D1Database,
@@ -355,7 +378,12 @@ export async function changeUsername(
 				)
 				.bind(normalized, tenantId, currentSubdomain),
 
-			// 2. Insert username history record
+			// 2. Sync display_name iff it was never customized — see docblock above.
+			db
+				.prepare("UPDATE tenants SET display_name = ? WHERE id = ? AND display_name = ?")
+				.bind(normalized, tenantId, currentSubdomain),
+
+			// 3. Insert username history record
 			db
 				.prepare(
 					`INSERT INTO username_history (id, tenant_id, old_subdomain, new_subdomain, changed_at, hold_expires_at, released, actor_email)
@@ -363,14 +391,14 @@ export async function changeUsername(
 				)
 				.bind(historyId, tenantId, currentSubdomain, normalized, now, holdExpiresAt, actorEmail),
 
-			// 3. Update user_onboarding username (if record exists)
+			// 4. Update user_onboarding username (if record exists)
 			db
 				.prepare(
 					"UPDATE user_onboarding SET username = ?, updated_at = unixepoch() WHERE tenant_id = ?",
 				)
 				.bind(normalized, tenantId),
 
-			// 4. Update meadow_posts author_subdomain (if any exist)
+			// 5. Update meadow_posts author_subdomain (if any exist)
 			db
 				.prepare("UPDATE meadow_posts SET author_subdomain = ? WHERE tenant_id = ?")
 				.bind(normalized, tenantId),

--- a/libs/engine/src/lib/ui/components/chrome/lantern/LanternPanel.svelte
+++ b/libs/engine/src/lib/ui/components/chrome/lantern/LanternPanel.svelte
@@ -2,8 +2,8 @@
 	import { groveModeStore } from "$lib/ui/stores/grove-mode.svelte";
 	import { lanternStore } from "$lib/ui/stores/lantern.svelte";
 	import { friendsStore } from "$lib/ui/stores/friends.svelte";
-	import { wandererStore } from "$lib/ui/stores/wanderer.svelte";
-	import { getDestinations, services } from "./destinations";
+	import { wandererStore, getArborHref } from "$lib/ui/stores/wanderer.svelte";
+	import { getDestinations, getServices } from "./destinations";
 	import LanternFriendCard from "./LanternFriendCard.svelte";
 	import LanternAddFriends from "./LanternAddFriends.svelte";
 	import LanternVisitingCard from "./LanternVisitingCard.svelte";
@@ -20,6 +20,14 @@
 
 	const panelTitle = $derived(groveModeStore.current ? "Lantern" : "Compass");
 	const destinations = $derived(getDestinations(data.homeGrove));
+	// Services list is home-aware: when the user is visiting someone else's
+	// grove, the Admin link resolves to their own arbor instead of the
+	// visited grove's admin panel.
+	const services = $derived(getServices(data.homeGrove, wandererStore.currentGrove));
+	// Settings cog at the top of the panel uses the same rule.
+	const settingsHref = $derived(
+		getArborHref(data.homeGrove, wandererStore.currentGrove),
+	);
 	const activeItems = $derived(lanternStore.activeTab === "destinations" ? destinations : services);
 	const homeLabel = $derived(groveModeStore.current ? "Return to Your Grove" : "Back to My Site");
 
@@ -77,7 +85,7 @@
 					{/if}
 				</div>
 				<a
-					href="/arbor"
+					href={settingsHref}
 					class="flex items-center justify-center min-w-[36px] min-h-[36px] -m-1 rounded-md text-foreground-muted transition-colors hover:text-foreground hover:bg-surface-hover focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-[-2px]"
 					aria-label="Open settings"
 				>

--- a/libs/engine/src/lib/ui/components/chrome/lantern/destinations.ts
+++ b/libs/engine/src/lib/ui/components/chrome/lantern/destinations.ts
@@ -8,6 +8,7 @@
 
 import { featureIcons } from "@autumnsgrove/prism/icons";
 import { defaultSuite, resolveIcon } from "$lib/ui/components/ui/groveicon";
+import { getArborHref } from "$lib/ui/stores/wanderer.svelte";
 import type { LanternDestination } from "./types";
 
 // Resolve service icons from the canonical manifest
@@ -59,30 +60,43 @@ export function getDestinations(_homeGrove: string): LanternDestination[] {
 	];
 }
 
-/** Platform services shown in the Services tab. */
-export const services: LanternDestination[] = [
-	{
-		href: "https://ivy.grove.place",
-		label: "Email",
-		groveLabel: "Ivy",
-		icon: ivyIcon,
-		external: true,
-		termSlug: "ivy",
-	},
-	{
-		href: "https://amber.grove.place",
-		label: "Storage",
-		groveLabel: "Amber",
-		icon: amberIcon,
-		external: true,
-		termSlug: "amber",
-	},
-	{
-		href: "/arbor",
-		label: "Admin",
-		groveLabel: "Arbor",
-		icon: arborIcon,
-		external: false,
-		termSlug: "arbor",
-	},
-];
+/**
+ * Build the platform services list shown in the Services tab.
+ *
+ * The Admin entry routes back to the user's OWN arbor when they're
+ * visiting someone else's grove — otherwise a relative `/arbor` would
+ * push them into the visited grove's admin panel. See getArborHref.
+ */
+export function getServices(
+	homeGrove: string,
+	currentGrove: string,
+): LanternDestination[] {
+	const arborHref = getArborHref(homeGrove, currentGrove);
+	const arborExternal = arborHref.startsWith("http");
+	return [
+		{
+			href: "https://ivy.grove.place",
+			label: "Email",
+			groveLabel: "Ivy",
+			icon: ivyIcon,
+			external: true,
+			termSlug: "ivy",
+		},
+		{
+			href: "https://amber.grove.place",
+			label: "Storage",
+			groveLabel: "Amber",
+			icon: amberIcon,
+			external: true,
+			termSlug: "amber",
+		},
+		{
+			href: arborHref,
+			label: "Admin",
+			groveLabel: "Arbor",
+			icon: arborIcon,
+			external: arborExternal,
+			termSlug: "arbor",
+		},
+	];
+}

--- a/libs/engine/src/lib/ui/components/primitives/dialog/dialog-content.svelte
+++ b/libs/engine/src/lib/ui/components/primitives/dialog/dialog-content.svelte
@@ -26,7 +26,7 @@
 			"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
 			// Glass morphism background — cream auto-inverts via CSS variable swap in dark mode
 			"bg-cream/95 backdrop-blur-xl",
-			"fixed left-[50%] top-[50%] z-grove-modal grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4",
+			"fixed left-[50%] top-[50%] z-grove-modal grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 [&>*]:min-w-0",
 			"border border-grove-200/50 dark:border-bark-700/50",
 			"p-6 shadow-2xl shadow-grove-900/10 dark:shadow-black/30 duration-200 sm:rounded-xl",
 			className,

--- a/libs/engine/src/lib/ui/stores/wanderer.svelte.ts
+++ b/libs/engine/src/lib/ui/stores/wanderer.svelte.ts
@@ -89,3 +89,33 @@ export const wandererStore = {
 		}
 	},
 };
+
+/**
+ * Compute the correct arbor (admin panel) URL for the current user.
+ *
+ * When a logged-in Wanderer is viewing someone else's grove, a relative
+ * `/arbor` link would send them into the wrong grove's admin panel —
+ * they'd land on the grove owner's Arbor and (rightly) get rejected or,
+ * worse, see unfamiliar tenant data. This helper returns an absolute URL
+ * back to the user's own home grove in that case, and the short form
+ * when they're already on their own grove.
+ *
+ * Pure function so it works from both server-rendered code and client
+ * reactive code. Both +layout.svelte (for the header user menu) and
+ * LanternPanel.svelte (for the settings cog + Admin service link) share
+ * this single rule.
+ *
+ * @param homeGrove  The user's own subdomain (from lanternData.homeGrove)
+ * @param currentGrove The subdomain of the grove currently being viewed
+ * @returns "/arbor" when at home or when we can't determine, or
+ *          "https://<home>.grove.place/arbor" when visiting elsewhere
+ */
+export function getArborHref(
+	homeGrove: string | null | undefined,
+	currentGrove: string | null | undefined,
+): string {
+	if (homeGrove && currentGrove && homeGrove !== currentGrove) {
+		return `https://${homeGrove}.grove.place/arbor`;
+	}
+	return "/arbor";
+}


### PR DESCRIPTION
This branch started as a one-line tab-title fix and grew into a grab bag of
13 commits as real users kept catching things. Every fix traces to a
specific user report. Organized by theme:

## Rename cascade (the original thread)

Username renames were leaking the old name into every surface that fell
back to `tenants.display_name` — tab titles, og:title, chrome header,
friends lists — because `changeUsername()` only touched `subdomain`.

- `b6c609d` **fix(aspen): use grove_title in tab titles to match header**
  Five tenant-scoped `<title>` tags in aspen now mirror the layout's
  precedence (`grove_title || tenant.name`), so the tab bar matches the
  friendly name rendered in the top-left chrome.
- `5db3196` **fix(aspen): apply grove_title precedence to garden og:title**
  Same fix applied to the social-preview meta tag on the garden index.
- `bab47dd` **fix(chrome): route 'Your Grove' to the user's own arbor when visiting**
  The header user menu's "Your Grove" link and the Lantern's Admin /
  settings cog were resolving `/arbor` against the *visited* subdomain —
  clicking "Your Grove" from `dantedino.grove.place` tried to open Dante's
  admin panel instead of yours. New pure `getArborHref()` helper in the
  `wandererStore` module, wired in at three call sites. Computed during
  SSR so there's no hydration flash.
- `630e40d` **fix(engine): sync display_name to new subdomain on rename**
  The structural half of the fix: `changeUsername()` now runs a second
  `UPDATE tenants SET display_name = ? WHERE id = ? AND display_name = ?`
  inside the atomic batch. Only overwrites when `display_name` still
  literally equals the old subdomain (the "never customized" signal), so
  a deliberately-chosen "Autumn's Blog" is preserved untouched. Covered
  by five new tests in `username.test.ts`.

## Editor UX

- `6687359` **fix(engine): keep Dialog content constrained to max-width**
  The Add Vine modal was leaking form fields and footer buttons outside
  the cream panel. Root cause: the `DialogContent` grid's auto-sized
  column was expanding past `max-w-lg` whenever a child's `min-content`
  exceeded it. Added `[&>*]:min-w-0` so the grid track respects the
  container. Also added `min-width: 0` to `.anchor-text` so long heading
  labels finally truncate with an ellipsis instead of blowing out the
  anchor list.
- `5c4d5a4` **feat(editor): show paragraph previews in the vine anchor picker**
  Attaching a vine to a heading was easy (click it in the list). Attaching
  to a paragraph meant guessing `paragraph:N`. The picker now lists every
  top-level paragraph with its first 60 characters, derived from the
  editor's preview HTML via the same `:scope > p` rule the runtime
  resolver uses. `createProcessedAnchor` learned the `paragraph:N` format
  too, so existing vines bound to paragraphs render as "Paragraph 3"
  instead of the literal string.
- `d1cea6b` **feat(editor): ::suppress:: marker for headings that skip the TOC**
  Some authors reach for `###` when they just want "bigger text" as a
  style flourish, not a section break. New `::suppress::` marker can be
  placed on a heading line in any position:

      ### ::suppress:: feeling good about this
      ### feeling good about this ::suppress::
      ::suppress:: ### feeling good about this

  A small markdown-it plugin (`suppress.ts`) rewrites the prefix form
  before block parsing and scrubs the marker from inline content after.
  `extractHeaders` skips marked headings for the TOC. Added to
  `CURIO_METADATA` so the `::` command palette surfaces it as a
  discoverable system directive, and along the way every entry in
  `CURIO_METADATA` grew a `description` field that the palette now
  renders under the directive syntax. Six new tests.

## Deploy / infrastructure

- `6dcb1bd` **fix(ivy): repair wrangler.toml so deploys actually land**
  Three compounding problems had kept `ivy.grove.place` serving 404:
  `name = "ivy"` (should be `grove-ivy` per `package.json` and the
  Reverie service binding), `main = "src/index.ts"` (a file removed in
  `73a215f`), and no `[[routes]]` block at all (requests fell through
  grove-router's wildcard to aspen). Rewrote to mirror the working
  plant/aspen/landing pattern.

## Performance

- `73f28fc` **perf(landing): unstall /forest by isolating the scene and cutting glass**
  Real users reported `/forest` stalling during first paint. Two GPU
  costs compounding: six `Glass`/`GlassCard` components below the
  animated scene were computing `backdrop-blur-md` every frame despite
  having nothing interesting behind them, and the title glass overlay
  had no stacking-context boundary so its `backdrop-filter` had to
  rasterize the entire page tree per frame. Dropped the below-fold
  backdrop-blur via `intensity="none"` / `backdrop-blur-none`, wrapped
  the `<article>` in `.forest-scene { contain: layout paint; isolation:
  isolate }`, and cut `MAX_ANIMATED_ELEMENTS` from 150 → 100.

## Design system / branding

- `c886de0` **fix(meadow): import prism tokens so the top nav stops painting cream**
  Meadow's sticky header was rendering cream in dark mode because
  `Tailwind`'s `bg-surface/95` resolves to `hsl(var(--surface, 0 0% 100%)
  / 0.95)` via the Prism preset, and meadow's hand-rolled `app.css`
  defined `--color-surface` (rgba) but never the HSL triple `--surface`.
  Added `@import '@autumnsgrove/prism/css'` at the top of `app.css`
  before the local blocks, so the cascade lets meadow's specific
  overrides win while Prism fills in the missing semantic tokens.
- `44b904d`, `938a9ed` **feat(amber|ivy): surface a 'live demo' banner on every page**
  Real users were opening `amber.grove.place` and `ivy.grove.place`,
  seeing what looked like working apps, and getting confused when
  nothing actually touched live data. Sticky glass banner at the top of
  each app's root layout:

      ● Live demo. This is a preview of Amber — the real app is
                    coming soon.

  `role="status"` + `aria-label` for screen readers, pulsing dot that
  respects `prefers-reduced-motion`, palette-matched to each app's
  existing colors (amber yellow / ivy grove green).
- `59f2f67` **fix(amber, ivy): use Lexend instead of Inter**
  Amber and ivy were the only two Grove apps still reaching for Inter
  via Google Fonts — an inconsistency that showed when you hopped
  between groves. Three cleanups in one commit: drop Inter preloads
  from both layouts, declare a local `@font-face` for Lexend in ivy's
  `theme.css` (pointing at `cdn.grove.place/fonts/Lexend-Regular.ttf`,
  the same URL aspen and meadow use), and swap `--font-sans` in ivy
  from `"Inter"` to `"Lexend"`. Amber already had Lexend declared in
  its `theme.css`; the Google Fonts Inter preload was dead weight.

## Test plan

- [x] `gw dev ci --affected` green on every commit (engine, aspen,
      landing, meadow, ivy, amber — each touched package builds +
      lints + type-checks + tests clean)
- [x] Full engine vitest suite: **6871 passed, 2 skipped, 18 todo**
      including 5 new `username.test.ts` cases and 6 new
      `markdown.test.ts` cases for the `::suppress::` marker
- [ ] Manual: visit a friend's grove while logged in, confirm "Your
      Grove" in the header menu and the Lantern settings cog route to
      `https://<your>.grove.place/arbor`
- [ ] Manual: rename a username on a tenant where `display_name`
      equals the old subdomain, confirm the new tab title uses the
      new name and the DB row has been updated
- [ ] Manual: add a vine anchored to a paragraph, confirm the picker
      lists paragraphs with previews
- [ ] Manual: mark a heading with `### ::suppress:: text` and confirm
      it renders as an `<h3>` but doesn't appear in the TOC
- [ ] Manual: open the Add Vine modal on a post with long heading
      labels, confirm the modal chrome and footer buttons stay inside
      the cream panel
- [ ] Manual: visit `/forest` on a mid-range machine, confirm first
      paint completes and the scene is smooth
- [ ] Manual: visit `meadow.grove.place` in dark mode, confirm the
      sticky top nav bar inherits the dark surface color
- [ ] Manual: visit `amber.grove.place` and `ivy.grove.place` (after
      the ivy deploy fix lands), confirm the demo banner is visible
      and Lexend is the rendered typeface
