### PR TITLE
fix(garden): apply :global() to post-card so stretched-link actually contains each card

### DIFF
--- a/apps/aspen/src/routes/garden/+page.svelte
+++ b/apps/aspen/src/routes/garden/+page.svelte
@@ -217,7 +217,9 @@
 	}
 
 	/* Stretched link: title link covers the whole card for click/middle-click */
-	.post-card {
+	/* :global needed — .post-card is on a Svelte component (Card), so scoped CSS
+	   wouldn't reach its root DOM element */
+	:global(.post-card) {
 		position: relative;
 	}
 


### PR DESCRIPTION
Svelte scopes CSS rules with a per-component hash, so .post-card { position: relative }
in +page.svelte never matched the Card component's root <div> (which carries card.svelte's
hash, not the page's). Without the positioning context the ::after pseudo-elements on
each post link expanded past their card and all overlapped on the same ancestor, making
every card click navigate to whichever post was last in DOM order.

https://claude.ai/code/session_018GTCCA7mwFRtCSci9Tysk8