### PR TITLE
fix(photo-upload): differentiate Petal infrastructure errors from content rejections

### DIFF
--- a/apps/aspen/src/routes/api/images/upload/+server.ts
+++ b/apps/aspen/src/routes/api/images/upload/+server.ts
@@ -220,9 +220,18 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
 			);
 
 			if (!petalResult.allowed) {
+				// Infrastructure/temporary errors use UPLOAD_SERVICE_UNAVAILABLE
+				const isInfraError = ["SCAN_ERROR", "CSAM_SCAN_FAILED"].includes(
+					petalResult.response?.code || "",
+				);
+				const apiError = isInfraError
+					? API_ERRORS.UPLOAD_SERVICE_UNAVAILABLE
+					: API_ERRORS.INVALID_FILE;
+
 				// Count this rejection. After 15 Petal rejections in an hour, restrict uploads.
 				// Limit is set high enough to survive Petal false positives on legitimate content.
-				if (threshold) {
+				// (Skip counting for infrastructure errors to avoid false positives)
+				if (threshold && !isInfraError) {
 					try {
 						const rejectedResult = await threshold.check({
 							key: `upload/rejected:${locals.user.id}`,
@@ -245,11 +254,11 @@ export const POST: RequestHandler = async ({ request, platform, locals }) => {
 
 				return json(
 					{
-						...buildErrorJson(API_ERRORS.INVALID_FILE),
+						...buildErrorJson(apiError),
 						error_description: petalResult.response?.message,
 						processingTimeMs: petalResult.response?.processingTimeMs,
 					},
-					{ status: 400 },
+					{ status: isInfraError ? 503 : 400 },
 				);
 			}
 		}

--- a/apps/aspen/src/routes/api/images/upload/upload-pipeline.ts
+++ b/apps/aspen/src/routes/api/images/upload/upload-pipeline.ts
@@ -131,7 +131,7 @@ export function validateFile(file: File, buffer: Uint8Array): { ext: string } {
 
 export interface PetalScanResult {
 	allowed: boolean;
-	response?: { message: string; processingTimeMs?: number };
+	response?: { message: string; processingTimeMs?: number; code?: string };
 }
 
 export async function runPetalScan(
@@ -165,6 +165,7 @@ export async function runPetalScan(
 			response: {
 				message: petalResult.message,
 				processingTimeMs: petalResult.processingTimeMs,
+				code: petalResult.code,
 			},
 		};
 	}

--- a/libs/engine/src/lib/server/petal/vision-client.ts
+++ b/libs/engine/src/lib/server/petal/vision-client.ts
@@ -441,15 +441,33 @@ export async function classifyImage(
 	// Parse JSON response
 	try {
 		// Extract JSON from response (may have surrounding text)
-		const jsonMatch = response.content.match(/\{[^}]+\}/);
-		if (!jsonMatch) {
+		// Use a more robust approach: find opening { and parse from there
+		const jsonStart = response.content.indexOf("{");
+		if (jsonStart === -1) {
 			throw new Error("No JSON found in response");
 		}
 
+		// Try to parse from the first { onwards, handling nested objects
+		let depth = 0;
+		let jsonEnd = jsonStart;
+		for (let i = jsonStart; i < response.content.length; i++) {
+			if (response.content[i] === "{") depth++;
+			if (response.content[i] === "}") depth--;
+			if (depth === 0) {
+				jsonEnd = i + 1;
+				break;
+			}
+		}
+
+		if (depth !== 0) {
+			throw new Error("Malformed JSON: unbalanced braces");
+		}
+
+		const jsonStr = response.content.substring(jsonStart, jsonEnd);
 		const parsed = safeParseJson<{
 			category: string;
 			confidence: number;
-		} | null>(jsonMatch[0], null);
+		} | null>(jsonStr, null);
 
 		if (!parsed) {
 			throw new Error("Failed to parse JSON");
@@ -509,18 +527,37 @@ export async function runSanityCheck(
 
 	// Parse JSON response
 	try {
-		const jsonMatch = response.content.match(/\{[^}]+\}/);
-		if (!jsonMatch) {
+		// Extract JSON from response (may have surrounding text)
+		// Use a more robust approach: find opening { and parse from there
+		const jsonStart = response.content.indexOf("{");
+		if (jsonStart === -1) {
 			throw new Error("No JSON found in response");
 		}
 
+		// Try to parse from the first { onwards, handling nested objects
+		let depth = 0;
+		let jsonEnd = jsonStart;
+		for (let i = jsonStart; i < response.content.length; i++) {
+			if (response.content[i] === "{") depth++;
+			if (response.content[i] === "}") depth--;
+			if (depth === 0) {
+				jsonEnd = i + 1;
+				break;
+			}
+		}
+
+		if (depth !== 0) {
+			throw new Error("Malformed JSON: unbalanced braces");
+		}
+
+		const jsonStr = response.content.substring(jsonStart, jsonEnd);
 		const parsed = safeParseJson<{
 			faceCount?: number;
 			isScreenshot?: boolean;
 			isMeme?: boolean;
 			isDrawing?: boolean;
 			quality?: number;
-		} | null>(jsonMatch[0], null);
+		} | null>(jsonStr, null);
 
 		if (!parsed) {
 			throw new Error("Failed to parse JSON");


### PR DESCRIPTION
When Petal scanning fails with infrastructure errors (SCAN_ERROR, CSAM_SCAN_FAILED),
the endpoint was returning GROVE-API-046 (INVALID_FILE) with a message about technical
difficulties, which was misleading to users and incorrect for the error code.

Changes:
- Pass through Petal error code in PetalScanResult
- Check Petal code to distinguish infrastructure errors from content rejections
- Use UPLOAD_SERVICE_UNAVAILABLE (GROVE-API-011) for infrastructure errors
- Use INVALID_FILE (GROVE-API-046) for content rejections
- Return 503 status for infrastructure errors instead of 400
- Skip rejection counter for infrastructure errors to avoid false positives

Fixes issue #46

Co-Authored-By: Claude (Grove Agent)
Claude-Session: https://claude.ai/code/session_011mVYERL1rNPUrNDQMgpJ8o