### PR TITLE
fix(auth): rate-limit session validation per real client, not "unknown"

### DIFF
--- a/apps/aspen/src/hooks.server.ts
+++ b/apps/aspen/src/hooks.server.ts
@@ -19,7 +19,12 @@ import {
 } from "@autumnsgrove/lattice/server/services/turnstile";
 import type { TenantConfig } from "@autumnsgrove/lattice/durable-objects/TenantDO";
 import { TIERS, type TierKey } from "@autumnsgrove/lattice/platform/config/tiers";
-import { getCookie, extractSessionCookie, setSecurityHeaders } from "@autumnsgrove/lattice/server";
+import {
+	getCookie,
+	extractSessionCookie,
+	setSecurityHeaders,
+	validateGroveSession,
+} from "@autumnsgrove/lattice/server";
 
 /**
  * Reserved subdomains that route to internal apps or have special handling.
@@ -426,13 +431,13 @@ const aspenHandle: Handle = async ({ event, resolve }) => {
 
 	const sessionAuthPromise =
 		sessionCookie && event.platform?.env?.AUTH
-			? event.platform.env.AUTH.fetch("https://login.grove.place/session/validate", {
-					method: "POST",
-					headers: { Cookie: cookieHeader || "" },
-				}).catch((err: unknown) => {
-					console.error("[Auth] SessionDO validation error:", err);
-					return null as Response | null;
-				})
+			? validateGroveSession(
+					event.platform.env.AUTH,
+					event.request,
+					sessionCookie,
+					cookieHeader || "",
+					event.platform?.context?.waitUntil?.bind(event.platform.context),
+				)
 			: Promise.resolve(null as Response | null);
 
 	// =========================================================================

--- a/apps/billing/src/hooks.server.ts
+++ b/apps/billing/src/hooks.server.ts
@@ -1,7 +1,13 @@
 import type { Handle } from "@sveltejs/kit";
 import { sequence } from "@sveltejs/kit/hooks";
 import { isGreenhouseMode, GREENHOUSE_AUTH } from "$lib/greenhouse";
-import { isGroveOrigin, isLocalOrigin, setSecurityHeaders } from "@autumnsgrove/lattice/server";
+import {
+	isGroveOrigin,
+	isLocalOrigin,
+	setSecurityHeaders,
+	extractSessionCookie,
+	validateGroveSession,
+} from "@autumnsgrove/lattice/server";
 import {
 	pulseHandle,
 	createPulseFlushHook,
@@ -49,17 +55,25 @@ function getCorsHeaders(origin: string): Record<string, string> {
  */
 async function validateSession(
 	auth: Fetcher,
+	request: Request,
 	cookieHeader: string | null,
+	waitUntil?: (promise: Promise<unknown>) => void,
 ): Promise<{ tenantId: string; userId: string } | undefined> {
 	if (!cookieHeader) return undefined;
 
-	try {
-		const response = await auth.fetch("https://login.grove.place/session/validate", {
-			method: "POST",
-			headers: { Cookie: cookieHeader },
-		});
+	const sessionCookie = extractSessionCookie(cookieHeader);
+	if (!sessionCookie) return undefined;
 
-		if (!response.ok) return undefined;
+	try {
+		const response = await validateGroveSession(
+			auth,
+			request,
+			sessionCookie,
+			cookieHeader,
+			waitUntil,
+		);
+
+		if (!response?.ok) return undefined;
 
 		const data = (await response.json()) as {
 			valid?: boolean;
@@ -96,7 +110,12 @@ const billingHandle: Handle = async ({ event, resolve }) => {
 	// Validate session for non-API, non-webhook routes
 	if (!isApi && platform?.env?.AUTH) {
 		const cookieHeader = request.headers.get("Cookie");
-		const session = await validateSession(platform.env.AUTH, cookieHeader);
+		const session = await validateSession(
+			platform.env.AUTH,
+			request,
+			cookieHeader,
+			platform?.context?.waitUntil?.bind(platform.context),
+		);
 		if (session) {
 			event.locals.tenantId = session.tenantId;
 			event.locals.userId = session.userId;

--- a/apps/domains/src/hooks.server.ts
+++ b/apps/domains/src/hooks.server.ts
@@ -7,7 +7,11 @@
 import type { Handle } from "@sveltejs/kit";
 import { sequence } from "@sveltejs/kit/hooks";
 import { getUserById, getSession, updateSessionTokens } from "$lib/server/db";
-import { extractSessionCookie, setSecurityHeaders } from "@autumnsgrove/lattice/server";
+import {
+	extractSessionCookie,
+	setSecurityHeaders,
+	validateGroveSession,
+} from "@autumnsgrove/lattice/server";
 import {
 	pulseHandle,
 	createPulseFlushHook,
@@ -93,15 +97,15 @@ const domainsHandle: Handle = async ({ event, resolve }) => {
 	if (sessionCookie && event.platform?.env?.AUTH) {
 		try {
 			// Pass full cookie header so GroveAuth can find whichever session cookie exists
-			const response = await event.platform.env.AUTH.fetch(
-				"https://login.grove.place/session/validate",
-				{
-					method: "POST",
-					headers: { Cookie: cookieHeader || "" },
-				},
+			const response = await validateGroveSession(
+				event.platform.env.AUTH,
+				event.request,
+				sessionCookie,
+				cookieHeader || "",
+				event.platform?.context?.waitUntil?.bind(event.platform.context),
 			);
 
-			if (response.ok) {
+			if (response?.ok) {
 				const data = (await response.json()) as {
 					valid: boolean;
 					user?: {

--- a/apps/landing/src/hooks.server.ts
+++ b/apps/landing/src/hooks.server.ts
@@ -9,7 +9,12 @@ import type { Handle } from "@sveltejs/kit";
 import { sequence } from "@sveltejs/kit/hooks";
 import { error } from "@sveltejs/kit";
 import { validateCSRF } from "@autumnsgrove/lattice/utils";
-import { getCookie, extractSessionCookie, setSecurityHeaders } from "@autumnsgrove/lattice/server";
+import {
+	getCookie,
+	extractSessionCookie,
+	setSecurityHeaders,
+	validateGroveSession,
+} from "@autumnsgrove/lattice/server";
 import {
 	pulseHandle,
 	createPulseFlushHook,
@@ -66,15 +71,15 @@ const landingHandle: Handle = async ({ event, resolve }) => {
 	if (sessionCookie && event.platform?.env?.AUTH) {
 		try {
 			// Pass full cookie header so GroveAuth can find whichever session cookie exists
-			const response = await event.platform.env.AUTH.fetch(
-				"https://login.grove.place/session/validate",
-				{
-					method: "POST",
-					headers: { Cookie: cookieHeader || "" },
-				},
+			const response = await validateGroveSession(
+				event.platform.env.AUTH,
+				event.request,
+				sessionCookie,
+				cookieHeader || "",
+				event.platform?.context?.waitUntil?.bind(event.platform.context),
 			);
 
-			if (response.ok) {
+			if (response?.ok) {
 				const data = (await response.json()) as {
 					valid: boolean;
 					user?: {

--- a/libs/engine/src/lib/server/hooks.test.ts
+++ b/libs/engine/src/lib/server/hooks.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for validateGroveSession
+ *
+ * Covers the two bugs it fixes: forwarding the real client IP on the
+ * service-binding call to Heartwood (so its per-IP rate limit doesn't
+ * collapse every caller into a single "unknown" bucket), and short-lived
+ * caching so a burst of near-simultaneous requests from one browser only
+ * pays for one round trip.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { validateGroveSession } from "./hooks";
+
+function createFakeEdgeCache() {
+	const store = new Map<string, Response>();
+	return {
+		match: vi.fn(async (req: Request) => {
+			const hit = store.get(req.url);
+			return hit ? hit.clone() : undefined;
+		}),
+		put: vi.fn(async (req: Request, res: Response) => {
+			store.set(req.url, res.clone());
+		}),
+	};
+}
+
+function createAuthFetcher(response: Response | (() => Response)) {
+	const fetch = vi.fn(async () => (typeof response === "function" ? response() : response));
+	return { fetch } as unknown as Fetcher;
+}
+
+const validBody = JSON.stringify({ valid: true, user: { id: "u1", email: "a@b.com" } });
+
+beforeEach(() => {
+	vi.unstubAllGlobals();
+	vi.stubGlobal("caches", { default: createFakeEdgeCache() });
+});
+
+describe("validateGroveSession", () => {
+	it("forwards the original request's CF-Connecting-IP to Heartwood", async () => {
+		const auth = createAuthFetcher(new Response(validBody, { status: 200 }));
+		const request = new Request("https://aspen.grove.place/arbor/garden", {
+			headers: { "CF-Connecting-IP": "203.0.113.7" },
+		});
+
+		await validateGroveSession(auth, request, "session-token-1", "grove_session=session-token-1");
+
+		expect(auth.fetch).toHaveBeenCalledTimes(1);
+		const [, init] = (auth.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+		const headers = init.headers as Record<string, string>;
+		expect(headers["CF-Connecting-IP"]).toBe("203.0.113.7");
+		expect(headers["Cookie"]).toBe("grove_session=session-token-1");
+	});
+
+	it("falls back to X-Forwarded-For when CF-Connecting-IP is absent", async () => {
+		const auth = createAuthFetcher(new Response(validBody, { status: 200 }));
+		const request = new Request("https://aspen.grove.place/arbor/garden", {
+			headers: { "X-Forwarded-For": "198.51.100.4, 10.0.0.1" },
+		});
+
+		await validateGroveSession(auth, request, "session-token-1", "grove_session=session-token-1");
+
+		const [, init] = (auth.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+		const headers = init.headers as Record<string, string>;
+		expect(headers["CF-Connecting-IP"]).toBe("198.51.100.4");
+	});
+
+	it("reuses a cached validation for a second near-simultaneous request instead of re-calling Heartwood", async () => {
+		const auth = createAuthFetcher(new Response(validBody, { status: 200 }));
+		const request = new Request("https://aspen.grove.place/arbor/garden", {
+			headers: { "CF-Connecting-IP": "203.0.113.7" },
+		});
+
+		const first = await validateGroveSession(
+			auth,
+			request,
+			"session-token-1",
+			"grove_session=session-token-1",
+		);
+		const second = await validateGroveSession(
+			auth,
+			request,
+			"session-token-1",
+			"grove_session=session-token-1",
+		);
+
+		expect(auth.fetch).toHaveBeenCalledTimes(1);
+		expect(await first?.json()).toEqual(JSON.parse(validBody));
+		expect(await second?.json()).toEqual(JSON.parse(validBody));
+	});
+
+	it("does not cache a rate-limited (non-ok) response", async () => {
+		const auth = createAuthFetcher(
+			new Response(JSON.stringify({ error: "rate_limit" }), { status: 429 }),
+		);
+		const request = new Request("https://aspen.grove.place/arbor/garden", {
+			headers: { "CF-Connecting-IP": "203.0.113.7" },
+		});
+
+		await validateGroveSession(auth, request, "session-token-1", "grove_session=session-token-1");
+		await validateGroveSession(auth, request, "session-token-1", "grove_session=session-token-1");
+
+		// A denied check must never be remembered — otherwise a transient
+		// hiccup would lock the user out for the full cache window.
+		expect(auth.fetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("keys the cache by session token, so two different sessions never collide", async () => {
+		const auth = createAuthFetcher(new Response(validBody, { status: 200 }));
+		const request = new Request("https://aspen.grove.place/arbor/garden", {
+			headers: { "CF-Connecting-IP": "203.0.113.7" },
+		});
+
+		await validateGroveSession(auth, request, "session-token-1", "grove_session=session-token-1");
+		await validateGroveSession(auth, request, "session-token-2", "grove_session=session-token-2");
+
+		expect(auth.fetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns null and does not throw when the service-binding call fails", async () => {
+		const auth = {
+			fetch: vi.fn().mockRejectedValue(new Error("network down")),
+		} as unknown as Fetcher;
+		const request = new Request("https://aspen.grove.place/arbor/garden");
+
+		const result = await validateGroveSession(
+			auth,
+			request,
+			"session-token-1",
+			"grove_session=session-token-1",
+		);
+
+		expect(result).toBeNull();
+	});
+});

--- a/libs/engine/src/lib/server/hooks.ts
+++ b/libs/engine/src/lib/server/hooks.ts
@@ -33,6 +33,112 @@ export function setSecurityHeaders(response: Response): Response {
 	return response;
 }
 
+/**
+ * Minimal shape of the Cloudflare Workers edge cache we rely on.
+ *
+ * We deliberately avoid referencing the ambient `caches`/`CacheStorage`
+ * globals directly: this package also ships browser Svelte components, so
+ * its tsconfig includes the DOM lib alongside `@cloudflare/workers-types`.
+ * DOM's `CacheStorage` interface has no `default` property, and it wins the
+ * ambient declaration over Cloudflare's — so `caches.default` fails to
+ * typecheck here even though it exists at runtime. Casting through
+ * `globalThis` sidesteps the collision.
+ */
+interface EdgeCache {
+	match(request: Request): Promise<Response | undefined>;
+	put(request: Request, response: Response): Promise<void>;
+}
+
+function getEdgeCache(): EdgeCache {
+	return (globalThis as unknown as { caches: { default: EdgeCache } }).caches.default;
+}
+
+/** SHA-256 hex digest, used to key the session-validation cache without storing raw tokens. */
+async function sha256Hex(value: string): Promise<string> {
+	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+	return Array.from(new Uint8Array(digest))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+/**
+ * Validate a Grove session via the Heartwood AUTH service binding.
+ *
+ * Two things this fixes over a bare `auth.fetch(...)` call:
+ *
+ * 1. Service-binding requests never touch Cloudflare's edge, so
+ *    `CF-Connecting-IP` is never auto-injected the way it is for normal
+ *    internet-facing requests. Without forwarding it explicitly, Heartwood's
+ *    `getClientIP()` falls back to the literal string "unknown" — meaning
+ *    its per-IP rate limit on /session/validate becomes one shared bucket
+ *    across every caller on the platform, not a per-user limit. We forward
+ *    the original request's client IP so the limit applies per real client.
+ *
+ * 2. Every request through a Grove app's hooks.server.ts re-validates the
+ *    session from scratch (page loads, API calls, etc.). A burst of
+ *    near-simultaneous requests from one browser — e.g. several admin tabs
+ *    opened at once — turns into a burst of validate calls. We cache
+ *    successful validations for a few seconds via the Workers Cache API,
+ *    keyed by a hash of the session token, so that burst only pays for one
+ *    round trip to Heartwood.
+ */
+export async function validateGroveSession(
+	auth: Fetcher,
+	request: Request,
+	sessionCookie: string,
+	cookieHeader: string,
+	waitUntil?: (promise: Promise<unknown>) => void,
+): Promise<Response | null> {
+	const clientIp =
+		request.headers.get("CF-Connecting-IP") ||
+		request.headers.get("X-Real-IP") ||
+		request.headers.get("X-Forwarded-For")?.split(",")[0]?.trim() ||
+		"";
+
+	const cache = getEdgeCache();
+	const cacheKey = new Request(
+		`https://session-validate.internal/${await sha256Hex(sessionCookie)}`,
+	);
+
+	const cached = await cache.match(cacheKey);
+	if (cached) return cached;
+
+	let response: Response;
+	try {
+		response = await auth.fetch("https://login.grove.place/session/validate", {
+			method: "POST",
+			headers: {
+				Cookie: cookieHeader,
+				...(clientIp ? { "CF-Connecting-IP": clientIp } : {}),
+			},
+		});
+	} catch (err) {
+		console.error("[Auth] SessionDO validation error:", err);
+		return null;
+	}
+
+	// Only cache successful validations — a rate-limited or failed check
+	// should never be remembered, or a transient hiccup would lock the
+	// user out for the full cache window.
+	if (response.ok) {
+		const cacheable = new Response(response.clone().body, {
+			status: response.status,
+			headers: {
+				"Content-Type": "application/json",
+				"Cache-Control": "private, max-age=5",
+			},
+		});
+		const putPromise = cache.put(cacheKey, cacheable);
+		if (waitUntil) {
+			waitUntil(putPromise);
+		} else {
+			await putPromise;
+		}
+	}
+
+	return response;
+}
+
 /** Matches https://<single-level-subdomain>.grove.place — prevents nested subdomain abuse. */
 export const GROVE_ORIGIN_RE = /^https:\/\/[a-z0-9-]+\.grove\.place$/;
 


### PR DESCRIPTION
Service-binding calls to Heartwood's /session/validate never traverse
Cloudflare's edge, so CF-Connecting-IP was never forwarded. Heartwood's
getClientIP() fell back to the literal string "unknown", turning the
per-IP rate limit into a single bucket shared by every session check on
the platform — a burst of admin tabs opened at once (or just concurrent
platform traffic) could trip it and bounce the user to sign-in.

Adds validateGroveSession() in libs/engine, used by aspen, domains,
billing, and landing: forwards the real client IP so the limit applies
per user, and caches successful validations for 5s via the edge cache so
a burst of near-simultaneous requests from one browser only costs one
round trip to Heartwood.

Co-Authored-By: Claude (Grove Agent)
Claude-Session: https://claude.ai/code/session_01AgVHYMSsad35WTGt2WHL3x